### PR TITLE
LoadHazards for memHierarchy

### DIFF
--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -199,34 +199,6 @@ static inline uint64_t dt_u64(int64_t binary, unsigned bits){
   return tmp;
 }
 
-#if 0
-static uint32_t twos_compl(uint32_t binary, int bits){
-  uint32_t tmp = binary;
-  uint32_t i = 0;
-  //std::cout << "Binary =  " << std::bitset<32>(tmp) << std::endl;
-  if( (binary & (1<<(bits-1))) > 0 ){
-    // sign extend to 32 bits
-    for( i=bits; i<32; i++ ){
-      tmp |= (1<<i);
-    }
-
-    // invert all the bits
-    tmp = ~tmp;
-    //std::cout << "Flipped = " << std::bitset<32>(tmp) << std::endl;
-
-    // add 1
-    tmp += 1;
-    //std::cout << "Added =   " << std::bitset<32>(tmp) << std::endl;
-
-    // set the sign bit
-    //tmp |= (1<<31);
-    tmp = tmp*-1;
-    //std::cout << "Signed =  " << std::bitset<32>(tmp) << std::endl;
-  }
-  return tmp;
-}
-#endif
-
 namespace SST{
   namespace RevCPU {
 
@@ -349,6 +321,7 @@ namespace SST{
       bool compressed;      ///< RevInst: determines if the instruction is compressed
       uint32_t cost;        ///< RevInst: the cost to execute this instruction, in clock cycles
       unsigned entry;       ///< RevInst: Where to find this instruction in the InstTables
+      bool *hazard;         ///< RevInst: signals a load hazard
     }RevInst;
 
     /// RevInstEntry: Holds the compressed index to normal index mapping

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -150,6 +150,7 @@ namespace SST {
 
       /// RevMem: read data from the target memory location
       bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void *Target,
+                    bool *Hazard,
                     StandardMem::Request::flags_t flags);
 
       /// RevMem: DEPRECATED: read data from the target memory location
@@ -162,16 +163,17 @@ namespace SST {
       /// RevMem: template read memory interface
       template <typename T>
       bool ReadVal( unsigned Hart, uint64_t Addr, T *Target,
+                    bool *Hazard,
                     StandardMem::Request::flags_t flags){
-        return ReadMem(Hart, Addr, sizeof(T), (void *)(Target), flags);
+        return ReadMem(Hart, Addr, sizeof(T), (void *)(Target), Hazard, flags);
       }
 
       ///  RevMem: template LOAD RESERVE memory interface
       template <typename T>
       bool LR( unsigned Hart, uint64_t Addr, T *Target,
-               uint8_t aq, uint8_t rl,
+               uint8_t aq, uint8_t rl, bool *Hazard,
                StandardMem::Request::flags_t flags){
-        return LRBase(Hart, Addr, sizeof(T), (void *)(Target), aq, rl, flags);
+        return LRBase(Hart, Addr, sizeof(T), (void *)(Target), aq, rl, Hazard, flags);
       }
 
       ///  RevMem: template STORE CONDITIONAL memory interface
@@ -185,8 +187,9 @@ namespace SST {
       /// RevMem: template AMO memory interface
       template <typename T>
       bool AMOVal( unsigned Hart, uint64_t Addr, T *Data, T *Target,
+                   bool *Hazard,
                    StandardMem::Request::flags_t flags){
-        return AMOMem(Hart, Addr, sizeof(T), (void *)(Data), (void *)(Target), flags);
+        return AMOMem(Hart, Addr, sizeof(T), (void *)(Data), (void *)(Target), Hazard, flags);
       }
 
       /// RevMem: DEPRECATED: Read uint8 from the target memory location
@@ -239,7 +242,7 @@ namespace SST {
       // ----------------------------------------------------
       /// RevMem: Add a memory reservation for the target address
       bool LRBase(unsigned Hart, uint64_t Addr, size_t Len,
-                  void *Data, uint8_t aq, uint8_t rl,
+                  void *Data, uint8_t aq, uint8_t rl, bool *Hazard,
                   StandardMem::Request::flags_t flags);
 
       /// RevMem: Clear a memory reservation for the target address
@@ -249,7 +252,7 @@ namespace SST {
 
       /// RevMem: Initiated an AMO request
       bool AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
-                  void *Data, void *Target,
+                  void *Data, void *Target, bool *Hazard,
                   StandardMem::Request::flags_t flags);
 
       /// RevMem: Initiates a future operation [RV64P only]

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -48,6 +48,7 @@ private:
   unsigned depth;                             ///< Depth of each prefetcher stream
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<uint32_t*> iStack;              ///< Vector of instruction vectors
+  std::vector<bool*> iHazard;                 ///< Vector of instruction cost vectors
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -26,6 +26,7 @@
 #include <random>
 #include <queue>
 #include <functional>
+#include <tuple>
 #include <inttypes.h>
 
 // -- RevCPU Headers
@@ -116,20 +117,20 @@ namespace SST{
       RevMem& GetMem(){ return *mem; }
 
       /// RevProc: Add a RevThreadCtx to the Proc's ThreadTable
-      bool AddCtx(RevThreadCtx& Ctx); 
-  
+      bool AddCtx(RevThreadCtx& Ctx);
+
       /// RevProc: Create a new RevThreadCtx w/ Parent is currently executing thread
-      uint32_t CreateChildCtx(); 
+      uint32_t CreateChildCtx();
 
       /// RevProc: Get the ThreadState of a thread (pid) from the ThreadTable (Unused)
       ThreadState GetThreadState(uint32_t pid);
-  
+
       /// RevProc: Set the ThreadState of a thread (pid) from the ThreadTable (Unused)
       bool SetState(ThreadState, uint32_t pid);
 
       /// RevProc: Used to pause RevThreadCtx w/ PID = pid (Unused)
       bool PauseThread(uint32_t pid);
-  
+
       /// RevProc: Used to ready RevThreadCtx w/ PID = pid (Unused)
       bool ReadyThread(uint32_t pid);
 
@@ -144,7 +145,7 @@ namespace SST{
 
       /// RevProc: Retires currently executing thread & then swaps to its parent. If no parent terminates program
       uint32_t RetireAndSwap(); // Returns new pid
-  
+
       /// RevProc: Used to raise an exception indicating a thread switch is coming (NewPID = PID of Ctx to switch to)
       void CtxSwitchAlert(uint32_t NewPID) { NextPID=NewPID;PendingCtxSwitch = true; }
 
@@ -153,7 +154,7 @@ namespace SST{
 
       ///< RevProc: Returns pointer to current ctx loaded into HartToExec
       std::shared_ptr<RevThreadCtx> HartToExecCtx();
-  
+
       ///< RevProc: Returns pointer to current ctx loaded into HartToDecode
       std::shared_ptr<RevThreadCtx> HartToDecodeCtx();
   
@@ -519,16 +520,16 @@ namespace SST{
 
       /// RevProc: Table of ecall codes w/ corresponding function pointer implementations
       std::unordered_map<uint32_t, std::function<void(RevProc*)>> Ecalls;
-      
+
       /// RevProc: Initialize all of the ecalls inside the above table
       void InitEcallTable();
-      
+
       /// RevProc: Execute the Ecall based on the code loaded in RegFile->RV64_SCAUSE
       void ExecEcall();
 
       /// RevProc: Get a pointer to the register file loaded into Hart w/ HartID
       RevRegFile* GetRegFile(uint16_t HartID);
-      
+
       /// RevProc: Vector of PIDs where index of ActivePIDs is the pid of the RevThreadCtx loaded into Hart #Idx
       std::vector<uint32_t> ActivePIDs;
 
@@ -538,7 +539,10 @@ namespace SST{
 
       std::vector<RevExt *> Extensions;           ///< RevProc: vector of enabled extensions
 
-      std::queue<std::pair<uint16_t, RevInst>>   Pipeline; ///< RevProc: pipeline of instructions - bypass paths not supported
+#define PIPE_HART     0
+#define PIPE_INST     1
+#define PIPE_HAZARD   2
+      std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
 
       std::map<std::string,unsigned> NameToEntry; ///< RevProc: instruction mnemonic to table entry mapping
       std::map<uint32_t,unsigned> EncToEntry;     ///< RevProc: instruction encoding to table entry mapping

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -27,6 +27,7 @@
 #include <queue>
 #include <functional>
 #include <tuple>
+#include <list>
 #include <inttypes.h>
 
 // -- RevCPU Headers
@@ -157,12 +158,12 @@ namespace SST{
 
       ///< RevProc: Returns pointer to current ctx loaded into HartToDecode
       std::shared_ptr<RevThreadCtx> HartToDecodeCtx();
-  
+
       ///< RevProc: Change HartToExec active pid
-      bool ChangeActivePID(uint32_t PID); 
-  
+      bool ChangeActivePID(uint32_t PID);
+
       ///< RevProc: Change HartID active pid
-      bool ChangeActivePID(uint32_t PID, uint16_t HartID); 
+      bool ChangeActivePID(uint32_t PID, uint16_t HartID);
 
       bool UpdateRegFile();
       // bool UpdateRegFile(uint16_t HartID);
@@ -184,7 +185,7 @@ namespace SST{
       uint64_t Retired;         ///< RevProc: number of retired instructions
       bool PendingCtxSwitch = false; ///< RevProc: determines if the core is halted
       bool SwapToParent = false; ///< RevProc: determines if the core is halted
-      uint32_t NextPID = 0; 
+      uint32_t NextPID = 0;
 
       RevOpts *opts;            ///< RevProc: options object
       RevMem *mem;              ///< RevProc: memory object
@@ -542,7 +543,9 @@ namespace SST{
 #define PIPE_HART     0
 #define PIPE_INST     1
 #define PIPE_HAZARD   2
-      std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
+      //std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
+      std::vector<std::pair<uint16_t,RevInst>> Pipeline;  ///< RevProc: pipeline of instructions
+      std::list<bool *> LoadHazards;                      ///< RevProc: list of allocated load hazards
 
       std::map<std::string,unsigned> NameToEntry; ///< RevProc: instruction mnemonic to table entry mapping
       std::map<uint32_t,unsigned> EncToEntry;     ///< RevProc: instruction encoding to table entry mapping
@@ -551,6 +554,12 @@ namespace SST{
       std::map<unsigned,std::pair<unsigned,unsigned>> EntryToExt;     ///< RevProc: instruction entry to extension object mapping
                                                                       ///           first = Master table entry number
                                                                       ///           second = pair<Extension Index, Extension Entry>
+
+      /// RevProc: creates a new pipeline load hazard and returns a pointer to it
+      bool *createLoadHazard();
+
+      /// RevProc: destroys the target load hazard object and removes it from the list
+      void destroyLoadHazard(bool *hazard);
 
       /// RevProc: splits a string into tokens
       void splitStr(const std::string& s, char c, std::vector<std::string>& v);

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -24,13 +24,13 @@ namespace SST{
         if( F->IsRV32() ){
           M->LR(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]),
                 (uint32_t *)(&R->RV32[Inst.rd]),
-                Inst.aq, Inst.rl,
+                Inst.aq, Inst.rl, Inst.hazard,
                 REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
           R->RV32_PC += Inst.instSize;
         }else{
           M->LR(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]),
                 (uint32_t *)(&R->RV64[Inst.rd]),
-                Inst.aq, Inst.rl,
+                Inst.aq, Inst.rl, Inst.hazard,
                 REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
           R->RV64_PC += Inst.instSize;
         }
@@ -60,16 +60,14 @@ namespace SST{
       static bool amoswapw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -77,6 +75,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -85,6 +84,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -96,16 +96,14 @@ namespace SST{
       static bool amoaddw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -113,6 +111,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -121,6 +120,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -132,16 +132,14 @@ namespace SST{
       static bool amoxorw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -149,6 +147,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -157,6 +156,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -168,16 +168,14 @@ namespace SST{
       static bool amoandw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -185,6 +183,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -193,6 +192,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -204,16 +204,14 @@ namespace SST{
       static bool amoorw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -221,6 +219,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -229,6 +228,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -240,16 +240,14 @@ namespace SST{
       static bool amominw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -257,6 +255,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -265,6 +264,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -276,16 +276,14 @@ namespace SST{
       static bool amomaxw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -293,6 +291,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -301,6 +300,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -312,16 +312,14 @@ namespace SST{
       static bool amominuw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -329,6 +327,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -337,6 +336,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }
@@ -348,16 +348,14 @@ namespace SST{
       static bool amomaxuw(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         if( F->IsRV32() ){
@@ -365,6 +363,7 @@ namespace SST{
                     (uint64_t)(R->RV32[Inst.rs1]),
                     (int32_t *)(&R->RV32[Inst.rs2]),
                     (int32_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV32_PC += Inst.instSize;
         }else{
@@ -373,6 +372,7 @@ namespace SST{
                     (uint64_t)(R->RV64[Inst.rs1]),
                     (int32_t *)(&R->RV64[Inst.rs2]),
                     (int32_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(flags));
           R->RV64_PC += Inst.instSize;
         }

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -61,12 +61,14 @@ namespace SST{
           //R->DPF[Inst.rd] = M->ReadDouble((uint64_t)(R->RV32[Inst.rs1]+Inst.imm));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &R->DPF[Inst.rd],
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV32_PC += Inst.instSize;
         }else{
           //R->DPF[Inst.rd] = M->ReadDouble((uint64_t)(R->RV64[Inst.rs1]+Inst.imm));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &R->DPF[Inst.rd],
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV64_PC += Inst.instSize;
         }

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -63,12 +63,14 @@ namespace SST{
             //R->DPF[Inst.rd] = M->ReadFloat((uint64_t)(R->RV32[Inst.rs1]+Inst.imm));
             M->ReadVal<float>(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (float *)(&R->DPF[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
             R->RV32_PC += Inst.instSize;
           }else{
             //R->DPF[Inst.rd] = M->ReadFloat((uint64_t)(R->RV64[Inst.rs1]+Inst.imm));
             M->ReadVal<float>(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (float *)(&R->DPF[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
             R->RV64_PC += Inst.instSize;
           }
@@ -77,12 +79,14 @@ namespace SST{
             //R->SPF[Inst.rd] = M->ReadFloat((uint64_t)(R->RV32[Inst.rs1]+Inst.imm));
             M->ReadVal<float>(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &R->SPF[Inst.rd],
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
             R->RV32_PC += Inst.instSize;
           }else{
             //R->SPF[Inst.rd] = M->ReadFloat((uint64_t)(R->RV64[Inst.rs1]+Inst.imm));
             M->ReadVal<float>(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &R->SPF[Inst.rd],
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
             R->RV64_PC += Inst.instSize;
           }

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -446,6 +446,7 @@ namespace SST{
           //SEXT(R->RV32[Inst.rd],M->ReadU8( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),32);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint8_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
           R->RV32[Inst.rd] = R->RV32[Inst.rd] & 0xFF;
           SEXTI(R->RV32[Inst.rd], 8);
@@ -454,6 +455,7 @@ namespace SST{
           //SEXT(R->RV64[Inst.rd],M->ReadU8( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),64);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint8_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFF;
           SEXTI(R->RV64[Inst.rd], 8);
@@ -469,6 +471,7 @@ namespace SST{
           //SEXT(R->RV32[Inst.rd],M->ReadU16( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),32);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                      (uint16_t *)(&R->RV32[Inst.rd]),
+                     Inst.hazard,
                      REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
           R->RV32[Inst.rd] = R->RV32[Inst.rd] & 0xFFFF;
           SEXTI(R->RV32[Inst.rd], 16);
@@ -477,6 +480,7 @@ namespace SST{
           //SEXT(R->RV64[Inst.rd],M->ReadU16( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),64);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                      (uint16_t *)(&R->RV64[Inst.rd]),
+                     Inst.hazard,
                      REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFFFF;
           SEXT(R->RV64[Inst.rd], R->RV64[Inst.rd], 16);
@@ -492,6 +496,7 @@ namespace SST{
           //SEXT(R->RV32[Inst.rd],M->ReadU32( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),32);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                      (uint32_t *)(&R->RV32[Inst.rd]),
+                     Inst.hazard,
                      REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
           R->RV32[Inst.rd] = R->RV32[Inst.rd] & 0xFFFFFFFF;
           SEXTI(R->RV32[Inst.rd], 32);
@@ -500,6 +505,7 @@ namespace SST{
           //SEXT(R->RV64[Inst.rd],M->ReadU32( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),64);
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                      (uint32_t *)(&R->RV64[Inst.rd]),
+                     Inst.hazard,
                      REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFFFFFFFF;
           SEXT(R->RV64[Inst.rd], R->RV64[Inst.rd], 32);
@@ -516,6 +522,7 @@ namespace SST{
           //R->RV32[Inst.rd] = M->ReadU8( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint8_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV32[Inst.rd] = R->RV32[Inst.rd] & 0xFF;
           R->RV32_PC += Inst.instSize;
@@ -524,6 +531,7 @@ namespace SST{
           //R->RV64[Inst.rd] = M->ReadU8( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint8_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFF;
           R->RV64_PC += Inst.instSize;
@@ -539,6 +547,7 @@ namespace SST{
           //R->RV32[Inst.rd] = M->ReadU16( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint16_t *)(&R->RV32[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFFFF;
           R->RV32_PC += Inst.instSize;
@@ -547,6 +556,7 @@ namespace SST{
           //R->RV64[Inst.rd] = M->ReadU16( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))));
           M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     (uint16_t *)(&R->RV64[Inst.rd]),
+                    Inst.hazard,
                     REVMEM_FLAGS(0));
           R->RV64[Inst.rd] = R->RV64[Inst.rd] & 0xFFFF;
           R->RV64_PC += Inst.instSize;

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -24,7 +24,7 @@ namespace SST{
 
         M->LR(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]),
                 (uint64_t *)(&R->RV64[Inst.rd]),
-                Inst.aq, Inst.rl,
+                Inst.aq, Inst.rl, Inst.hazard,
                 REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
 
         R->RV64_PC += Inst.instSize;
@@ -45,22 +45,21 @@ namespace SST{
       static bool amoswapd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -72,22 +71,21 @@ namespace SST{
       static bool amoaddd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOADD) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -99,22 +97,21 @@ namespace SST{
       static bool amoxord(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOXOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -126,22 +123,21 @@ namespace SST{
       static bool amoandd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOAND) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -153,22 +149,21 @@ namespace SST{
       static bool amoord(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOOR) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -180,22 +175,21 @@ namespace SST{
       static bool amomind(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMIN) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -207,22 +201,21 @@ namespace SST{
       static bool amomaxd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAX) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -234,22 +227,21 @@ namespace SST{
       static bool amominud(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMINU) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 
@@ -261,22 +253,21 @@ namespace SST{
       static bool amomaxud(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
         uint32_t flags = 0x00ul;
 
+        flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU);
         if( Inst.aq && Inst.rl){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= ((uint32_t)(RevCPU::RevFlag::F_AQ) |
+                    (uint32_t)(RevCPU::RevFlag::F_RL));
         }else if( Inst.aq ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_AQ);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_AQ);
         }else if( Inst.rl ){
-          flags = (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) |
-                  (uint32_t)(RevCPU::RevFlag::F_RL);
+          flags |= (uint32_t)(RevCPU::RevFlag::F_RL);
         }
 
         M->AMOVal(F->GetHart(),
                   (uint64_t)(R->RV64[Inst.rs1]),
                   (int64_t *)(&R->RV64[Inst.rs2]),
                   (int64_t *)(&R->RV64[Inst.rd]),
+                  Inst.hazard,
                   REVMEM_FLAGS(flags));
          R->RV64_PC += Inst.instSize;
 

--- a/include/insns/RV64I.h
+++ b/include/insns/RV64I.h
@@ -94,6 +94,7 @@ namespace SST{
         uint32_t val = 0;
         M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &val,
+                    Inst.hazard,
                     REVMEM_FLAGS(RevCPU::RevFlag::F_ZEXT64));
         R->RV64[Inst.rd] = 0x00ULL;
         R->RV64[Inst.rd] |= (uint64_t)(val);
@@ -107,6 +108,7 @@ namespace SST{
         //R->RV64[Inst.rd] = M->ReadU64( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))));
         M->ReadVal(F->GetHart(), (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))),
                     &R->RV64[Inst.rd],
+                    Inst.hazard,
                     REVMEM_FLAGS(0x00));
         R->cost += M->RandCost(F->GetMinCost(),F->GetMaxCost());
         R->RV64_PC += Inst.instSize;

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -461,9 +461,9 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Data, void *Target,
                     bool *Hazard,
                     StandardMem::Request::flags_t flags){
-//#ifdef _REV_DEBUG_
+#ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
-//#endif
+#endif
 
   uint64_t pageNum = Addr >> addrShift;
   uint64_t physAddr = CalcPhysAddr(pageNum, Addr);
@@ -479,7 +479,6 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
 
   if( ctrl ){
     // sending to the RevMemCtrl
-    std::cout << "AMOMem flags = 0x" << std::hex << (uint32_t)(flags) << std::dec << std::endl;
     ctrl->sendAMORequest(Hart, Addr, (uint64_t)(BaseMem),
                               Len, reinterpret_cast<char *>(Data),
                               Target, Hazard, flags);
@@ -577,10 +576,6 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
     }
     // clear the hazard
     *Hazard = false;
-  }
-
-  if( *Hazard ){
-    std::cout << "HAZARD IS SET" << std::endl;
   }
 
   return true;

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -136,6 +136,7 @@ bool RevMem::StatusFuture(uint64_t Addr){
 
 bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Target, uint8_t aq, uint8_t rl,
+                    bool *Hazard,
                     StandardMem::Request::flags_t flags){
   std::vector<std::tuple<unsigned,uint64_t,unsigned,uint64_t*>>::iterator it;
 
@@ -171,12 +172,15 @@ bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
   char *DataMem = (char *)(Target);
 
   if( ctrl ){
+    *Hazard = true;
     ctrl->sendREADLOCKRequest(Hart, Addr, (uint64_t)(BaseMem),
-                              Len, Target, flags);
+                              Len, Target, Hazard, flags);
   }else{
     for( unsigned i=0; i<Len; i++ ){
       DataMem[i] = BaseMem[i];
     }
+    // clear the hazard
+    *Hazard = false;
   }
 
   return true;
@@ -455,10 +459,11 @@ bool RevMem::FenceMem(unsigned Hart){
 
 bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Data, void *Target,
+                    bool *Hazard,
                     StandardMem::Request::flags_t flags){
-#ifdef _REV_DEBUG_
+//#ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
-#endif
+//#endif
 
   uint64_t pageNum = Addr >> addrShift;
   uint64_t physAddr = CalcPhysAddr(pageNum, Addr);
@@ -469,11 +474,15 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
   char *BaseMem = &physMem[physAddr];
   char *DataMem = (char *)(Target);
 
+  // set the hazard
+  *Hazard = true;
+
   if( ctrl ){
     // sending to the RevMemCtrl
+    std::cout << "AMOMem flags = 0x" << std::hex << (uint32_t)(flags) << std::dec << std::endl;
     ctrl->sendAMORequest(Hart, Addr, (uint64_t)(BaseMem),
                               Len, reinterpret_cast<char *>(Data),
-                              Target, flags);
+                              Target, Hazard, flags);
   }else{
     // process the request locally
     if( Len == 4 ){
@@ -484,39 +493,39 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
       uint32_t *TmpDataU = reinterpret_cast<uint32_t *>(Data);
 
       if(       ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOADD) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget += *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOXOR) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget ^= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOAND) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget &= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOOR) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget |= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMIN) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = std::min(*TmpTarget,*TmpData);
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMAX) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = std::max(*TmpTarget,*TmpData);
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMINU) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),Hazard,flags);
         *TmpTargetU = std::min(*TmpTargetU,*TmpDataU);
         WriteMem(Hart,Addr,Len,(void *)(TmpTargetU));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),Hazard,flags);
         *TmpTargetU = std::max(*TmpTargetU,*TmpDataU);
         WriteMem(Hart,Addr,Len,(void *)(TmpTargetU));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }
@@ -529,43 +538,49 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
       uint64_t *TmpDataU = reinterpret_cast<uint64_t *>(Data);
 
       if(       ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOADD) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget += *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOXOR) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget ^= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOAND) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget &= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOOR) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget |= *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMIN) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = std::min(*TmpTarget,*TmpData);
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMAX) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = std::max(*TmpTarget,*TmpData);
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMINU) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),Hazard,flags);
         *TmpTargetU = std::min(*TmpTargetU,*TmpDataU);
         WriteMem(Hart,Addr,Len,(void *)(TmpTargetU));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOMAXU) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTargetU),Hazard,flags);
         *TmpTargetU = std::max(*TmpTargetU,*TmpDataU);
         WriteMem(Hart,Addr,Len,(void *)(TmpTargetU));
       }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOSWAP) ) > 0 ){
-        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),flags);
+        ReadMem(Hart,Addr,Len,(void *)(TmpTarget),Hazard,flags);
         *TmpTarget = *TmpData;
         WriteMem(Hart,Addr,Len,(void *)(TmpTarget));
       }
     }
+    // clear the hazard
+    *Hazard = false;
+  }
+
+  if( *Hazard ){
+    std::cout << "HAZARD IS SET" << std::endl;
   }
 
   return true;
@@ -776,7 +791,7 @@ bool RevMem::ReadMem( uint64_t Addr, size_t Len, void *Data ){
 }
 
 bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
-                     StandardMem::Request::flags_t flags){
+                     bool *Hazard, StandardMem::Request::flags_t flags){
 #ifdef _REV_DEBUG_
   std::cout << "NEW READMEM: Reading " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -788,12 +803,16 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
   uint64_t endOfPage = (pageMap[pageNum].first << addrShift) + pageSize;
   char *BaseMem = &physMem[physAddr];
   char *DataMem = (char *)(Target);
+
+  // set the hazard
+  *Hazard = true;
+
   if((physAddr + Len) > endOfPage){
     uint32_t span = (physAddr + Len) - endOfPage;
     adjPageNum = ((Addr+Len)-span) >> addrShift;
     adjPhysAddr = CalcPhysAddr(adjPageNum, ((Addr+Len)-span));
     if( ctrl ){
-      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, Target, flags);
+      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, Target, Hazard, flags);
     }else{
       for( unsigned i=0; i< (Len-span); i++ ){
         DataMem[i] = BaseMem[i];
@@ -802,24 +821,28 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
     BaseMem = &physMem[adjPhysAddr];
     if( ctrl ){
       unsigned Cur = (Len-span);
-      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, flags);
+      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, Hazard, flags);
     }else{
       unsigned Cur = (Len-span);
       for( unsigned i=0; i< span; i++ ){
         DataMem[Cur] = BaseMem[i];
         Cur++;
       }
+      // clear the hazard
+      *Hazard = false;
     }
 #ifdef _REV_DEBUG_
     std::cout << "Warning: Reading off end of page... " << std::endl;
 #endif
   }else{
     if( ctrl ){
-      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, Target, flags);
+      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, Target, Hazard, flags);
     }else{
       for( unsigned i=0; i<Len; i++ ){
         DataMem[i] = BaseMem[i];
       }
+      // clear the hazard
+      *Hazard = false;
     }
   }
 

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -20,7 +20,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    RevMemOp::MemOp Op, StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false),
     Op(Op), CustomOpc(0),
-    SplitRqst(1), flags(flags), target(nullptr){
+    SplitRqst(1), flags(flags), target(nullptr), hazard(nullptr){
 }
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
@@ -28,7 +28,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                    RevMemOp::MemOp Op, StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false),
     Op(Op), CustomOpc(0),
-    SplitRqst(1), flags(flags), target(target){
+    SplitRqst(1), flags(flags), target(target), hazard(nullptr){
 }
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
@@ -36,7 +36,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
-    SplitRqst(1), flags(flags), target(nullptr){
+    SplitRqst(1), flags(flags), target(nullptr), hazard(nullptr){
   for(unsigned i=0; i<(unsigned)(Size); i++ ){
     membuf.push_back((uint8_t)(buffer[i]));
   }
@@ -47,7 +47,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
-    SplitRqst(1), flags(flags), target(target){
+    SplitRqst(1), flags(flags), target(target), hazard(nullptr){
   for(unsigned i=0; i<(unsigned)(Size); i++ ){
     membuf.push_back((uint8_t)(buffer[i]));
   }
@@ -58,7 +58,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
-    SplitRqst(1), membuf(buffer), flags(flags), target(nullptr){
+    SplitRqst(1), membuf(buffer), flags(flags), target(nullptr), hazard(nullptr){
 }
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
@@ -66,7 +66,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false), Op(Op),
     CustomOpc(CustomOpc), SplitRqst(1), flags(flags),
-    target(target){
+    target(target), hazard(nullptr){
 }
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
@@ -74,7 +74,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                    unsigned CustomOpc, RevMemOp::MemOp Op,
                    StandardMem::Request::flags_t flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false), Op(Op),
-    CustomOpc(CustomOpc), SplitRqst(1), flags(flags), target(nullptr){
+    CustomOpc(CustomOpc), SplitRqst(1), flags(flags), target(nullptr), hazard(nullptr){
   for(unsigned i=0; i<(unsigned)(Size); i++ ){
     membuf.push_back((uint8_t)(buffer[i]));
   }
@@ -105,9 +105,10 @@ RevBasicMemCtrl::RevBasicMemCtrl(ComponentId_t id, Params& params)
   : RevMemCtrl(id,params), memIface(nullptr), stdMemHandlers(nullptr),
     hasCache(false), lineSize(0),
     max_loads(64), max_stores(64), max_flush(64), max_llsc(64),
-    max_readlock(64), max_writeunlock(64), max_custom(64), max_amo(64), max_ops(2),
-    num_read(0), num_write(0), num_flush(0), num_llsc(0), num_readlock(0),
-    num_writeunlock(0), num_custom(0), num_fence(0), num_amo(0){
+    max_readlock(64), max_writeunlock(64), max_custom(64), max_ops(2),
+    num_read(0x00ull), num_write(0x00ull), num_flush(0x00ull), num_llsc(0x00ull),
+    num_readlock(0x00ull), num_writeunlock(0x00ull), num_custom(0x00ull),
+    num_fence(0x00ull) {
 
   stdMemHandlers = new RevBasicMemCtrl::RevStdMemHandlers(this,output);
 
@@ -120,7 +121,6 @@ RevBasicMemCtrl::RevBasicMemCtrl(ComponentId_t id, Params& params)
   max_readlock = params.find<unsigned>("max_readlock", 64);
   max_writeunlock = params.find<unsigned>("max_writeunlock", 64);
   max_custom = params.find<unsigned>("max_custom", 64);
-  max_amo = params.find<unsigned>("max_amo", 64);
   max_ops = params.find<unsigned>("ops_per_cycle", 2);
 
   rqstQ.reserve(max_ops);
@@ -221,11 +221,14 @@ bool RevBasicMemCtrl::sendREADRequest(unsigned Hart,
                                       uint64_t PAddr,
                                       uint32_t Size,
                                       void *target,
+                                      bool *Hazard,
                                       StandardMem::Request::flags_t flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, target,
                               RevMemOp::MemOp::MemOpREAD, flags);
+  Op->setHazard(Hazard);
+  *Hazard = true;
   rqstQ.push_back(Op);
   recordStat(RevBasicMemCtrl::MemCtrlStats::ReadPending,1);
   return true;
@@ -252,15 +255,19 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
                                      uint32_t Size,
                                      char *buffer,
                                      void *target,
+                                     bool *Hazard,
                                      StandardMem::Request::flags_t flags){
+
+  std::cout << "sendAMORequest" << std::endl;
   if( Size == 0 )
     return true;
 
   // Check to see if our flags contain an atomic request
   // The flag hex value is a bitwise OR of all the RevFlag
   // AMO enums
-  if( ((uint32_t)(flags) & (uint32_t)(0x1FE00000)) == 0){
+  if( ((uint32_t)(flags) & (uint32_t)(0x3FE00000)) == 0){
     // not an atomic request
+    std::cout << "FUCK THIS : 0x" << std::hex << (uint32_t)(flags) << std::hex << std::endl;
     return true;
   }
 
@@ -269,6 +276,11 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
   // is a MemOpREAD.
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, buffer, target,
                               RevMemOp::MemOp::MemOpREAD, flags);
+  Op->setHazard(Hazard);
+  *Hazard = true;
+
+  std::cout << "MY AMO HAZARD ADDRESS IS : 0x" << std::hex
+             << Op->getHazard() << std::dec << std::endl;
 
   // Store the first operation in the AMOTable.  When the read
   // response comes back, we will catch the response, perform
@@ -310,11 +322,14 @@ bool RevBasicMemCtrl::sendREADLOCKRequest(unsigned Hart,
                                           uint64_t PAddr,
                                           uint32_t Size,
                                           void *target,
+                                          bool *Hazard,
                                           StandardMem::Request::flags_t flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, target,
                               RevMemOp::MemOp::MemOpREADLOCK, flags);
+  Op->setHazard(Hazard);
+  *Hazard = true;
   rqstQ.push_back(Op);
   recordStat(RevBasicMemCtrl::MemCtrlStats::ReadLockPending,1);
   return true;
@@ -442,22 +457,7 @@ bool RevBasicMemCtrl::isMemOpAvail(RevMemOp *Op,
                                    unsigned &t_max_llsc,
                                    unsigned &t_max_readlock,
                                    unsigned &t_max_writeunlock,
-                                   unsigned &t_max_custom,
-                                   unsigned &t_max_amo){
-
-  // Determine if this request is an AMO
-  auto it = AMOTable.find(Op->getAddr());
-  if( it != AMOTable.end() ){
-    auto range = AMOTable.equal_range(Op->getAddr());
-    for( auto i = range.first; i != range.second; ++ i ){
-      auto Entry = i->second;
-      // determine if we have an atomic request associated
-      // with this operation
-      if( std::get<AMOTABLE_MEMOP>(Entry) == Op ){
-        t_max_amo++;
-      }
-    }
-  }
+                                   unsigned &t_max_custom){
 
   switch(Op->getOp()){
   case RevMemOp::MemOp::MemOpREAD:
@@ -1090,7 +1090,7 @@ bool RevBasicMemCtrl::isAQ(unsigned Slot, unsigned Hart){
 
   // search all preceding slots for an AMO from the same Hart
   for( unsigned i=0; i<Slot; i++ ){
-    if( (((uint32_t)(rqstQ[i]->getFlags()) & (uint32_t)(0x1FE00000)) > 0) &&
+    if( (((uint32_t)(rqstQ[i]->getFlags()) & (uint32_t)(0x3FE00000)) > 0) &&
         (rqstQ[i]->getHart() == rqstQ[Slot]->getHart()) ){
       if( ((uint32_t)(rqstQ[i]->getFlags()) &
            (uint32_t)(RevCPU::RevFlag::F_AQ)) > 0 ){
@@ -1113,7 +1113,7 @@ bool RevBasicMemCtrl::isRL(unsigned Slot, unsigned Hart){
     return false;
   }
 
-  if( (((uint32_t)(rqstQ[Slot]->getFlags()) & (uint32_t)(0x1FE00000)) > 0) &&
+  if( (((uint32_t)(rqstQ[Slot]->getFlags()) & (uint32_t)(0x3FE00000)) > 0) &&
       (((uint32_t)(rqstQ[Slot]->getFlags()) & (uint32_t)(RevCPU::RevFlag::F_RL))>0) ){
     // this is an AMO, check to see if there are other ops from the same
     // HART in flight
@@ -1140,7 +1140,6 @@ bool RevBasicMemCtrl::processNextRqst(unsigned &t_max_loads,
                                       unsigned &t_max_readlock,
                                       unsigned &t_max_writeunlock,
                                       unsigned &t_max_custom,
-                                      unsigned &t_max_amo,
                                       unsigned &t_max_ops){
   if( rqstQ.size() == 0 ){
     // nothing to do, saturate and exit this cycle
@@ -1160,8 +1159,7 @@ bool RevBasicMemCtrl::processNextRqst(unsigned &t_max_loads,
                      t_max_llsc,
                      t_max_readlock,
                      t_max_writeunlock,
-                     t_max_custom,
-                     t_max_amo) ){
+                     t_max_custom) ){
 
       // op is good to execute, build a StandardMem packet
       t_max_ops++;
@@ -1263,6 +1261,8 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
     for( unsigned i=0; i<(unsigned)(op->getSize()); i++ ){
       std::cout << "               : data[" << i << "] = " << (unsigned)(ev->data[i]) << std::endl;
     }
+    std::cout << "hazard ptr = 0x" << std::hex << op->getHazard() << std::dec << std::endl;
+    std::cout << "hazard value before processing = " << *op->getHazard() << std::endl;
 #endif
 
     auto range = AMOTable.equal_range(op->getAddr());
@@ -1294,6 +1294,8 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
         if( isAMO ){
           handleAMO(op);
         }
+        bool *Hazard = op->getHazard();
+        *Hazard = false;
         delete op;
       }
       outstanding.erase(ev->getID());
@@ -1313,6 +1315,8 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
     if( isAMO ){
       handleAMO(op);
     }
+    bool *Hazard = op->getHazard();
+    *Hazard = false;
     delete op;
     outstanding.erase(ev->getID());
     delete ev;
@@ -1335,6 +1339,9 @@ void RevBasicMemCtrl::performAMO(std::tuple<unsigned,char *,void *,
   StandardMem::Request::flags_t flags = Tmp->getFlags();
   std::vector<uint8_t> buffer = Tmp->getBuf();
 
+  std::cout << "buffer size = " << buffer.size() << std::endl;
+  std::cout << "tmp size = " << Tmp->getSize() << std::endl;
+
   if( Tmp->getSize() == 4 ){
     int32_t TmpBuf = 0x00ul;
     int32_t *TmpTarget = reinterpret_cast<int32_t *>(Target);
@@ -1346,7 +1353,12 @@ void RevBasicMemCtrl::performAMO(std::tuple<unsigned,char *,void *,
 
     // 32-bit (W) AMOs
     if(       ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOADD) ) > 0 ){
+      std::cout << "handling AMOAdd command" << std::endl;
+      std::cout << "TmpTarget = 0x" << std::hex << *TmpTarget << std::dec << std::endl;
+      std::cout << "TmpBuf = 0x" << std::hex << TmpBuf << std::dec << std::endl;
       *TmpTarget += TmpBuf;
+      SEXTI(*TmpTarget,32);
+      std::cout << "Result TmpTarget = 0x" << std::hex << *TmpTarget << std::dec << std::endl;
     }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOXOR) ) > 0 ){
       *TmpTarget ^= TmpBuf;
     }else if( ((uint32_t)(flags) & (uint32_t)(RevCPU::RevFlag::F_AMOAND) ) > 0 ){
@@ -1408,9 +1420,13 @@ void RevBasicMemCtrl::performAMO(std::tuple<unsigned,char *,void *,
                               RevMemOp::MemOp::MemOpWRITE,
                               Tmp->getFlags());
 
+  bool *Hazard = Tmp->getHazard();
+  Op->setHazard(Hazard);
+  *Hazard = true;
+
   // insert a new entry into the AMO Table
   auto NewEntry = std::make_tuple(Op->getHart(),
-                                  nullptr,        // this can be null here since we don't need to modify the response
+                                  nullptr,// this can be null here since we don't need to modify the response
                                   Op->getTarget(),
                                   Op->getFlags(),
                                   Op,true);
@@ -1451,7 +1467,6 @@ void RevBasicMemCtrl::handleWriteResp(StandardMem::WriteResp* ev){
       // then delete it
       if( std::get<AMOTABLE_MEMOP>(Entry) == op ){
         AMOTable.erase(i++);
-        num_amo--;
       }else{
         ++i;
       }
@@ -1462,6 +1477,10 @@ void RevBasicMemCtrl::handleWriteResp(StandardMem::WriteResp* ev){
       // split request exists, determine how to handle it
       if( getNumSplitRqsts(op) == 1 ){
         // this was the last request to service, delete the op
+        if( op->getHazard() != nullptr ){
+          // this was a write request for an AMO, clear the hazard
+          *(op->getHazard()) = false;
+        }
         delete op;
       }
       outstanding.erase(ev->getID());
@@ -1471,6 +1490,10 @@ void RevBasicMemCtrl::handleWriteResp(StandardMem::WriteResp* ev){
     }
 
     // no split request exists; handle as normal
+    if( op->getHazard() != nullptr ){
+      // this was a write request for an AMO, clear the hazard
+      *(op->getHazard()) = false;
+    }
     delete op;
     outstanding.erase(ev->getID());
     delete ev;
@@ -1582,7 +1605,8 @@ bool RevBasicMemCtrl::clockTick(Cycle_t cycle){
   // check to see if the top request is a FENCE
   if( num_fence > 0 ){
     if( (num_read + num_write + num_llsc +
-         num_readlock + num_writeunlock + num_custom) != 0 ){
+         num_readlock + num_writeunlock +
+         num_custom) != 0 ){
       // waiting for the outstanding ops to clear
       recordStat(RevBasicMemCtrl::MemCtrlStats::FencePending,1);
       return false;
@@ -1602,12 +1626,11 @@ bool RevBasicMemCtrl::clockTick(Cycle_t cycle){
   unsigned t_max_readlock = 0;
   unsigned t_max_writeunlock = 0;
   unsigned t_max_custom = 0;
-  unsigned t_max_amo = 0;
 
   while( !done ){
     if( !processNextRqst(t_max_loads, t_max_stores, t_max_flush,
                          t_max_llsc, t_max_readlock, t_max_writeunlock,
-                         t_max_custom, t_max_amo, t_max_ops) ){
+                         t_max_custom, t_max_ops) ){
       // error occurred
       output->fatal(CALL_INFO, -1, "Error : failed to process next memory request");
     }

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -172,17 +172,20 @@ void RevPrefetcher::Fill(uint64_t Addr){
   // allocate a new stream buffer
   baseAddr.push_back(Addr);
   iStack.push_back( new uint32_t[depth] );
+  iHazard.push_back( new bool[depth] );
 
   // initialize it
   unsigned x = baseAddr.size()-1;
   for( unsigned y = 0; y<depth; y++ ){
     iStack[x][y] = REVPREF_INIT_ADDR;
+    iHazard[x][y] = true;
   }
 
   // now fill it
   for( unsigned y=0; y<depth; y++ ){
     mem->ReadVal( feature->GetHart(), Addr+(y*4),
                   (uint32_t *)(&iStack[x][y]),
+                  &(iHazard[x][y]),
                   REVMEM_FLAGS(0x00) );
 
   }
@@ -196,7 +199,9 @@ void RevPrefetcher::DeleteStream(unsigned i){
 
   // delete it
   delete [] iStack[i];
+  delete [] iHazard[i];
   iStack.erase(iStack.begin() + i);
+  iHazard.erase(iHazard.begin() + i);
   baseAddr.erase(baseAddr.begin() + i);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,7 +93,7 @@ add_test(NAME TEST_BIG_LOOP COMMAND run_big_loop.sh WORKING_DIRECTORY "${CMAKE_C
 set_tests_properties(TEST_BIG_LOOP
   PROPERTIES
     ENVIRONMENT "RVCC=${RVCC}"
-    TIMEOUT 65
+    TIMEOUT 90
     PASS_REGULAR_EXPRESSION "${passRegex}"
     LABELS "all;rv64"
 )

--- a/test/amo/amoadd_c_memh/rev-test-amoadd_c_memh.py
+++ b/test/amo/amoadd_c_memh/rev-test-amoadd_c_memh.py
@@ -45,7 +45,6 @@ comp_lsq.addParams({
       "max_readlock"    : 16,
       "max_writeunlock" : 16,
       "max_custom"      : 16,
-      "max_amo"         : 16,
       "ops_per_cycle"   : 16
 })
 comp_lsq.enableAllStatistics({"type":"sst.AccumulatorStatistic"})

--- a/test/amo/amoadd_cxx/run_amoadd_cxx.sh
+++ b/test/amo/amoadd_cxx/run_amoadd_cxx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Build the test
-clean && make
+make clean && make
 
 # Check that the exec was built...
 if [ -f amoadd_cxx.exe ]; then

--- a/test/amo/amoadd_cxx_memh/amoadd_cxx_memh.cc
+++ b/test/amo/amoadd_cxx_memh/amoadd_cxx_memh.cc
@@ -3,7 +3,8 @@
 
 int main() {
         std::atomic<int> a;
-        a = 0;
-        a++;
+        a = 1;  //amoswap
         assert(a == 1);
+        a++;    //amoadd
+        assert(a == 2);
 }

--- a/test/amo/amoadd_cxx_memh/rev-test-amoadd_cxx_memh.py
+++ b/test/amo/amoadd_cxx_memh/rev-test-amoadd_cxx_memh.py
@@ -45,7 +45,6 @@ comp_lsq.addParams({
       "max_readlock"    : 16,
       "max_writeunlock" : 16,
       "max_custom"      : 16,
-      "max_amo"         : 16,
       "ops_per_cycle"   : 16
 })
 comp_lsq.enableAllStatistics({"type":"sst.AccumulatorStatistic"})


### PR DESCRIPTION
Creating load hazard infrastructure for all AMOs and LOAD operations.  Correctly ordering pipeline hazards.  Fix for Issue #56 