### PR TITLE
Memseg cleanup

### DIFF
--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -87,7 +87,7 @@ namespace SST {
           // Check if a given range is inside a segment
           bool contains(const uint64_t& vBaseAddr, const uint64_t& Size){
             // exclusive top address
-            uint64_t vTopAddr = vBaseAddr + Size - 1; 
+            uint64_t vTopAddr = vBaseAddr + Size - 1;
             return (this->contains(vBaseAddr) && this->contains(vTopAddr));
           };
 
@@ -95,7 +95,7 @@ namespace SST {
       // Override for easy std::cout << *Seg << std::endl;
       friend std::ostream& operator<<(std::ostream& os, MemSegment& obj) {
         std::cout << "---------------------------------------------------------------" << std::endl;
-        return os << State << " | 0x" << std::hex << obj.getBaseAddr()
+        return os << " | 0x" << std::hex << obj.getBaseAddr()
                   << " | 0x" << std::hex << obj.getTopAddr()
                   << " | Size = " << std::dec << obj.getSize();
       }

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -80,13 +80,14 @@ namespace SST {
           void setSize(uint64_t size) { Size = size; TopAddr = BaseAddr + size; }
 
           /// MemSegment: Check if vAddr is included in this segment
-          bool contains(const uint64_t vAddr){
-            return (vAddr >= BaseAddr && vAddr <= TopAddr);
+          bool contains(const uint64_t& vAddr){
+            return (vAddr >= BaseAddr && vAddr < TopAddr);
           };
 
           // Check if a given range is inside a segment
-          bool contains(const uint64_t vBaseAddr, const uint64_t Size){
-            uint64_t vTopAddr = vBaseAddr + Size;
+          bool contains(const uint64_t& vBaseAddr, const uint64_t& Size){
+            // exclusive top address
+            uint64_t vTopAddr = vBaseAddr + Size - 1; 
             return (this->contains(vBaseAddr) && this->contains(vTopAddr));
           };
 
@@ -292,9 +293,7 @@ namespace SST {
       /// RevMem: Attempts to allocate memory at a specific address
       uint64_t AllocMemAt(const uint64_t& BaseAddr, const uint64_t& Size);
 
-      /// RevMem: Shrinks segment (Only moves top addr & marks upper part as free)
-      uint64_t ShrinkMemSeg(std::shared_ptr<MemSegment> Seg, const uint64_t NewSegSize);
-      
+
       /// RevMem: Sets the HeapStart & HeapEnd to EndOfStaticData
       void InitHeap(const uint64_t& EndOfStaticData);
       void SetHeapStart(const uint64_t& HeapStart){ heapstart = HeapStart; }

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -282,7 +282,7 @@ namespace SST {
       uint64_t AddMemSegAt(const uint64_t& BaseAddr, const uint64_t& SegSize);
 
       /// RevMem: Add new MemSegment (starting at BaseAddr) and round it up to the nearest page
-      uint64_t AddRoundedMemSeg(const uint64_t& BaseAddr, const uint64_t& SegSize, size_t RoundUpSize);
+      uint64_t AddRoundedMemSeg(uint64_t BaseAddr, const uint64_t& SegSize, size_t RoundUpSize);
 
       /// RevMem: Removes or shrinks segment
       uint64_t DeallocMem(uint64_t BaseAddr, uint64_t Size);

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -90,28 +90,17 @@ namespace SST {
             return (this->contains(vBaseAddr) && this->contains(vTopAddr));
           };
 
-          bool isFree(){ return IsFree; }
-          void setIsFree(bool freeState){ IsFree = freeState; }
 
-
-      // Custom Print Function
+      // Override for easy std::cout << *Seg << std::endl;
       friend std::ostream& operator<<(std::ostream& os, MemSegment& obj) {
-        std::string State = "| Free |";
-        if( !obj.IsFree ){
-          State = "| Allocated | "; 
-        }
         std::cout << "---------------------------------------------------------------" << std::endl;
-        return os << State << " | 0x" << std::hex << obj.getBaseAddr() << " | 0x" << std::hex << obj.getTopAddr() << " | Size = " << std::dec << obj.getSize();
+        return os << " | BaseAddr:  0x" << std::hex << obj.getBaseAddr() << " | TopAddr: 0x" << std::hex << obj.getTopAddr() << " | Size: " << std::dec << obj.getSize() << " Bytes";
       }
 
       private:
           uint64_t BaseAddr;
           uint64_t Size;
           uint64_t TopAddr;
-          bool IsFree = false;
-          // Potentially add a pointer to the previous segment and next segment
-          // but this may not be needed if we have the vector that is allocated sequentially
-          // and when a segment is freed it's not removed, its freeness is 
       };
 
       /// RevMem: determine if there are any outstanding requests
@@ -279,34 +268,38 @@ namespace SST {
       /// RevMem: Get memSize value set in .py file
       const uint64_t GetMemSize(){ return memSize; }
   
-      ///< RevMem: default memory size allocated to new threads (Unimplemented)
+      ///< RevMem: Get MemSegs vector
       std::vector<std::shared_ptr<MemSegment>>& GetMemSegs(){ return MemSegs; } 
 
+      ///< RevMem: Get FreeMemSegs vector
+      std::vector<std::shared_ptr<MemSegment>>& GetFreeMemSegs(){ return FreeMemSegs; } 
+
       /// RevMem: Add new MemSegment (anywhere) --- Returns BaseAddr of segment
-      uint64_t AddMemSeg(const uint64_t SegSize);
+      uint64_t AddMemSeg(const uint64_t& SegSize);
 
       /// RevMem: Add new MemSegment (starting at BaseAddr)
-      uint64_t AddMemSeg(const uint64_t& BaseAddr, const uint64_t SegSize);
+      uint64_t AddMemSegAt(const uint64_t& BaseAddr, const uint64_t& SegSize);
 
       /// RevMem: Add new MemSegment (starting at BaseAddr) and round it up to the nearest page
-      uint64_t AddMemSeg(const uint64_t& BaseAddr, const uint64_t SegSize, const bool roundUpToPage);
+      uint64_t AddRoundedMemSeg(const uint64_t& BaseAddr, const uint64_t& SegSize, size_t RoundUpSize);
 
       /// RevMem: Removes or shrinks segment
       uint64_t DeallocMem(uint64_t BaseAddr, uint64_t Size);
 
       /// RevMem: Removes or shrinks segment
-      uint64_t AllocMem(uint64_t Size);
+      uint64_t AllocMem(const uint64_t& Size);
+
+      /// RevMem: Attempts to allocate memory at a specific address
+      uint64_t AllocMemAt(const uint64_t& BaseAddr, const uint64_t& Size);
 
       /// RevMem: Shrinks segment (Only moves top addr & marks upper part as free)
       uint64_t ShrinkMemSeg(std::shared_ptr<MemSegment> Seg, const uint64_t NewSegSize);
       
-      ///< RevMem: default memory size allocated to new threads
-      uint64_t DefaultThreadMemSize = 4*1024*1024;    
-
+      /// RevMem: Sets the HeapStart & HeapEnd to EndOfStaticData
       void InitHeap(const uint64_t& EndOfStaticData);
-      void SetHeapStart(uint64_t HeapStart){ heapstart = HeapStart; }
-      void SetHeapEnd(uint64_t HeapEnd){ heapend = HeapEnd; }
-      const uint64_t GetHeapEnd(){ return heapend; }
+      void SetHeapStart(const uint64_t& HeapStart){ heapstart = HeapStart; }
+      void SetHeapEnd(const uint64_t& HeapEnd){ heapend = HeapEnd; }
+      const uint64_t& GetHeapEnd(){ return heapend; }
 
       uint64_t ExpandHeap(uint64_t Size);
 
@@ -330,7 +323,8 @@ namespace SST {
     private:
       std::unordered_map<uint64_t, std::pair<uint64_t, std::list<uint64_t>::iterator>> TLB;
       std::list<uint64_t> LRUQueue; ///< RevMem: List ordered by last access for implementing LRU policy when TLB fills up
-      std::vector<std::shared_ptr<MemSegment>> MemSegs;
+      std::vector<std::shared_ptr<MemSegment>> MemSegs;     // Currently Allocated MemSegs
+      std::vector<std::shared_ptr<MemSegment>> FreeMemSegs; // MemSegs that have been unallocated
       unsigned long memSize;        ///< RevMem: size of the target memory
       unsigned tlbSize;             ///< RevMem: size of the target memory
       unsigned maxHeapSize;             ///< RevMem: size of the target memory
@@ -344,6 +338,7 @@ namespace SST {
       uint64_t CalcPhysAddr(uint64_t pageNum, uint64_t vAddr);  ///< RevMem: Used to calculate the physical address based on virtual address
       bool isValidVirtAddr(const uint64_t vAddr);               ///< RevMem: Used to check if a virtual address exists in MemSegs
 
+      std::mutex memseg_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
       std::mutex heap_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
       std::mutex pid_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
       uint32_t PIDCount = 1023;   ///< RevMem: Monotonically increasing PID counter for assigning new PIDs without conflicts
@@ -354,9 +349,9 @@ namespace SST {
       uint32_t                                      nextPage;  ///< RevMem: next physical page to be allocated. Will result in index 
                                                                     /// nextPage * pageSize into physMem
 
-    uint64_t heapend;        ///< RevMem: top of the stack
-    uint64_t heapstart;        ///< RevMem: top of the stack
-    uint64_t stacktop;        ///< RevMem: top of the stack
+      uint64_t heapend;        ///< RevMem: top of the stack
+      uint64_t heapstart;        ///< RevMem: top of the stack
+      uint64_t stacktop;        ///< RevMem: top of the stack
 
       std::vector<uint64_t> FutureRes;  ///< RevMem: future operation reservations
 

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <time.h>
 #include <random>
-#include <mutex>
 #include <tuple>
 
 // -- SST Headers
@@ -337,9 +336,6 @@ namespace SST {
       uint64_t CalcPhysAddr(uint64_t pageNum, uint64_t vAddr);  ///< RevMem: Used to calculate the physical address based on virtual address
       bool isValidVirtAddr(const uint64_t vAddr);               ///< RevMem: Used to check if a virtual address exists in MemSegs
 
-      std::mutex memseg_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
-      std::mutex heap_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
-      std::mutex pid_mtx;         ///< RevMem: Used for incrementing ThreadCtx PID counter
       uint32_t PIDCount = 1023;   ///< RevMem: Monotonically increasing PID counter for assigning new PIDs without conflicts
 
       std::map<uint64_t, std::pair<uint32_t, bool>> pageMap;   ///< RevMem: map of logical to pair<physical addresses, allocated>

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -17,7 +17,6 @@ RevLoader::RevLoader( std::string Exe, std::string Args,
     RV32Entry(0x00l), RV64Entry(0x00ull) {
   if( !LoadElf() )
     output->fatal(CALL_INFO, -1, "Error: failed to load executable into memory\n");
-  InitStaticMem();
 }
 
 RevLoader::~RevLoader(){
@@ -148,16 +147,15 @@ bool RevLoader::LoadElf32(char *membuf, size_t sz){
       output->fatal(CALL_INFO, -1, "Error: RV32 Elf is unrecognizable\n" );
     }
     // Add a memory segment for the program header
-    mem->AddRoundedMemSeg(ph[i].p_paddr, ph[i].p_filesz, __PAGE_SIZE__);
+    if( ph[i].p_memsz ){
+      mem->AddRoundedMemSeg(ph[i].p_paddr, ph[i].p_memsz, __PAGE_SIZE__);
+    }
   }
 
   uint64_t StaticDataEnd = 0; 
   uint64_t BSSEnd = 0; 
   uint64_t DataEnd = 0; 
   uint64_t TextEnd = 0; 
-  // Add memory segments for each section header 
-  // - This should automatically handle overlap and not add segments
-  //   that are already there from program headers
   for (unsigned i = 0; i < eh->e_shnum; i++) {
     // check if the section header name is bss
     if( strcmp(shstrtab + sh[i].sh_name, ".bss") == 0 ){
@@ -169,7 +167,6 @@ bool RevLoader::LoadElf32(char *membuf, size_t sz){
     if( strcmp(shstrtab + sh[i].sh_name, ".data") == 0 ){
       DataEnd = sh[i].sh_addr + sh[i].sh_size;
     }
-    mem->AddRoundedMemSeg(sh[i].sh_addr, sh[i].sh_size, __PAGE_SIZE__);
   }
   // If BSS exists, static data ends after it
   if( BSSEnd > 0 ){
@@ -250,8 +247,6 @@ bool RevLoader::LoadElf32(char *membuf, size_t sz){
   // If the string table index and symbol table index are valid (NonZero)
   if( strtabidx && symtabidx ){
     // If there is a string table and symbol table, add them as valid memory
-    mem->AddRoundedMemSeg(sh[strtabidx].sh_addr, sh[strtabidx].sh_size, __PAGE_SIZE__);
-    mem->AddRoundedMemSeg(sh[symtabidx].sh_addr, sh[symtabidx].sh_size, __PAGE_SIZE__);
     // Parse the string table
     char *strtab = membuf + sh[strtabidx].sh_offset;
     Elf32_Sym* sym = (Elf32_Sym*)(membuf + sh[symtabidx].sh_offset);
@@ -294,7 +289,9 @@ bool RevLoader::LoadElf64(char *membuf, size_t sz){
       output->fatal(CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
     }
     // Add a memory segment for the program header
-    mem->AddRoundedMemSeg(ph[i].p_paddr, ph[i].p_filesz, __PAGE_SIZE__);
+    if( ph[i].p_memsz ){
+      mem->AddRoundedMemSeg(ph[i].p_paddr, ph[i].p_memsz, __PAGE_SIZE__);
+    }
   }
 
   uint64_t StaticDataEnd = 0; 
@@ -315,7 +312,6 @@ bool RevLoader::LoadElf64(char *membuf, size_t sz){
     if( strcmp(shstrtab + sh[i].sh_name, ".data") == 0 ){
       DataEnd = sh[i].sh_addr + sh[i].sh_size;
     }
-    mem->AddRoundedMemSeg(sh[i].sh_addr, sh[i].sh_size, __PAGE_SIZE__);
   }
   // If BSS exists, static data ends after it
   if( BSSEnd > 0 ){
@@ -345,7 +341,6 @@ bool RevLoader::LoadElf64(char *membuf, size_t sz){
   uint64_t sp = mem->GetStackTop() - (uint64_t)(elfinfo.phdr_size);
   WriteCacheLine(sp,elfinfo.phdr_size,(void *)(ph));
   mem->SetStackTop(sp);
-
 
   // iterate over the program headers
   for( unsigned i=0; i<eh->e_phnum; i++ ){
@@ -381,11 +376,10 @@ bool RevLoader::LoadElf64(char *membuf, size_t sz){
 
   // Iterate over every section header
   for( unsigned i=0; i<eh->e_shnum; i++ ){
+    // If the section header is empty, skip it
     if( sh[i].sh_type & SHT_NOBITS ){
       continue;
     }
-    mem->AddRoundedMemSeg(sh[i].sh_addr, sh[i].sh_size, __PAGE_SIZE__);
-    // If the section header is empty, skip it
     if( sz < sh[i].sh_offset + sh[i].sh_size ){
       output->fatal(CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
     }
@@ -415,7 +409,7 @@ bool RevLoader::LoadElf64(char *membuf, size_t sz){
     }
   }
 
-  // Initialize the heap after the bss section header
+  // Initialize the heap 
   mem->InitHeap(StaticDataEnd);
 
   return true;
@@ -544,18 +538,5 @@ uint64_t RevLoader::GetSymbolAddr(std::string Symbol){
   }
   return tmp;
 }
-
-void RevLoader::InitStaticMem(){
-  // if( mem->GetMemSegs().size() != 1 ){
-  //   output->fatal(CALL_INFO, 99, "Loader Error: Attempting to initialize static memory however there is either more or less than 1 memory segment\n");
-  //   return;
-  // } else {
-
-  //   mem->SetHeapStart(StaticDataEnd + 1);
-  //   mem->SetHeapEnd(StaticDataEnd + 1);
-    return;
-  // }
-}
-
 
 // EOF

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -439,7 +439,6 @@ uint64_t RevMem::AllocMem(const uint64_t& SegSize){
       MemSegs.emplace_back(std::make_shared<MemSegment>(NewSegBaseAddr, SegSize));
       FreeSeg->setBaseAddr(FreeSeg->getBaseAddr() + SegSize);
       FreeSeg->setSize(oldFreeSegSize - SegSize);
-      output->verbose(CALL_INFO, 10, 99, "  => allocating start fit %lul bytes at %p\n", SegSize, NewSegBaseAddr);
       return NewSegBaseAddr;
     }
     // New data will fit exactly in the free segment
@@ -449,7 +448,6 @@ uint64_t RevMem::AllocMem(const uint64_t& SegSize){
       NewSegBaseAddr = FreeSeg->getBaseAddr();
       MemSegs.emplace_back(std::make_shared<MemSegment>(NewSegBaseAddr, SegSize));
       FreeMemSegs.erase(FreeMemSegs.begin()+i);
-      output->verbose(CALL_INFO, 10, 99, "  => allocating perfect fit %lul bytes at %p\n", SegSize, NewSegBaseAddr);
       return NewSegBaseAddr;
     }
     // FreeSeg not big enough to fit the new data

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -1160,8 +1160,8 @@ void RevMem::InitHeap(const uint64_t& EndOfStaticData){
     // Mark heap as free
     FreeMemSegs.emplace_back(std::make_shared<MemSegment>(EndOfStaticData+1, maxHeapSize));
 
-    heapend = EndOfStaticData;
-    heapstart = EndOfStaticData;
+    heapend = EndOfStaticData + 1;
+    heapstart = EndOfStaticData + 1;
   }
   return;
 }

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2858,11 +2858,10 @@ void RevProc::ECALL_mmap(){
     // Currently there is no handling of getting it 'close' to the 
     // suggested address... instead if it can't allocate a new segment 
     // there it fails.
-    if( !mem->AddMemSeg(Addr, Size) ){
+    if( !mem->AllocMemAt(Addr, Size) ){
       output->fatal(CALL_INFO, 11, "Failed to add mem segment\n");
     }
   }
-  // std::cout << "MMAP Returning Addr = 0x" << Addr << std::endl; 
   RegFile->RV64[10] = Addr;
   return;
 }

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2874,12 +2874,15 @@ void RevProc::ECALL_munmap(){
   uint64_t Addr = RegFile->RV64[10];
   uint64_t Size = RegFile->RV64[11];
 
-  if( mem->DeallocMem(Addr, Size) == -1 ){
+  int rc =  mem->DeallocMem(Addr, Size) == -1;
+  if(rc == -1){
     output->fatal(CALL_INFO, 11, 
                   "Failed to perform munmap(Addr = 0x%lx, Size = 0x%lx)"
                   "likely because the memory was not allocated to begin with" , 
                   Addr, Size);
   }
+
+  RegFile->RV64[10] = rc;
   return;
 }
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2874,9 +2874,10 @@ void RevProc::ECALL_munmap(){
   uint64_t Addr = RegFile->RV64[10];
   uint64_t Size = RegFile->RV64[11];
 
-  if( !mem->DeallocMem(Addr, Size) ){
+  if( mem->DeallocMem(Addr, Size) == -1 ){
     output->fatal(CALL_INFO, 11, 
-                  "Failed to perform munmap(Addr = 0x%lx, Size = 0x%lx)", 
+                  "Failed to perform munmap(Addr = 0x%lx, Size = 0x%lx)"
+                  "likely because the memory was not allocated to begin with" , 
                   Addr, Size);
   }
   return;

--- a/test/minfft/Makefile
+++ b/test/minfft/Makefile
@@ -21,7 +21,8 @@ ARCH=rv64imfd
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).c
 	#$(CC) -O1 -mcmodel=medlow -march=$(ARCH) -mabi=lp64d -o $(EXAMPLE).exe minfft.c $(EXAMPLE).c -lm
-	$(CC) -O2 -mno-explicit-relocs -mno-save-restore -march=$(ARCH) -mabi=lp64d -static -o $(EXAMPLE).exe $(EXAMPLE).c ex1.c -lm
+	#$(CC) -O2 -mno-explicit-relocs -mno-save-restore -march=$(ARCH) -mabi=lp64d -static -o $(EXAMPLE).exe $(EXAMPLE).c ex1.c -lm
+	$(CC) -O2 -march=$(ARCH) -mabi=lp64d -static -o $(EXAMPLE).exe minfft_new.cc -lm
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/minfft/minfft_new.cc
+++ b/test/minfft/minfft_new.cc
@@ -1,0 +1,87 @@
+#include <complex>
+#define MAX 200
+
+using namespace std;
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932384
+#endif
+
+int log2(int N)    /*function to calculate the log2(.) of int numbers*/
+{
+  int k = N, i = 0;
+  while(k) {
+    k >>= 1;
+    i++;
+  }
+  return i - 1;
+}
+
+int check(int n)    //checking if the number of element is a power of 2
+{
+  return n > 0 && (n & (n - 1)) == 0;
+}
+
+int reverse(int N, int n)    //calculating revers number
+{
+  int j, p = 0;
+  for(j = 1; j <= log2(N); j++) {
+    if(n & (1 << (log2(N) - j)))
+      p |= 1 << (j - 1);
+  }
+  return p;
+}
+
+void ordina(complex<double>* f1, int N) //using the reverse order in the array
+{
+  complex<double> f2[MAX];
+  for(int i = 0; i < N; i++)
+    f2[i] = f1[reverse(N, i)];
+  for(int j = 0; j < N; j++)
+    f1[j] = f2[j];
+}
+
+void transform(complex<double>* f, int N) //
+{
+  ordina(f, N);    //first: reverse order
+  complex<double> *W;
+  W = (complex<double> *)malloc(N / 2 * sizeof(complex<double>));
+  W[1] = polar(1., -2. * M_PI / N);
+  W[0] = 1;
+  for(int i = 2; i < N / 2; i++)
+    W[i] = pow(W[1], i);
+  int n = 1;
+  int a = N / 2;
+  for(int j = 0; j < log2(N); j++) {
+    for(int i = 0; i < N; i++) {
+      if(!(i & n)) {
+        complex<double> temp = f[i];
+        complex<double> Temp = W[(i * a) % (n * a)] * f[i + n];
+        f[i] = temp + Temp;
+        f[i + n] = temp - Temp;
+      }
+    }
+    n *= 2;
+    a = a / 2;
+  }
+  free(W);
+}
+
+void FFT(complex<double>* f, int N, double d)
+{
+  transform(f, N);
+  for(int i = 0; i < N; i++)
+    f[i] *= d; //multiplying by step
+}
+
+int main()
+{
+  int n = 1024;
+  double d = 10.;
+  complex<double> vec[MAX];
+  for(int i = 0; i < n; i++) {
+    vec[i] = rand();
+  }
+  FFT(vec, n, d);
+  return 0;
+}

--- a/test/syscalls/munmap/munmap.c
+++ b/test/syscalls/munmap/munmap.c
@@ -1,40 +1,27 @@
 #include "../../../common/syscalls/syscalls.h"
 #include "unistd.h"
+// #include "sys/mman.h"
+
+#define assert(x) if (!(x)) { asm(".byte 0x00"); asm(".byte 0x00"); asm(".byte 0x00"); asm(".byte 0x00"); }
 
 int main() {
-  uint32_t *addr;
+  uint64_t *addr;
+#define N 237
 
   // Create an anonymous memory mapping
-  addr = rev_mmap(NULL,                 // Let rev choose the address
-              237 * sizeof(uint32_t),                 
+  addr = (uint64_t*)rev_mmap(0,                 // Let rev choose the address
+              N * sizeof(uint32_t),
               PROT_READ | PROT_WRITE | PROT_EXEC, // RWX permissions
               MAP_PRIVATE | MAP_ANONYMOUS, // Not shared, anonymous
               -1,                   // No file descriptor because it's an anonymous mapping
               0);                   // No offset, irrelevant for anonymous mappings
 
-  
-  for( uint32_t i=0; i<120; i++ ){
+
+  for( uint32_t i=0; i< N; i++ ){
     addr[i] = i;
   }
-  // rev_write(STDOUT_FILENO, &addr[0], 128*sizeof(int));
-  // rev_write(STDOUT_FILENO, '\n', 1);
+  for (uint32_t i = 0; i < N ; i++){
+        assert(addr[i] == i);
+  }
 
-  rev_munmap(*addr, 120);
-  // Should segfault at start of loop
-  // for( int i=0; i<513; i++ ){
-  //   addr[i] = 0;
-  // }
-
-  // rev_write(STDOUT_FILENO, addr, 128 );
-  // rev_write(STDOUT_FILENO, '\n', 1);
-  rev_exit(0);
-
-  // We can now use the memory region pointed to by 'addr' as RWX memory...
-
-  // Unmap the memory region when we're done with it
-  // if (rev_munmap(addr, 4096) == -1) {
-  //     return 1;
-  // }
-
-  return 0;
 }

--- a/test/syscalls/vector/Makefile
+++ b/test/syscalls/vector/Makefile
@@ -1,0 +1,27 @@
+#
+# Makefile
+#
+# makefile: vector
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+.PHONY: src
+
+EXAMPLE=vector
+#CC=riscv64-unknown-linux-gnu-gcc
+CC="${RVCC}"
+#ARCH=rv64g
+ARCH=rv64imafdc
+
+all: $(EXAMPLE).exe
+$(EXAMPLE).exe: $(EXAMPLE).c
+	$(CC) -march=$(ARCH) -O0 -o $(EXAMPLE).exe $(EXAMPLE).c -static
+clean:
+	rm -Rf $(EXAMPLE).exe
+
+#-- EOF

--- a/test/syscalls/vector/rev-test.py
+++ b/test/syscalls/vector/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+	"verbose" : 10,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+	"clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "vector.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/syscalls/vector/vector.c
+++ b/test/syscalls/vector/vector.c
@@ -1,0 +1,7 @@
+#include <vector>
+int main() {
+  std::vector<int> v;
+  v.push_back(1);
+  return 0;
+}
+


### PR DESCRIPTION
### FreeMemSegs
- Added a FreeMemSegs vector which in turn simplified quite a bit of the AddMemSeg code
The FreeMemSegs vector occupies all the space after StaticDataEnd (ie. HeapSpace) up to `StaticDataEnd + MaxHeapSize`.
- Removed the `isFree` boolean from `MemSegment` class
- When checking if a virtual address is valid via the `isValidVirtAddr` this cuts down significantly on overhead from checking every allocated segment and then checking if it's free... Now, once a segment is free, we don't have to bother looking through it

### Internal functions (User cannot trigger)
**AddMemSegAt(BaseAddr, Size)**
- Add mem seg starting at BaseAddr of size 

**AddRoundedMemSeg(BaseAddr, Size, RoundUpSize)**
- Add mem seg at BaseAddr of Size rounded up to the nearest multiple of RoundUpSize (this is used mainly in the loader where the headers get added and rounded up to the nearest multiple of PAGE_SIZE


### System Call Triggerable Functions (Alloc/Dealloc)

**AllocMem(SegSize)** 
- Attempts to find a space >= SegSize inside of the FreeMemSegs vector 
- If a FreeSeg is found, we shrink FreeSeg by moving its baseAddr up to `FreeSeg->getBaseAddr()+NewSegSize` and then add the NewSeg (w/ `BaseAddr = OldFreeSeg->BaseAddr` ) to the MemSegs (ie. allocated segment vector)
- If `FreeSeg->getSize == SegSize`, we simply move that segment from the `FreeMemSegs` vector to the `MemSegs` vector 
- If there is no `FreeMemSeg` big enough, we add it to the `HeapEnd` and expand the heap

**AllocMemAt(BaseAddr, SegSize)**
- Checks `FreeMemSegs` to see if we can fit the segment where the user requested
- If it finds a segment big enough, handle the four cases:
	1. New Segment is the same size as FreeSeg found
	2. New Segment fits in the middle of the FreeSeg
	3. NewSegment is allocated at the beginning of the FreeSeg (ie. `FreeSeg->getBaseAddr == BaseAddr`) 
        4. NewSegment is allocated at the end of the `FreeSeg` (ie. `FreeSeg->getTopAddr == BaseAddr + SegSize`)
       
*NOTE: In an actual OS, I believe Linux will try to fit the segment at the nearest address to the requested one if it can’t fit it exactly where the user wants it. We will not be supporting this as there are much higher priority items in flight. Consequently, if we can’t allocate a segment at the requested location we will end the simulation.*


**DeallocMem**:
- Logic in this one pretty much stayed the same
- The only difference is moving the deallocated memory to the FreeMemSegs vector instead of setting the (now removed) `isFree` flag for that segment

