### PR TITLE
Incremental merge of memHierarchy support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,8 @@ librevcpu.so: $(REV_INCS) $(REV_OBJS)
 	$(CXX) $(OPTIMIZE_FLAGS) $(CXXFLAGS) $(CPPFLAGS) -c $<
 %.inc:%.py
 	od -v -t x1 < $< | sed -e 's/^[^ ]*[ ]*//g' -e '/^\s*$$/d' -e 's/\([0-9a-f]*\)[ $$]*/0x\1,/g' > $@
+uninstall:
+	sst-register -u revcpu
 install: librevcpu.so
 	sst-register revcpu revcpu_LIBDIR=$(CURDIR)
 clean:

--- a/src/PanNet.cc
+++ b/src/PanNet.cc
@@ -550,6 +550,7 @@ PanNet::PanNet(ComponentId_t id, Params& params)
 }
 
 PanNet::~PanNet(){
+  delete output;
 }
 
 void PanNet::setMsgHandler(Event::HandlerBase* handler){

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -33,8 +33,8 @@ const char *pan_splash_msg = "\
 
 RevCPU::RevCPU( SST::ComponentId_t id, SST::Params& params )
   : SST::Component(id), testStage(0), PrivTag(0), address(-1), PrevAddr(_PAN_RDMA_MAILBOX_),
-    EnableNIC(false), EnablePAN(false), EnablePANStats(false), ReadyForRevoke(false),
-    Nic(nullptr), PNic(nullptr), PExec(nullptr) {
+    EnableNIC(false), EnablePAN(false), EnablePANStats(false), EnableMemH(false),
+    ReadyForRevoke(false), Nic(nullptr), PNic(nullptr), PExec(nullptr), Ctrl(nullptr) {
 
   const int Verbosity = params.find<int>("verbose", 0);
 
@@ -48,10 +48,12 @@ RevCPU::RevCPU( SST::ComponentId_t id, SST::Params& params )
   {
     const std::string cpuClock = params.find<std::string>("clock", "1GHz");
     if( EnablePANTest ){
-      timeConverter  = registerClock(cpuClock, new SST::Clock::Handler<RevCPU>(this,&RevCPU::clockTickPANTest));
+      timeConverter  = registerClock(cpuClock,
+                                     new SST::Clock::Handler<RevCPU>(this,&RevCPU::clockTickPANTest));
       testIters = params.find<unsigned>("testIters", 255);
     }else{
-      timeConverter  = registerClock(cpuClock, new SST::Clock::Handler<RevCPU>(this,&RevCPU::clockTick));
+      timeConverter  = registerClock(cpuClock,
+                                     new SST::Clock::Handler<RevCPU>(this,&RevCPU::clockTick));
     }
   }
 
@@ -161,28 +163,6 @@ RevCPU::RevCPU( SST::ComponentId_t id, SST::Params& params )
     RevokeHasArrived = true;
   }
 
-  TotalCycles.reserve(TotalCycles.size() + numCores);
-  CyclesWithIssue.reserve(CyclesWithIssue.size() + numCores);
-  FloatsRead.reserve(FloatsRead.size() + numCores);
-  FloatsWritten.reserve(FloatsWritten.size() + numCores);
-  DoublesRead.reserve(DoublesRead.size() + numCores);
-  DoublesWritten.reserve(DoublesWritten.size() + numCores);
-  BytesRead.reserve(BytesRead.size() + numCores);
-  BytesWritten.reserve(BytesWritten.size() + numCores);
-  FloatsExec.reserve(FloatsExec.size() + numCores);
-
-  for(int s = 0; s < numCores; s++){
-    TotalCycles.push_back(registerStatistic<uint64_t>("TotalCycles", "core_" + std::to_string(s)));
-    CyclesWithIssue.push_back(registerStatistic<uint64_t>("CyclesWithIssue", "core_" + std::to_string(s)));
-    FloatsRead.push_back( registerStatistic<uint64_t>("FloatsRead", "core_" + std::to_string(s)));
-    FloatsWritten.push_back( registerStatistic<uint64_t>("FloatsWritten", "core_" + std::to_string(s)));
-    DoublesRead.push_back( registerStatistic<uint64_t>("DoublesRead", "core_" + std::to_string(s)));
-    DoublesWritten.push_back( registerStatistic<uint64_t>("DoublesWritten", "core_" + std::to_string(s)));
-    BytesRead.push_back( registerStatistic<uint64_t>("BytesRead", "core_" + std::to_string(s)));
-    BytesWritten.push_back( registerStatistic<uint64_t>("BytesWritten", "core_" + std::to_string(s)));
-    FloatsExec.push_back( registerStatistic<uint64_t>("FloatsExec", "core_" + std::to_string(s)));
-  }
-
   // See if we should load the test harness as opposed to a binary payload
   if( EnablePANTest && (!EnablePAN) ){
     output.fatal(CALL_INFO, -1, "Error: enabling PAN tests requires a pan_nic");
@@ -203,11 +183,23 @@ RevCPU::RevCPU( SST::ComponentId_t id, SST::Params& params )
   }
 
   // Create the memory object
-  {
+  EnableMemH = params.find<bool>("enable_memH", 0);
+  if( !EnableMemH ){
     const unsigned long memSize = params.find<unsigned long>("memSize", 1073741824);
     Mem = new RevMem( memSize, Opts,  &output );
     if( !Mem )
       output.fatal(CALL_INFO, -1, "Error: failed to initialize the memory object\n" );
+  }else{
+    Ctrl = loadUserSubComponent<RevMemCtrl>("memory");
+    if( !Ctrl )
+      output.fatal(CALL_INFO, -1, "Error : failed to inintialize the memory controller subcomponent\n");
+
+    Mem = new RevMem( Opts, Ctrl, &output );
+    if( !Mem )
+      output.fatal(CALL_INFO, -1, "Error : failed to initialize the memory object\n" );
+
+    if( EnableFaults )
+      output.verbose(CALL_INFO, 1, 0, "Warning: memory faults cannot be enabled with memHierarchy support\n");
   }
 
   // Load the binary into memory
@@ -220,6 +212,29 @@ RevCPU::RevCPU( SST::ComponentId_t id, SST::Params& params )
   Procs.reserve(Procs.size() + numCores);
   for( unsigned i=0; i<numCores; i++ ){
     Procs.push_back( new RevProc( i, Opts, Mem, Loader, &output ) );
+  }
+
+  // setup the per-proc statistics
+  TotalCycles.reserve(TotalCycles.size() + numCores);
+  CyclesWithIssue.reserve(CyclesWithIssue.size() + numCores);
+  FloatsRead.reserve(FloatsRead.size() + numCores);
+  FloatsWritten.reserve(FloatsWritten.size() + numCores);
+  DoublesRead.reserve(DoublesRead.size() + numCores);
+  DoublesWritten.reserve(DoublesWritten.size() + numCores);
+  BytesRead.reserve(BytesRead.size() + numCores);
+  BytesWritten.reserve(BytesWritten.size() + numCores);
+  FloatsExec.reserve(FloatsExec.size() + numCores);
+
+  for(int s = 0; s < numCores; s++){
+    TotalCycles.push_back(registerStatistic<uint64_t>("TotalCycles", "core_" + std::to_string(s)));
+    CyclesWithIssue.push_back(registerStatistic<uint64_t>("CyclesWithIssue", "core_" + std::to_string(s)));
+    FloatsRead.push_back( registerStatistic<uint64_t>("FloatsRead", "core_" + std::to_string(s)));
+    FloatsWritten.push_back( registerStatistic<uint64_t>("FloatsWritten", "core_" + std::to_string(s)));
+    DoublesRead.push_back( registerStatistic<uint64_t>("DoublesRead", "core_" + std::to_string(s)));
+    DoublesWritten.push_back( registerStatistic<uint64_t>("DoublesWritten", "core_" + std::to_string(s)));
+    BytesRead.push_back( registerStatistic<uint64_t>("BytesRead", "core_" + std::to_string(s)));
+    BytesWritten.push_back( registerStatistic<uint64_t>("BytesWritten", "core_" + std::to_string(s)));
+    FloatsExec.push_back( registerStatistic<uint64_t>("FloatsExec", "core_" + std::to_string(s)));
   }
 
   // setup the PAN execution contexts
@@ -269,6 +284,10 @@ RevCPU::~RevCPU(){
 
   if( PExec )
     delete PExec;
+
+  // delete the memory controller if present
+  if( Ctrl )
+    delete Ctrl;
 
   // delete the memory object
   delete Mem;

--- a/src/RevCPU.h
+++ b/src/RevCPU.h
@@ -123,7 +123,7 @@ namespace SST {
       SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
         {"nic", "Network interface", "SST::RevCPU::RevNIC"},
         {"pan_nic", "PAN Network interface", "SST::RevCPU::PanNet"},
-        {"memory", "Memory interface to utilize for cache/memory hierachy", "SST::RevCPU::RevBasicMemCtrl"}
+        {"memory", "Memory interface to utilize for cache/memory hierachy", "SST::RevCPU::RevMemCtrl"}
       )
 
       // -------------------------------------------------------

--- a/src/RevCPU.h
+++ b/src/RevCPU.h
@@ -29,6 +29,7 @@
 // -- Rev Headers
 #include "RevOpts.h"
 #include "RevMem.h"
+#include "RevMemCtrl.h"
 #include "RevLoader.h"
 #include "RevProc.h"
 #include "RevNIC.h"
@@ -98,6 +99,7 @@ namespace SST {
         {"enable_pan",      "Enable PAN network endpoint",                  "0"},
         {"enable_test",     "Enable PAN network endpoint test",             "0"},
         {"enable_pan_stats","Enable PAN network statistics",                "1"},
+        {"enable_memH",     "Enable memHierarchy",                          "0"},
         {"enableRDMAMbox",  "Enable the RDMA mailbox",                      "1"},
         {"enable_faults",   "Enable the fault injection logic",             "0"},
         {"faults",          "Enable specific faults",                       "decode,mem,reg,alu"},
@@ -113,14 +115,15 @@ namespace SST {
       // RevCPU Port Parameter Data
       // -------------------------------------------------------
       SST_ELI_DOCUMENT_PORTS(
-                            )
+      )
 
       // -------------------------------------------------------
       // RevCPU SubComponent Parameter Data
       // -------------------------------------------------------
       SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
         {"nic", "Network interface", "SST::RevCPU::RevNIC"},
-        {"pan_nic", "PAN Network interface", "SST::RevCPU::PanNet"}
+        {"pan_nic", "PAN Network interface", "SST::RevCPU::PanNet"},
+        {"memory", "Memory interface to utilize for cache/memory hierachy", "SST::RevCPU::RevBasicMemCtrl"}
       )
 
       // -------------------------------------------------------
@@ -217,6 +220,8 @@ namespace SST {
       bool EnablePANStats;                ///< RevCPU: Flag for enabling PAN statistics
       bool EnableRDMAMBox;                ///< RevCPU: Enable the RDMA Mailbox
 
+      bool EnableMemH;                    ///< RevCPU: Enable memHierarchy
+
       bool EnableFaults;                  ///< RevCPU: Enable fault injection logic
       bool EnableCrackFaults;             ///< RevCPU: Enable Crack+Decode Faults
       bool EnableMemFaults;               ///< RevCPU: Enable memory faults (bit flips)
@@ -232,6 +237,7 @@ namespace SST {
       nicAPI *Nic;                        ///< RevCPU: Network interface controller
       panNicAPI *PNic;                    ///< RevCPU: PAN network interface controller
       PanExec *PExec;                     ///< RevCPU: PAN execution context
+      RevMemCtrl *Ctrl;                   ///< RevCPU: Rev memory controller
 
 
       std::queue<std::pair<panNicEvent *,int>> SendMB;  ///< RevCPU: outgoing command mailbox; pair<Cmd,Dest>
@@ -302,7 +308,7 @@ namespace SST {
       Statistic<uint64_t>* SuccessRecv;
       Statistic<uint64_t>* FailedRecv;
       Statistic<uint64_t>* BOTWRecv;
-      // ----- Per Core Statistics 
+      // ----- Per Core Statistics
       std::vector<Statistic<uint64_t>*> TotalCycles;
       std::vector<Statistic<uint64_t>*> CyclesWithIssue;
       std::vector<Statistic<uint64_t>*> FloatsRead;

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -155,6 +155,13 @@ uint64_t RevMem::CalcPhysAddr(uint64_t pageNum, uint64_t Addr){
   return physAddr;
 }
 
+bool RevMem::FenceMem(){
+  if( ctrl ){
+    return ctrl->sendFENCE();
+  }
+  return true;  // base RevMem support does nothing here
+}
+
 bool RevMem::WriteMem( uint64_t Addr, size_t Len, void *Data ){
 #ifdef _REV_DEBUG_
   std::cout << "Writing " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
@@ -184,12 +191,10 @@ bool RevMem::WriteMem( uint64_t Addr, size_t Len, void *Data ){
     BaseMem = &physMem[adjPhysAddr];
     if( ctrl ){
       // write the memory using RevMemCtrl
-      if( !ctrl->sendWRITERequest((uint64_t)(BaseMem),
-                                  Len,
-                                  DataMem,
-                                  0x00) ){
-        output->fatal(CALL_INFO, -1, "Error : failed to dispatch write request to RevMemCtrl");
-      }
+      return ctrl->sendWRITERequest((uint64_t)(BaseMem),
+                                    Len,
+                                    DataMem,
+                                    0x00);
     }else{
       // write the memory using the internal RevMem model
       for( unsigned i=0; i< span; i++ ){
@@ -199,12 +204,10 @@ bool RevMem::WriteMem( uint64_t Addr, size_t Len, void *Data ){
   }else{
     if( ctrl ){
       // write the memory using RevMemCtrl
-      if( !ctrl->sendWRITERequest((uint64_t)(BaseMem),
-                                  Len,
-                                  DataMem,
-                                  0x00) ){
-        output->fatal(CALL_INFO, -1, "Error : failed to dispatch write request to RevMemCtrl");
-      }
+      return ctrl->sendWRITERequest((uint64_t)(BaseMem),
+                                    Len,
+                                    DataMem,
+                                    0x00);
     }else{
       // write the memory using the internal RevMem model
       for( unsigned i=0; i<Len; i++ ){

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -11,8 +11,21 @@
 #include "RevMem.h"
 #include <math.h>
 
+RevMem::RevMem( RevOpts *Opts, RevMemCtrl *Ctrl, SST::Output *Output )
+  : memSize(0), opts(Opts), ctrl(Ctrl), output(Output), physMem(nullptr),
+    stacktop(0x00ull) {
+  // Note: this constructor assumes the use of the memHierarchy backend
+  memStats.bytesRead = 0;
+  memStats.bytesWritten = 0;
+  memStats.doublesRead = 0;
+  memStats.doublesWritten = 0;
+  memStats.floatsRead = 0;
+  memStats.floatsWritten = 0;
+}
+
 RevMem::RevMem( unsigned long MemSize, RevOpts *Opts, SST::Output *Output )
-  : memSize(MemSize), opts(Opts), output(Output), physMem(nullptr), stacktop(0x00ull) {
+  : memSize(MemSize), opts(Opts), ctrl(nullptr),output(Output),
+    physMem(nullptr), stacktop(0x00ull) {
 
   // allocate the backing memory
   physMem = new char [memSize];

--- a/src/RevMem.h
+++ b/src/RevMem.h
@@ -26,6 +26,7 @@
 
 // -- RevCPU Headers
 #include "RevOpts.h"
+#include "RevMemCtrl.h"
 
 #ifndef _REVMEM_BASE_
 #define _REVMEM_BASE_ 0x00000000
@@ -45,8 +46,14 @@ namespace SST {
       /// RevMem: standard constructor
       RevMem( unsigned long MemSize, RevOpts *Opts, SST::Output *Output );
 
+      /// RevMem: standard memory controller constructor
+      RevMem( RevOpts *Opts, RevMemCtrl *Ctrl, SST::Output *Output );
+
       /// RevMem: standard destructor
       ~RevMem();
+
+      /// RevMem: handle incoming memory event
+      void handleEvent(Interfaces::StandardMem::Request* ev) { }
 
       /// RevMem: handle memory injection
       void HandleMemFault(unsigned width);
@@ -118,7 +125,7 @@ namespace SST {
       bool StatusFuture( uint64_t Addr );
 
     class RevMemStats {
-      public:
+    public:
       uint32_t floatsRead;
       uint32_t floatsWritten;
       uint32_t doublesWritten;
@@ -132,13 +139,14 @@ namespace SST {
     private:
       unsigned long memSize;    ///< RevMem: size of the target memory
       RevOpts *opts;            ///< RevMem: options object
+      RevMemCtrl *ctrl;         ///< RevMem: memory controller object
       SST::Output *output;      ///< RevMem: output handler
 
       uint64_t CalcPhysAddr(uint64_t pageNum, uint64_t Addr);
 
       char *physMem;                          ///< RevMem: memory container
-      
-      //c++11 should guarentee that these are all zero-initializaed 
+
+      //c++11 should guarentee that these are all zero-initializaed
       std::map<uint64_t, std::pair<uint32_t, bool>> pageMap;   ///< RevMem: map of logical to pair<physical addresses, allocated>
       uint32_t                                      pageSize;  ///< RevMem: size of allocated pages
       uint32_t                                      addrShift; ///< RevMem: Bits to shift to caclulate page of address 

--- a/src/RevMem.h
+++ b/src/RevMem.h
@@ -64,6 +64,9 @@ namespace SST {
       /// RevMem: set the stack_top address
       void SetStackTop(uint64_t Addr) { stacktop = Addr; }
 
+      /// RevMem: initiate a memory fence
+      bool FenceMem();
+
       /// RevMem: write to the target memory location
       bool WriteMem( uint64_t Addr, size_t Len, void *Data );
 

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -1,0 +1,84 @@
+//
+// _RevMemCtrl_h_
+//
+// Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "RevMemCtrl.h"
+
+using namespace SST;
+using namespace RevCPU;
+
+// ---------------------------------------------------------------
+// RevMemCtrl
+// ---------------------------------------------------------------
+RevMemCtrl::RevMemCtrl(ComponentId_t id, Params& params)
+  : SubComponent(id), output(nullptr) {
+
+  uint32_t verbosity = params.find<uint32_t>("verbose");
+  output = new SST::Output("[RevMemCtrl @t]: ", verbosity, 0, SST::Output::STDOUT);
+
+}
+
+RevMemCtrl::~RevMemCtrl(){
+  delete output;
+}
+
+// ---------------------------------------------------------------
+// RevBasicMemCtrl
+// ---------------------------------------------------------------
+RevBasicMemCtrl::RevBasicMemCtrl(ComponentId_t id, Params& params)
+  : RevMemCtrl(id,params), memIface(nullptr),stdMemHandlers(nullptr){
+
+  stdMemHandlers = new RevBasicMemCtrl::RevStdMemHandlers(this,output);
+
+  std::string ClockFreq = params.find<std::string>("clock", "1Ghz");
+
+  memIface = loadUserSubComponent<Interfaces::StandardMem>(
+    "memIface", ComponentInfo::SHARE_PORTS | ComponentInfo::INSERT_STATS,
+    getTimeConverter(ClockFreq), new StandardMem::Handler<SST::RevCPU::RevBasicMemCtrl>(
+      this, &RevBasicMemCtrl::processMemEvent));
+
+
+  registerClock( ClockFreq,
+              new Clock::Handler<RevBasicMemCtrl>(this,&RevBasicMemCtrl::clockTick));
+}
+
+RevBasicMemCtrl::~RevBasicMemCtrl(){
+  delete stdMemHandlers;
+}
+
+void RevBasicMemCtrl::processMemEvent(StandardMem::Request* ev){
+}
+
+void RevBasicMemCtrl::init(unsigned int phase){
+  memIface->init(phase);
+}
+
+bool RevBasicMemCtrl::clockTick(Cycle_t cycle){
+  return false;
+}
+
+// ---------------------------------------------------------------
+// RevStdMemHandlers
+// ---------------------------------------------------------------
+RevBasicMemCtrl::RevStdMemHandlers::RevStdMemHandlers( RevBasicMemCtrl* Ctrl,
+                                                       SST::Output* output)
+  : Interfaces::StandardMem::RequestHandler(output), ctrl(Ctrl){
+}
+
+RevBasicMemCtrl::RevStdMemHandlers::~RevStdMemHandlers(){
+}
+
+void RevBasicMemCtrl::RevStdMemHandlers::handle(StandardMem::ReadResp* ev){
+}
+
+void RevBasicMemCtrl::RevStdMemHandlers::handle(StandardMem::WriteResp* ev){
+}
+
+
+// EOF

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -522,7 +522,7 @@ bool RevBasicMemCtrl::clockTick(Cycle_t cycle){
 // ---------------------------------------------------------------
 RevBasicMemCtrl::RevStdMemHandlers::RevStdMemHandlers( RevBasicMemCtrl* Ctrl,
                                                        SST::Output* output)
-  : Interfaces::StandardMem::RequestHandler(output), ctrl(Ctrl){
+  : Interfaces::StandardMem::RequestHandler(output), Ctrl(Ctrl){
 }
 
 RevBasicMemCtrl::RevStdMemHandlers::~RevStdMemHandlers(){

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -14,6 +14,41 @@ using namespace SST;
 using namespace RevCPU;
 
 // ---------------------------------------------------------------
+// RevMemOp
+// ---------------------------------------------------------------
+RevMemOp::RevMemOp(uint64_t Addr, uint32_t Size, RevMemOp::MemOp Op )
+  : Addr(Addr), Size(Size), Op(Op), CustomOpc(0), membuf(nullptr), target(nullptr){
+}
+
+RevMemOp::RevMemOp(uint64_t Addr, uint32_t Size, void *target, RevMemOp::MemOp Op )
+  : Addr(Addr), Size(Size), Op(Op), CustomOpc(0), membuf(nullptr), target(target){
+}
+
+RevMemOp::RevMemOp(uint64_t Addr, uint32_t Size,
+                   char *buffer, RevMemOp::MemOp Op )
+  : Addr(Addr), Size(Size), Op(Op), CustomOpc(0), membuf(nullptr), target(nullptr){
+  membuf = new char[Size]();
+  std::copy_n(buffer, Size, membuf);
+}
+
+RevMemOp::RevMemOp(uint64_t Addr, uint32_t Size,
+                   void *target, unsigned CustomOpc, RevMemOp::MemOp Op )
+  : Addr(Addr), Size(Size), Op(Op), CustomOpc(CustomOpc), membuf(nullptr), target(target){
+}
+
+RevMemOp::RevMemOp(uint64_t Addr, uint32_t Size, char *buffer,
+                   unsigned CustomOpc, RevMemOp::MemOp Op )
+  : Addr(Addr), Size(Size), Op(Op), CustomOpc(CustomOpc), membuf(nullptr), target(nullptr){
+  membuf = new char[Size]();
+  std::copy_n(buffer, Size, membuf);
+}
+
+RevMemOp::~RevMemOp(){
+  if( membuf != nullptr )
+    delete membuf;
+}
+
+// ---------------------------------------------------------------
 // RevMemCtrl
 // ---------------------------------------------------------------
 RevMemCtrl::RevMemCtrl(ComponentId_t id, Params& params)
@@ -33,7 +68,10 @@ RevMemCtrl::~RevMemCtrl(){
 // ---------------------------------------------------------------
 RevBasicMemCtrl::RevBasicMemCtrl(ComponentId_t id, Params& params)
   : RevMemCtrl(id,params), memIface(nullptr),stdMemHandlers(nullptr),
-    max_loads(64), max_stores(64), max_ops(2){
+    max_loads(64), max_stores(64), max_flush(64), max_llsc(64),
+    max_readlock(64), max_writeunlock(64), max_custom(64), max_ops(2),
+    num_read(0), num_write(0), num_flush(0), num_llsc(0), num_readlock(0),
+    num_writeunlock(0), num_custom(0), num_fence(0){
 
   stdMemHandlers = new RevBasicMemCtrl::RevStdMemHandlers(this,output);
 
@@ -41,6 +79,11 @@ RevBasicMemCtrl::RevBasicMemCtrl(ComponentId_t id, Params& params)
 
   max_loads = params.find<unsigned>("max_loads", 64);
   max_stores = params.find<unsigned>("max_stores", 64);
+  max_flush = params.find<unsigned>("max_flush", 64);
+  max_llsc = params.find<unsigned>("max_llsc", 64);
+  max_readlock = params.find<unsigned>("max_readlock", 64);
+  max_writeunlock = params.find<unsigned>("max_writeunlock", 64);
+  max_custom = params.find<unsigned>("max_custom", 64);
   max_ops = params.find<unsigned>("ops_per_cycle", 2);
 
   memIface = loadUserSubComponent<Interfaces::StandardMem>(
@@ -78,24 +121,275 @@ void RevBasicMemCtrl::registerStats(){
   stats.push_back(registerStatistic<uint64_t>("LoadLinkPending"));
   stats.push_back(registerStatistic<uint64_t>("StoreCondInFlight"));
   stats.push_back(registerStatistic<uint64_t>("StoreCondPending"));
+  stats.push_back(registerStatistic<uint64_t>("CustomInFlight"));
+  stats.push_back(registerStatistic<uint64_t>("CustomPending"));
+  stats.push_back(registerStatistic<uint64_t>("CustomBytes"));
+  stats.push_back(registerStatistic<uint64_t>("FencePending"));
 }
 
-void RevBasicMemCtrl::recordStat(RevBasicMemCtrl::MemCtrlStats Stat, uint64_t Data){
-  if( Stat > RevBasicMemCtrl::MemCtrlStats::StoreCondPending){
+void RevBasicMemCtrl::recordStat(RevBasicMemCtrl::MemCtrlStats Stat,
+                                 uint64_t Data){
+  if( Stat > RevBasicMemCtrl::MemCtrlStats::FencePending){
     // do nothing
     return ;
   }
   stats[Stat]->addData(Data);
 }
 
+bool RevBasicMemCtrl::sendFLUSHRequest(uint64_t Addr,
+                                       uint32_t Size){
+  RevMemOp *Op = new RevMemOp(Addr, Size, RevMemOp::MemOp::MemOpFLUSH);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::FlushPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendREADRequest(uint64_t Addr,
+                                      uint32_t Size,
+                                      void *target){
+  RevMemOp *Op = new RevMemOp(Addr, Size, target, RevMemOp::MemOp::MemOpREAD);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::ReadPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendWRITERequest(uint64_t Addr,
+                                       uint32_t Size,
+                                       char *buffer){
+  RevMemOp *Op = new RevMemOp(Addr, Size, buffer, RevMemOp::MemOp::MemOpWRITE);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::WritePending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendREADLOCKRequest(uint64_t Addr,
+                                          uint32_t Size,
+                                          void *target){
+  RevMemOp *Op = new RevMemOp(Addr, Size, target, RevMemOp::MemOp::MemOpREADLOCK);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::ReadLockPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendWRITELOCKRequest(uint64_t Addr,
+                                           uint32_t Size,
+                                           char *buffer){
+  RevMemOp *Op = new RevMemOp(Addr, Size, buffer, RevMemOp::MemOp::MemOpWRITEUNLOCK);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::WriteUnlockPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendLOADLINKRequest(uint64_t Addr,
+                                          uint32_t Size){
+  RevMemOp *Op = new RevMemOp(Addr, Size, RevMemOp::MemOp::MemOpLOADLINK);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::LoadLinkPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendSTORECONDRequest(uint64_t Addr,
+                                           uint32_t Size,
+                                           char *buffer){
+  RevMemOp *Op = new RevMemOp(Addr, Size, buffer, RevMemOp::MemOp::MemOpSTORECOND);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::StoreCondPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendCUSTOMREADRequest(uint64_t Addr,
+                                            uint32_t Size,
+                                            void *target,
+                                            unsigned Opc){
+  RevMemOp *Op = new RevMemOp(Addr, Size, target, Opc, RevMemOp::MemOp::MemOpCUSTOM);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::CustomPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendCUSTOMWRITERequest(uint64_t Addr,
+                                             uint32_t Size,
+                                             char *buffer,
+                                             unsigned Opc){
+  RevMemOp *Op = new RevMemOp(Addr, Size, buffer, Opc, RevMemOp::MemOp::MemOpCUSTOM);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::CustomPending,1);
+  return true;
+}
+
+bool RevBasicMemCtrl::sendFENCE(){
+  RevMemOp *Op = new RevMemOp(0x00ull, 0x00, RevMemOp::MemOp::MemOpFENCE);
+  rqstQ.push_back(Op);
+  recordStat(RevBasicMemCtrl::MemCtrlStats::FencePending,1);
+  return true;
+}
+
 void RevBasicMemCtrl::processMemEvent(StandardMem::Request* ev){
+  output->verbose(CALL_INFO, 15, 0, "Received memory request event\n");
+  if( ev == nullptr ){
+    output->fatal(CALL_INFO, -1, "Error : Received null memory event\n");
+  }
+  ev->handle(stdMemHandlers);
 }
 
 void RevBasicMemCtrl::init(unsigned int phase){
   memIface->init(phase);
 }
 
+bool RevBasicMemCtrl::isMemOpAvail(RevMemOp *Op,
+                                   unsigned &t_max_loads,
+                                   unsigned &t_max_stores,
+                                   unsigned &t_max_flush,
+                                   unsigned &t_max_llsc,
+                                   unsigned &t_max_readlock,
+                                   unsigned &t_max_writeunlock,
+                                   unsigned &t_max_custom){
+  switch(Op->getOp()){
+  case RevMemOp::MemOp::MemOpREAD:
+    if( t_max_loads < max_loads ){
+      t_max_loads++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpWRITE:
+    if( t_max_stores < max_stores ){
+      t_max_stores++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpFLUSH:
+    if( t_max_flush < max_flush ){
+      t_max_flush++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpREADLOCK:
+    if( t_max_readlock < max_readlock ){
+      t_max_readlock++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpWRITEUNLOCK:
+    if( t_max_writeunlock < max_writeunlock ){
+      t_max_writeunlock++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpLOADLINK:
+    if( t_max_llsc < max_llsc ){
+      t_max_llsc++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpSTORECOND:
+    if( t_max_llsc < max_llsc ){
+      t_max_llsc++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpCUSTOM:
+    if( t_max_custom < max_custom ){
+      t_max_custom++;
+      return true;
+    }
+    return false;
+    break;
+  case RevMemOp::MemOp::MemOpFENCE:
+    return true;
+    break;
+  default:
+    return false;
+    break;
+  }
+  return false;
+}
+
+bool RevBasicMemCtrl::processNextRqst(unsigned &t_max_loads,
+                                      unsigned &t_max_stores,
+                                      unsigned &t_max_flush,
+                                      unsigned &t_max_llsc,
+                                      unsigned &t_max_readlock,
+                                      unsigned &t_max_writeunlock,
+                                      unsigned &t_max_custom,
+                                      unsigned &t_max_ops){
+  if( rqstQ.size() == 0 ){
+    // nothing to do, saturate and exit this cycle
+    t_max_ops = max_ops;
+    return true;
+  }
+
+  // retrieve the next candidate memory operation
+  for (auto &op : rqstQ) {
+    if( isMemOpAvail(op,
+                     t_max_loads,
+                     t_max_stores,
+                     t_max_flush,
+                     t_max_llsc,
+                     t_max_readlock,
+                     t_max_writeunlock,
+                     t_max_custom) ){
+      // op is good to execute, build a StandardMem packet
+      t_max_ops++;
+      if( op->getOp() == RevMemOp::MemOp::MemOpFENCE ){
+        // time to fence!
+        // saturate and exit this cycle
+        t_max_ops = max_ops;
+      }
+      return true;
+    }
+  }
+
+  return true;
+}
+
 bool RevBasicMemCtrl::clockTick(Cycle_t cycle){
+
+  // check to see if the top request is a FENCE
+  if( rqstQ.front()->getOp() == RevMemOp::MemOp::MemOpFENCE ){
+    if( (num_read + num_write + num_llsc +
+         num_readlock + num_writeunlock + num_custom) != 0 ){
+      // waiting for the outstanding ops to clear
+      recordStat(RevBasicMemCtrl::MemCtrlStats::FencePending,1);
+      return false;
+    }else{
+      // clear the fence and continue processing
+      RevMemOp *TmpOp = rqstQ.front();
+      rqstQ.pop_front();
+      num_fence--;
+      delete TmpOp;
+    }
+  }
+
+  // process the memory queue
+  bool done = false;
+  unsigned t_max_ops = 0;
+  unsigned t_max_loads = 0;
+  unsigned t_max_stores = 0;
+  unsigned t_max_flush = 0;
+  unsigned t_max_llsc = 0;
+  unsigned t_max_readlock = 0;
+  unsigned t_max_writeunlock = 0;
+  unsigned t_max_custom = 0;
+  while( !done ){
+    if( !processNextRqst(t_max_loads, t_max_stores, t_max_flush,
+                         t_max_llsc, t_max_readlock, t_max_writeunlock,
+                         t_max_custom, t_max_ops) ){
+      // error occurred
+      output->fatal(CALL_INFO, -1, "Error : failed to process next memory request");
+    }
+
+    if( t_max_ops == max_ops ){
+      done = true;
+    }
+  }
+
   return false;
 }
 

--- a/src/RevMemCtrl.h
+++ b/src/RevMemCtrl.h
@@ -346,7 +346,7 @@ namespace SST {
         virtual void handle(StandardMem::InvNotify* ev);
 
       private:
-        RevBasicMemCtrl *ctrl;       ///< RevStdMemHandlers: memory controller object
+        RevBasicMemCtrl *Ctrl;       ///< RevStdMemHandlers: memory controller object
       }; // class RevStdMemHandlers
 
 

--- a/src/RevMemCtrl.h
+++ b/src/RevMemCtrl.h
@@ -70,15 +70,58 @@ namespace SST {
                                             SST::RevCPU::RevMemCtrl
                                            )
 
-      SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the memory controller", "0" },
-                              { "clock",   "Sets the clock frequency of the memory conroller", "1Ghz" }
+      SST_ELI_DOCUMENT_PARAMS({ "verbose",        "Set the verbosity of output for the memory controller",    "0" },
+                              { "clock",          "Sets the clock frequency of the memory conroller",         "1Ghz" },
+                              { "max_loads",      "Sets the maximum number of outstanding loads",             "64"},
+                              { "max_stores",     "Sets the maximum number of outstanding stores",            "64"},
+                              { "ops_per_cycle",  "Sets the maximum number of operations to issue per cycle", "2" }
       )
 
       SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS({ "memIface", "Set the interface to memory", "SST::Interfaces::StandardMem" })
 
       SST_ELI_DOCUMENT_PORTS({ "cache_link", "Connects the controller to the first level of cache/memory", {} })
 
-      SST_ELI_DOCUMENT_STATISTICS()
+      SST_ELI_DOCUMENT_STATISTICS(
+        {"ReadInFlight",        "Counts the number of reads in flight",             "count", 1},
+        {"ReadPending",         "Counts the number of reads pending",               "count", 1},
+        {"ReadBytes",           "Counts the number of bytes read",                  "bytes", 1},
+        {"WriteInFlight",       "Counts the number of writes in flight",            "count", 1},
+        {"WritePending",        "Counts the number of writes pending",              "count", 1},
+        {"WriteBytes",          "Counts the number of bytes written",               "bytes", 1},
+        {"FlushInFlight",       "Counts the number of flushes in flight",           "count", 1},
+        {"FlushPending",        "Counts the number of flushes pending",             "count", 1},
+        {"ReadLockInFlight",    "Counts the number of readlocks in flight",         "count", 1},
+        {"ReadLockPending",     "Counts the number of readlocks pending",           "count", 1},
+        {"ReadLockBytes",       "Counts the number of readlock bytes read",         "bytes", 1},
+        {"WriteUnlockInFlight", "Counts the number of write unlocks in flight",     "count", 1},
+        {"WriteUnlockPending",  "Counts the number of write unlocks pending",       "count", 1},
+        {"WriteUnlockBytes",    "Counts the number of write unlock bytes written",  "bytes", 1},
+        {"LoadLinkInFlight",    "Counts the number of loadlinks in flight",         "count", 1},
+        {"LoadLinkPending",     "Counts the number of loadlinks pending",           "count", 1},
+        {"StoreCondInFlight",   "Counts the number of storeconds in flight",        "count", 1},
+        {"StoreCondPending",    "Counts the number of storeconds pending",          "count", 1}
+      )
+
+      typedef enum{
+        ReadInFlight        = 0,
+        ReadPending         = 1,
+        ReadBytes           = 2,
+        WriteInFlight       = 3,
+        WritePending        = 4,
+        WriteBytes          = 5,
+        FlushInFlight       = 6,
+        FlushPending        = 7,
+        ReadLockInFlight    = 8,
+        ReadLockPending     = 9,
+        ReadLockBytes       = 10,
+        WriteUnlockInFlight = 11,
+        WriteUnlockPending  = 12,
+        WriteUnlockBytes    = 13,
+        LoadLinkInFlight    = 14,
+        LoadLinkPending     = 15,
+        StoreCondInFlight   = 16,
+        StoreCondPending    = 17
+      }MemCtrlStats;
 
       /// RevBasicMemCtrl: constructor
       RevBasicMemCtrl(ComponentId_t id, Params& params);
@@ -118,8 +161,21 @@ namespace SST {
 
 
     private:
+
+      /// RevBasicMemCtrl: register statistics
+      void registerStats();
+
+      /// RevBasicMemCtrl: inject statistics data for the target metric
+      void recordStat(MemCtrlStats Stat, uint64_t Data);
+
+      // -- private data members
       StandardMem* memIface;                  ///< StandardMem memory interface
       RevStdMemHandlers* stdMemHandlers;      ///< StandardMem interface response handlers
+      unsigned max_loads;                     ///< maximum number of outstanding loads
+      unsigned max_stores;                    ///< maximum number of outstanding stores
+      unsigned max_ops;                       ///< maximum number of ops to issue per cycle
+
+      std::vector<Statistic<uint64_t>*> stats;///< statistics vector
 
     }; // RevBasicMemCtrl
   } // namespace RevCPU

--- a/src/RevMemCtrl.h
+++ b/src/RevMemCtrl.h
@@ -1,0 +1,128 @@
+//
+// _RevMemCtrl_h_
+//
+// Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_REVCPU_REVMEMCTRL_H_
+#define _SST_REVCPU_REVMEMCTRL_H_
+
+// -- C++ Headers
+#include <ctime>
+#include <vector>
+#include <algorithm>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <random>
+
+// -- SST Headers
+#include <sst/core/sst_config.h>
+#include <sst/core/output.h>
+#include <sst/core/subcomponent.h>
+#include <sst/core/interfaces/stdMem.h>
+
+// -- RevCPU Headers
+#include "RevOpts.h"
+
+namespace SST::RevCPU {
+  class RevMemCtrl;
+}
+
+using namespace SST::RevCPU;
+using namespace SST::Interfaces;
+
+namespace SST {
+  namespace RevCPU {
+
+    class RevMemCtrl : public SST::SubComponent {
+    public:
+
+      SST_ELI_REGISTER_SUBCOMPONENT_API(SST::RevCPU::RevMemCtrl)
+
+      SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the memory controller", "0" }
+      )
+
+      /// RevMemCtrl: default constructor
+      RevMemCtrl( ComponentId_t id, Params& params);
+
+      /// RevMemCtrl: default destructor
+      virtual ~RevMemCtrl();
+
+      /// RevMemCtrl: initialization function
+      virtual void init(unsigned int phase) = 0;
+
+    protected:
+      SST::Output *output;       ///< RevMemCtrl: sst output object
+
+    }; // class RevMemCtrl
+
+    class RevBasicMemCtrl : public RevMemCtrl{
+    public:
+      SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(RevBasicMemCtrl, "revcpu",
+                                            "RevBasicMemCtrl",
+                                            SST_ELI_ELEMENT_VERSION(1, 0, 0),
+                                            "RISC-V Rev basic memHierachy controller",
+                                            SST::RevCPU::RevMemCtrl
+                                           )
+
+      SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the memory controller", "0" },
+                              { "clock",   "Sets the clock frequency of the memory conroller", "1Ghz" }
+      )
+
+      SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS({ "memIface", "Set the interface to memory", "SST::Interfaces::StandardMem" })
+
+      SST_ELI_DOCUMENT_PORTS({ "cache_link", "Connects the controller to the first level of cache/memory", {} })
+
+      SST_ELI_DOCUMENT_STATISTICS()
+
+      /// RevBasicMemCtrl: constructor
+      RevBasicMemCtrl(ComponentId_t id, Params& params);
+
+      /// RevBasicMemCtrl: destructor
+      virtual ~RevBasicMemCtrl();
+
+      /// RevBasicMemCtrl: initialization function
+      virtual void init(unsigned int phase) override;
+
+      /// RevBasicMemCtrl: clock tick function
+      virtual bool clockTick(Cycle_t cycle);
+
+      /// RevBasicMemCtrl: memory event processing handler
+      void processMemEvent(StandardMem::Request* ev);
+
+    protected:
+      class RevStdMemHandlers : public Interfaces::StandardMem::RequestHandler {
+      public:
+        friend class RevBasicMemCtrl;
+
+        /// RevStdMemHandlers: constructor
+        RevStdMemHandlers( RevBasicMemCtrl* Ctrl, SST::Output* output);
+
+        /// RevStdMemHandlers: destructor
+        virtual ~RevStdMemHandlers();
+
+        /// RevStdMemHandlers: handle read response
+        virtual void handle(StandardMem::ReadResp* ev);
+
+        /// RevStdMemhandlers: handle write response
+        virtual void handle(StandardMem::WriteResp* ev);
+
+      private:
+        RevBasicMemCtrl *ctrl;       ///< RevStdMemHandlers: memory controller object
+      }; // class RevStdMemHandlers
+
+
+    private:
+      StandardMem* memIface;                  ///< StandardMem memory interface
+      RevStdMemHandlers* stdMemHandlers;      ///< StandardMem interface response handlers
+
+    }; // RevBasicMemCtrl
+  } // namespace RevCPU
+} // namespace SST
+
+#endif // _SST_REVCPU_REVMEMCTRL_H_

--- a/src/RevMemCtrl.h
+++ b/src/RevMemCtrl.h
@@ -135,6 +135,49 @@ namespace SST {
       /// RevMemCtrl: initialization function
       virtual void init(unsigned int phase) = 0;
 
+      /// RevMemCtrl: send flush request
+      virtual bool sendFLUSHRequest(uint64_t Addr, uint32_t Size,
+                                    bool Inv,
+                                    StandardMem::Request::flags_t flags) = 0;
+
+      /// RevMemCtrl: send a read request
+      virtual bool sendREADRequest(uint64_t Addr, uint32_t Size, void *target,
+                                   StandardMem::Request::flags_t flags) = 0;
+
+      /// RevMemCtrl: send a write request
+      virtual bool sendWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
+                                    StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a readlock request
+      virtual bool sendREADLOCKRequest(uint64_t Addr, uint32_t Size, void *target,
+                                       StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a writelock request
+      virtual bool sendWRITELOCKRequest(uint64_t Addr, uint32_t Size, char *buffer,
+                                        StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a loadlink request
+      virtual bool sendLOADLINKRequest(uint64_t Addr, uint32_t Size,
+                                       StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a storecond request
+      virtual bool sendSTORECONDRequest(uint64_t Addr, uint32_t Size, char *buffer,
+                                        StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send an void custom read memory request
+      virtual bool sendCUSTOMREADRequest(uint64_t Addr, uint32_t Size, void *target,
+                                         unsigned Opc,
+                                         StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a custom write request
+      virtual bool sendCUSTOMWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
+                                          unsigned Opc,
+                                          StandardMem::Request::flags_t flags) = 0;
+
+      // RevMemCtrl: send a FENCE request
+      virtual bool sendFENCE() = 0;
+
+
     protected:
       SST::Output *output;       ///< RevMemCtrl: sst output object
 
@@ -234,44 +277,44 @@ namespace SST {
       void processMemEvent(StandardMem::Request* ev);
 
       /// RevBasicMemCtrl: send a flush request
-      bool sendFLUSHRequest(uint64_t Addr, uint32_t Size,
+      virtual bool sendFLUSHRequest(uint64_t Addr, uint32_t Size,
                             bool Inv,
                             StandardMem::Request::flags_t flags);
 
       /// RevBasicMemCtrl: send a read request
-      bool sendREADRequest(uint64_t Addr, uint32_t Size, void *target,
+      virtual bool sendREADRequest(uint64_t Addr, uint32_t Size, void *target,
                            StandardMem::Request::flags_t flags);
 
       /// RevBasicMemCtrl: send a write request
-      bool sendWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
-                            StandardMem::Request::flags_t flags);
+      virtual bool sendWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
+                            StandardMem::Request::flags_t flags = 0);
 
       // RevBasicMemCtrl: send a readlock request
-      bool sendREADLOCKRequest(uint64_t Addr, uint32_t Size, void *target,
+      virtual bool sendREADLOCKRequest(uint64_t Addr, uint32_t Size, void *target,
                                StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send a writelock request
-      bool sendWRITELOCKRequest(uint64_t Addr, uint32_t Size, char *buffer,
+      virtual bool sendWRITELOCKRequest(uint64_t Addr, uint32_t Size, char *buffer,
                                 StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send a loadlink request
-      bool sendLOADLINKRequest(uint64_t Addr, uint32_t Size,
+      virtual bool sendLOADLINKRequest(uint64_t Addr, uint32_t Size,
                                StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send a storecond request
-      bool sendSTORECONDRequest(uint64_t Addr, uint32_t Size, char *buffer,
+      virtual bool sendSTORECONDRequest(uint64_t Addr, uint32_t Size, char *buffer,
                                 StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send an void custom read memory request
-      bool sendCUSTOMREADRequest(uint64_t Addr, uint32_t Size, void *target,
+      virtual bool sendCUSTOMREADRequest(uint64_t Addr, uint32_t Size, void *target,
                                  unsigned Opc, StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send a custom write request
-      bool sendCUSTOMWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
+      virtual bool sendCUSTOMWRITERequest(uint64_t Addr, uint32_t Size, char *buffer,
                                   unsigned Opc, StandardMem::Request::flags_t flags);
 
       // RevBasicMemCtrl: send a FENCE request
-      bool sendFENCE();
+      virtual bool sendFENCE();
 
     protected:
       // ----------------------------------------

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1750,8 +1750,11 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       // we are really done, return
       output->verbose(CALL_INFO,2,0,"Program execution complete\n");
       Stats.percentEff = float(Stats.cyclesBusy)/Stats.totalCycles;
-      output->verbose(CALL_INFO,2,0,"Program Stats: Total Cycles: %d Busy Cycles: %d Idle Cycles: %d Eff: %f\n", Stats.totalCycles, Stats.cyclesBusy, Stats.cyclesIdle, Stats.percentEff);
-      output->verbose(CALL_INFO,2,0,"\t Bytes Read: %d Bytes Written: %d Floats Read: %d Doubles Read %d  Floats Exec: %d Inst Retired: %" PRIu64 "\n", \
+      output->verbose(CALL_INFO,2,0,
+                      "Program Stats: Total Cycles: %" PRIu64 " Busy Cycles: %" PRIu64 " Idle Cycles: %" PRIu64 " Eff: %f\n",
+                      Stats.totalCycles, Stats.cyclesBusy,
+                      Stats.cyclesIdle, Stats.percentEff);
+      output->verbose(CALL_INFO,2,0,"\t Bytes Read: %d Bytes Written: %d Floats Read: %d Doubles Read %d  Floats Exec: %" PRIu64 " Inst Retired: %" PRIu64 "\n", \
                                       mem->memStats.bytesRead, \
                                       mem->memStats.bytesWritten, \
                                       mem->memStats.floatsRead, \

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1754,7 +1754,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
                       "Program Stats: Total Cycles: %" PRIu64 " Busy Cycles: %" PRIu64 " Idle Cycles: %" PRIu64 " Eff: %f\n",
                       Stats.totalCycles, Stats.cyclesBusy,
                       Stats.cyclesIdle, Stats.percentEff);
-      output->verbose(CALL_INFO,2,0,"\t Bytes Read: %d Bytes Written: %d Floats Read: %d Doubles Read %d  Floats Exec: %" PRIu64 " Inst Retired: %" PRIu64 "\n", \
+      output->verbose(CALL_INFO,3,0,"\t Bytes Read: %d Bytes Written: %d Floats Read: %d Doubles Read %d  Floats Exec: %" PRIu64 " Inst Retired: %" PRIu64 "\n", \
                                       mem->memStats.bytesRead, \
                                       mem->memStats.bytesWritten, \
                                       mem->memStats.floatsRead, \

--- a/src/RevProc.h
+++ b/src/RevProc.h
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <random>
+#include <inttypes.h>
 
 // -- RevCPU Headers
 #include "RevOpts.h"

--- a/src/insns/RV32I.h
+++ b/src/insns/RV32I.h
@@ -264,11 +264,13 @@ namespace SST{
       }
 
       static bool auipc(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
+        uint64_t tmp;
         if( F->IsRV32() ){
           R->RV32[Inst.rd] = 0x00;
           R->RV32[Inst.rd] = (Inst.imm << 12) + dt_u32(R->RV32_PC,32);
           R->RV32_PC += Inst.instSize;
         }else{
+          SEXT(tmp, Inst.imm << 12, 32);
           R->RV64[Inst.rd] = 0x00;
           R->RV64[Inst.rd] = (Inst.imm << 12) + dt_u64(R->RV64_PC,64);
           R->RV64_PC += Inst.instSize;

--- a/src/insns/RV32I.h
+++ b/src/insns/RV32I.h
@@ -791,9 +791,19 @@ namespace SST{
       }
 
       static bool ecall(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
+        // x17 (a7) is the code for ecall
         if( F->IsRV32() ){
+          uint32_t code = R->RV32[17];
+          switch( code ){
+          case 4: 
+            // execute the getc syscall
+            break;
+          default:
+            break;
+          }
           R->RV32_PC += Inst.instSize;
         }else{
+          uint64_t code = R->RV64[17];
           R->RV64_PC += Inst.instSize;
         }
         return true;


### PR DESCRIPTION
Merging initial support for memHierarchy to devel.  This is only the initial class infrastructure and request injection methods.  The memHierarchy path is disabled by default, so the existing RevMem support is effectively unchanged with this merge.  