### PR TITLE
Use smart pointers

### DIFF
--- a/documentation/ExtensionDevelopment.md
+++ b/documentation/ExtensionDevelopment.md
@@ -7,10 +7,9 @@ There are also several limitations of the current extension functionality.  Thes
 
 1. The Rev crack/decode functions currently only support the standard set of RISC-V instruction formats.  Additional formats can be supported, but will require additional source code modifications to the crack/decode engine.
 2. The Rev model supports the ability for users to override default extensions (for example, the D-extension) with new functionality.  However, you cannot load two extensions with conflicting encodings.  This will break the Rev crack/decode engine.  
-3. The Rev model does not currently support the compressed encodings.
-4. The naming convention for the new extension cannot conflict with the standard set of the extensions if they are utilized in the same core.  Eg, an RV64IMAFD device cannot have a second "F" extension.  You must utilize a different naming convention.
-5. The Rev model utilizes a standard ELF loader.  If the extension breaks the base RISC-V (RV32, RV64) relocation, then the device may not function as expected.
-6. The Rev model supports the standard set of RV32/RV64-G registers for integer and floating point.  Any extension-specific register state will require additional source code modifications.
+3. The naming convention for the new extension cannot conflict with the standard set of the extensions if they are utilized in the same core.  Eg, an RV64IMAFD device cannot have a second "F" extension.  You must utilize a different naming convention.
+4. The Rev model utilizes a standard ELF loader.  If the extension breaks the base RISC-V (RV32, RV64) relocation, then the device may not function as expected.
+5. The Rev model supports the standard set of RV32/RV64-G registers for integer and floating point.  Any extension-specific register state will require additional source code modifications.
 
 ## Source Code Organization
 
@@ -36,36 +35,97 @@ Each extension requires a notional mnemonic that can be parsed by the Rev infras
 
 ### Add the Mnemonic to the RevFeature Handlers
 
-Now that we have a mnemonic defined, we need to add the support for the new extension in the `RevFeature` class.  The first step in doing so is to added an entry in the `RevFeatureType` enumerated type list to represent your extension.  This can be found in the `RevFeature.h` header.  Make sure that you choose a unique numerical identifier.  An example of doing so is as follows: 
+Now that we have a mnemonic defined, we need to add the support for the new extension in the `RevFeature` class.
+
+The first step in doing so is to added an entry in the `RevFeatureType` enumerated type list to represent your extension.  This can be found in the `RevFeature.h` header.  Make sure that you choose a unique power of 2, since the features are ORed together. Right now the list includes all feature strings defined in the RISC-V Unproviledged Specification, Chapter 27.
 
 ```c++
-typedef enum{
-      RV_UNKNOWN    = 0,        ///< RevFeatureType: unknown feature
-      RV_I          = 1,        ///< RevFeatureType: I-extension
-      RV_M          = 2,        ///< RevFeatureType: M-extension
-      RV_A          = 3,        ///< RevFeatureType: A-extension
-      RV_F          = 4,        ///< RevFeatureType: F-extension
-      RV_D          = 5,        ///< RevFeatureType: D-extension
-      RV_C          = 6,        ///< RevFeatureType: C-extension
-
-      RV_Z          = 20        ///< RevFeatureType: Z-extension
-}RevFeatureType;
+enum RevFeatureType : uint32_t {
+    RV_UNKNOWN  = 0,      ///< RevFeatureType: unknown feature
+    RV_E        = 1<<0,   ///< RevFeatureType: E-extension
+    RV_I        = 1<<1,   ///< RevFeatureType: I-extension
+    RV_M        = 1<<2,   ///< RevFeatureType: M-extension
+    RV_A        = 1<<3,   ///< RevFeatureType: A-extension
+    RV_F        = 1<<4,   ///< RevFeatureType: F-extension
+    RV_D        = 1<<5,   ///< RevFeatureType: D-extension
+    RV_Q        = 1<<6,   ///< RevFeatureType: Q-extension
+    RV_L        = 1<<7,   ///< RevFeatureType: L-extension
+    RV_C        = 1<<8,   ///< RevFeatureType: C-extension
+    RV_B        = 1<<9,   ///< RevFeatureType: B-extension
+    RV_J        = 1<<10,  ///< RevFeatureType: J-extension
+    RV_T        = 1<<11,  ///< RevFeatureType: T-extension
+    RV_P        = 1<<12,  ///< RevFeatureType: P-Extension
+    RV_V        = 1<<13,  ///< RevFeatureType: V-extension
+    RV_N        = 1<<14,  ///< RevFeatureType: N-extension
+    RV_ZICSR    = 1<<15,  ///< RevFEatureType: Zicsr-extension
+    RV_ZIFENCEI = 1<<16,  ///< RevFeatureType: Zifencei-extension
+    RV_ZAM      = 1<<17,  ///< RevFeatureType: Zam-extension
+    RV_ZTSO     = 1<<18,  ///< RevFeatureType: Ztso-extension
+    RV_ZFA      = 1<<19,  ///< RevFeatureType: Zfa-extension
+    };
 ```
 
-Now we need to add support in the extension parser.  This resides in the `ParseMachineModel` function inside `RevFeature.cc`.  This function loops over the device string and adds the necessary support for the specific extension.  Add support for new features is as simple as adding a new case entry into the machine model loop as folows.  Notice how we utilize the `SetMachineEntry` function with the appropriate enumerated type defined above.  
+Now we need to add support in the extension parser.  This resides in the `ParseMachineModel` function inside `RevFeature.cc`.
+
+This function a loop over the device string and adds the necessary support for the specific extension(s).
+
+Adding support for new features is as simple as adding a new entry into the machine model table as folows.
+Notice how we utilize the `SetMachineEntry` function with the appropriate enumerated type defined above.  
 
 ```c++
-while( found < machine.length() ){
-    switch( machine[found] ){
-    case 'Z':
-      SetMachineEntry(RV_Z);
-      break;
-    case 'I':
-      SetMachineEntry(RV_I);
-      break;
-....
-```
+  ///< List of architecture extensions. These must listed in canonical order
+  ///< as shown in Table 27.11, Chapter 27, of the RiSC-V Unpriviledged Spec.
+  ///< By using a canonical ordering, the extensions' presence can be tested
+  ///< in linear time complexity of the table and the string. Some of the
+  ///< extensions imply other extensions, so the extension flags are ORed.
+  static constexpr std::pair<std::string_view, uint32_t> table[] = {
+    { "E",          RV_E                                                      },
+    { "I",          RV_I                                                      },
+    { "M",          RV_M                                                      },
+    { "A",          RV_A                                                      },
+    { "F",          RV_F | RV_ZICSR                                           },
+    { "D",          RV_D | RV_F | RV_ZICSR                                    },
+    { "G",          RV_I | RV_M | RV_A | RV_F | RV_D | RV_ZICSR | RV_ZIFENCEI },
+    { "Q",          RV_Q | RV_D | RV_F | RV_ZICSR                             },
+    { "L",          RV_L                                                      },
+    { "C",          RV_C                                                      },
+    { "B",          RV_B                                                      },
+    { "J",          RV_J                                                      },
+    { "T",          RV_T                                                      },
+    { "P",          RV_P                                                      },
+    { "V",          RV_V | RV_D | RV_F | RV_ZICSR                             },
+    { "N",          RV_N                                                      },
+    { "Zicsr",      RV_ZICSR                                                  },
+    { "Zifencei",   RV_ZIFENCEI                                               },
+    { "Zam",        RV_ZAM | RV_A                                             },
+    { "Ztso",       RV_ZTSO                                                   },
+    { "Zfa",        RV_ZFA | RV_F | RV_ZICSR                                  },
+  };
 
+  // -- step 2: parse all the features
+  // Note: Extension strings, if present, must appear in the order listed in the table above.
+  if (*mac){
+    for (const auto& tab : table) {
+      // Look for an architecture string matching the current extension
+      if(!strncasecmp(mac, tab.first.data(), tab.first.size())){
+
+        // Set the machine entries for the matching extension
+        SetMachineEntry(RevFeatureType{tab.second});
+
+        // Move past the currently matching extension
+        mac += tab.first.size();
+
+        // Skip underscore separators
+        while (*mac == '_') ++mac;
+
+        // Success if end of string is reached
+        if (!*mac)
+          return true;
+      }
+    }
+  }
+  return false;
+```
 ### Add the Extension Header to the RevInstTables Header
 
 Now that you've defined your new extension mnemonic, you need to add an entry in the `RevInstTables.h` header 
@@ -159,36 +219,57 @@ using namespace SST::RevCPU;
 
 namespace SST{
   namespace RevCPU{
-    class RV32Z : public RevExt {
+    struct RV32Z : RevExt {
 
     // RV32Z Implementation Functions
 
     // RV32Z Instruction Table
 
-    public:
       /// RV32Z: standard constructor
       RV32Z( RevFeature *Feature,
              RevRegFile *RegFile,
              RevMem *RevMem,
              SST::Output *Output )
         : RevExt( "RV32Z", Feature, RegFile, RevMem, Output ) {
-          this->SetTable(RV32ZTable);
+          SetTable(RV32ZTable);
         }
 
       /// RV32Z: standard destructor
-      ~RV32Z() { }
+      ~RV32Z() = default;
 
     }; // end class RV32I
   } // namespace RevCPU
 } // namespace SST
 ```
 
-There are a few important things we need to point out before we move on.  First, notice how the new implementation class resides inside the `SST::RevCPU` namespace and inherits functions from the base `RevExt` class.  This is very important in order to correctly load your new instructions into the simulator.  Second, notice how we instantiate the constructor for the new extension.  The constructor **MUST** contain a call to `this->SetTable(RV32ZTable)`.  Given that this is a header-only implementation, the order of which the class constructors and associated data members must be preserved.  This method forces the child constructor to create its private data members before registering them with the base class.  
+There are a few important things we need to point out before we move on. First,
+notice how the new implementation class resides inside the `SST::RevCPU`
+namespace and inherits functions from the base `RevExt` class. This is very
+important in order to correctly load your new instructions into the simulator.
+Second, notice how we instantiate the constructor for the new extension. The
+constructor **MUST** contain a call to `SetTable(RV32ZTable)`. Given that this
+is a header-only implementation, the order of which the class constructors and
+associated data members must be preserved. This method forces the child
+constructor to create its private data members before registering them with the
+base class.
 
-Now that we have our basic skeleton in place, we can start creating our instruction table.  The table is actually a C++ vector of struct entries where each entry corresponds to a single instruction entry.  This needs to be done in the private section of the class (see the comment above for RV32Z Instruction Table).  The stuct for each entry is created by an in-line creation of a `RevInstEntryBuilder< >` object. This object will utilize the class declared in the template parameter for the default values.  The base default values can be found in the `RevInstDefaults` class and can be overriden through inheritence (shown in the example below).  The individual elements of the `RevInstEntry` struct are initialized using named arguments so they can be initialized in any order. It is important to end the argument initialization chain with `.InstEntry` as this is the actual struct that will be added to the `std::vector`.First, lets create a few basic entries in our table, then we'll explain what each entry is used for.
+Now that we have our basic skeleton in place, we can start creating our
+instruction table. The table is actually a C++ vector of struct entries where
+each entry corresponds to a single instruction entry. This needs to be done in
+the private section of the class (see the comment above for RV32Z Instruction
+Table). The stuct for each entry is created by an in-line creation of a
+`RevInstEntryBuilder< >` object. This object will utilize the class declared in
+the template parameter for the default values. The base default values can be
+found in the `RevInstDefaults` class and can be overriden through inheritence
+(shown in the example below). The individual elements of the `RevInstEntry`
+struct are initialized using named arguments so they can be initialized in any
+order. It is important to end the argument initialization chain with
+`.InstEntry` as this is the actual struct that will be added to the
+`std::vector`.First, lets create a few basic entries in our table, then we'll
+explain what each entry is used for.
 
 ```c++
-class Rev32ZInstDefaults : public RevInstDefaults {
+struct Rev32ZInstDefaults : RevInstDefaults {
   RevRegF format = RVTypeR; 
 }
 std::vector<RevInstEntry> RV32ZTable = {
@@ -223,157 +304,251 @@ For this, we've created four instructions: `zadd`, `zsub`, `zlb` and `zsb` to re
 
 Now that we have our instruction encoding tables, we can begin implementing each of our instruction functions in the private section of the header file.  Note that this must be done **above** the instruction table as the symbol names must be defined prior to their use in the instruction table.  First, we'll show an example implementation of our four instructions before outlining all the requirements and features.
 
+### Helper Functions
+There are several helper functions to make generating instruction implementations easier.
+
 ```c++
-static bool zadd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
+  /// Zero-extend value of bits size
+  template<typename T>
+  constexpr auto ZeroExt(T val, size_t bits);
+```
+```c++
+  /// Sign-extend value of bits size
+  template<typename T>
+  constexpr auto SignExt(T val, size_t bits);
+```
+```c++
+  /// BoxNaN: Store a boxed float inside a double
+  inline void BoxNaN(double* dest, const void* value);
+```
+```c++
+  /// GetX: Get the specifed X register cast to a specific integral type
+  template<typename T>
+  T GetX(const RevFeature* F, size_t rs) const;
+```
+```c++
+  /// SetX: Set the specifed X register to a specific value
+  template<typename T>
+  void SetX(const RevFeature* F, size_t rd, T val);
+```
+```c++
+  /// GetPC: Get the Program Counter
+  uint64_t GetPC(const RevFeature* F) const;
+```
+```c++
+  /// SetPC: Set the Program Counter to a specific value
+  template<typename T>
+  void SetPC(const RevFeature* F, T val);
+```
+```c++
+  /// AdvancePC: Advance the program counter a certain number of bytes
+  template<typename T>
+  void AdvancePC(const RevFeature* F, T bytes);
+```
+```c++
+  /// GetFP32: Get the 32-bit float value of a specific FP register
+  float GetFP32(const RevFeature* F, size_t rs) const;
+```
+```c++
+  /// SetFP32: Set a specific FP register to a 32-bit float value
+  void SetFP32(const RevFeature* F, size_t rd, float value);
+```
+```c++
+  /// RevInst: Sign-extended immediate value
+  constexpr int32_t ImmSignExt(size_t bits) const;
+```
+```c++
+/// General template for converting between Floating Point and Integer.
+/// FP values outside the range of the target integer type are clipped
+/// at the integer type's numerical limits, whether signed or unsigned.
+template<typename FP, typename INT>
+bool CvtFpToInt(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// fclass: Return FP classification like the RISC-V fclass instruction
+// See: https://github.com/riscv/riscv-isa-sim/blob/master/softfloat/f32_classify.c
+// Because quiet and signaling NaNs are not distinguished by the C++ standard,
+// an additional argument has been added to disambiguate between quiet and
+// signaling NaNs.
+template<typename T>
+unsigned fclass(T val, bool quietNaN = true);
+```
+```c++
+/// Load template
+template<typename T>
+bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Store template
+template<typename T>
+bool store(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Floating-point load template
+template<typename T>
+bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Floating-point store template
+template<typename T>
+bool fstore(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Floating-point operation template
+template<typename T, template<class> class OP>
+bool foper(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Floating-point minimum functor
+template<typename = void>
+struct FMin;
+```
+```c++
+/// Floating-point maximum functor
+template<typename = void>
+struct FMax;
+```
+```
+/// Floating-point conditional operation template
+template<typename T, template<class> class OP>
+bool fcondop(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Arithmetic operator template
+// The First parameter is the operator functor (such as std::plus)
+// The second parameter is the operand kind (OpKind::Imm or OpKind::Reg)
+// The third parameter is std::make_unsigned_t or std::make_signed_t (default)
+// The optional fourth parameter indicates W mode (32-bit on XLEN == 64)
+template<template<class> class OP, OpKind KIND,
+         template<class> class SIGN = std::make_signed_t, bool W_MODE = false>
+bool oper(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+```c++
+/// Left shift functor
+template<typename = void>
+struct ShiftLeft;
+```
+```c++
+/// Right shift functor
+template<typename = void>
+struct ShiftRight;
+```
+```c++
+enum class DivRem { Div, Rem };
+```
+```c++
+/// Division/Remainder template
+// The first parameter is DivRem::Div or DivRem::Rem
+// The second parameter is std::make_signed_t or std::make_unsigned_t
+// The optional third parameter indicates W mode (32-bit on XLEN == 64)
+template<DivRem DIVREM, template<class> class SIGN, bool W_MODE = false>
+bool divrem(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+```
+
+Many instructions can be implemented as references to template functions,
+such as:
+
+```c++
+  // Arithmetic operators
+  static constexpr auto& add   = oper<std::plus,    OpKind::Reg>;
+  static constexpr auto& addi  = oper<std::plus,    OpKind::Imm>;
+  static constexpr auto& sub   = oper<std::minus,   OpKind::Reg>;
+  static constexpr auto& f_xor = oper<std::bit_xor, OpKind::Reg>;
+  static constexpr auto& xori  = oper<std::bit_xor, OpKind::Imm>;
+  static constexpr auto& f_or  = oper<std::bit_or,  OpKind::Reg>;
+  static constexpr auto& ori   = oper<std::bit_or,  OpKind::Imm>;
+  static constexpr auto& f_and = oper<std::bit_and, OpKind::Reg>;
+  static constexpr auto& andi  = oper<std::bit_and, OpKind::Imm>;
+
+  // Boolean test and set operators
+  static constexpr auto& slt   = oper<std::less,    OpKind::Reg>;
+  static constexpr auto& slti  = oper<std::less,    OpKind::Imm>;
+  static constexpr auto& sltu  = oper<std::less,    OpKind::Reg, std::make_unsigned_t>;
+  static constexpr auto& sltiu = oper<std::less,    OpKind::Imm, std::make_unsigned_t>;
+
+  // Shift operators
+  static constexpr auto& slli = oper<ShiftLeft,     OpKind::Imm, std::make_unsigned_t>;
+  static constexpr auto& srli = oper<ShiftRight,    OpKind::Imm, std::make_unsigned_t>;
+  static constexpr auto& srai = oper<ShiftRight,    OpKind::Imm>;
+  static constexpr auto& sll  = oper<ShiftLeft,     OpKind::Reg, std::make_unsigned_t>;
+  static constexpr auto& srl  = oper<ShiftRight,    OpKind::Reg, std::make_unsigned_t>;
+  static constexpr auto& sra  = oper<ShiftRight,    OpKind::Reg>;
+```
+
+These define references to function template instantiations, which
+can then be used just like the names of ordinary functions.
+
+### Implementing the instruction
+
+```c++
+static bool zadd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
   if( F->IsRV32() ){
-    R->RV32[Inst.rd] = dt_u32(td_u32(R->RV32[Inst.rs1],32) + td_u32(R->RV32[Inst.rs2],32),32);
-    R->RV32_PC += Inst.instSize;
+    R->SetX(F, Inst.rd, R->GetX<uint32_t>(F, Inst.rs1) + R->GetX<uint32_t>(F, Inst.rs2));
   }else{
-    R->RV64[Inst.rd] = dt_u64(td_u64(R->RV64[Inst.rs1],64) + td_u64(R->RV64[Inst.rs2],64),64);
-    R->RV64_PC += Inst.instSize;
+    R->SetX(F, Inst.rd, R->GetX<uint64_t>(F, Inst.rs1) + R->GetX<uint64_t>(F, Inst.rs2));
   }
+  R->AdvancePC(F, Inst.instSize);
   return true;
 }
-
+```
+```c++
 static bool zsub(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
   if( F->IsRV32() ){
-    R->RV32[Inst.rd] = dt_u32(td_u32(R->RV32[Inst.rs1],32) - td_u32(R->RV32[Inst.rs2],32),32);
-    R->RV32_PC += Inst.instSize;
+    R->SetX(F, Inst.rd, R->GetX<uint32_t>(F, Inst.rs1) - R->GetX<uint32_t>(F, Inst.rs2));
   }else{
-    R->RV64[Inst.rd] = dt_u64(td_u64(R->RV64[Inst.rs1],64) - td_u64(R->RV64[Inst.rs2],64),64);
-    R->RV64_PC += Inst.instSize;
+    R->SetX(F, Inst.rd, R->GetX<uint64_t>(F, Inst.rs1) - R->GetX<uint64_t>(F, Inst.rs2));
   }
+  R->AdvancePC(F, Inst.instSize);
   return true;
 }
 
 static bool zlb(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
   if( F->IsRV32() ){
-    SEXT(R->RV32[Inst.rd],M->ReadU8( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),32);
-    R->RV32_PC += Inst.instSize;
+    M->ReadVal(F->GetHart(),
+               R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
+               reinterpret_cast<int8_t*>(&R->RV32[Inst.rd]),
+               Inst.hazard,
+               RevCPU::REvFlag::F_SEXT32);
+    R->SetX(F, Inst.rd, static_cast<int8_t>(R->RV32[Inst.rd]));
   }else{
-    SEXT(R->RV64[Inst.rd],M->ReadU8( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),64);
-    R->RV64_PC += Inst.instSize;
+    M->ReadVal(F->GetHart(),
+               R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
+               reinterpret_cast<int8_t*>(&R->RV64[Inst.rd]),
+               Inst.hazard,
+               RevCPU::REvFlag::F_SEXT32);
+    R->SetX(F, Inst.rd, static_cast<int8_t>(R->RV64[Inst.rd]));
   }
+  R->AdvancePC(F, Inst.instSize);
   // update the cost
   R->cost += M->RandCost(F->GetMinCost(),F->GetMaxCost());
   return true;
 }
 
 static bool zsb(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
-  if( F->IsRV32() ){
-    M->WriteU8((uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))), (uint8_t)(R->RV32[Inst.rs2]));
-    R->RV32_PC += Inst.instSize;
-  }else{
-    M->WriteU8((uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))), (uint8_t)(R->RV64[Inst.rs2]));
-    R->RV64_PC += Inst.instSize;
-  }
+  M->Write(F->GetHart(),
+           R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
+           R->GetX<uint8_t>(F, Inst.rs2));
+  R->AdvancePC(F, Inst.instSize);
   return true;
 }
 ```
+Or, with the helper functions:
+```c++
+  static constexpr auto& zadd = oper<std::plus,  OpKind::Reg>;
+  static constexpr auto& zadd = oper<std::minus, OpKind::Reg>;
+  static constexpr auto& zlb  = load<int8_t>;
+  static constexpr auto& zsb  = store<int8_t>;
+```
 
-As we can see from the source code above, each function must be formatted as: `static bool FUNC(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst)`.  All instructions carry the same arguments.  The first thing to note is the ability to use the `RevFeature` object to query the device architecture.  The Rev model stores register state in different logical storage for RV32 and RV64.  As a result, if your extension supports both variations of *XLEN*, then its often useful to query the loaded features to see which register file to manipulate.  The second and third arguments represent the register file object and the memory object, respectively.  These objects permit the user to access internal register state and read/write memory.  Finally, the `RevInst` structure contains all the decoded state from the instruction.  This includes all the opcode and function codes as well as each of the encoded register values.  This structure also contains the floating point rounding mode information.  For more information on the exacting contents and their respective data types, see the `RevInstTable.h` header file.  
+As we can see from the source code above, each function must be formatted as: `static bool FUNC(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst)`.  All instructions carry the same arguments.  The first thing to note is the ability to use the `RevFeature` object to query the device architecture.  The Rev model stores register state in different logical storage for RV32 and RV64.  As a result, if your extension supports both variations of *XLEN*, then its often useful to query the loaded features to see which register file to manipulate, but the `R->GetX<T>(F, reg)` and `R->SetX(F, reg, value) functions can automate this.
+
+The second and third arguments represent the register file object and the memory object, respectively.  These objects permit the user to access internal register state and read/write memory.  Finally, the `RevInst` structure contains all the decoded state from the instruction.  This includes all the opcode and function codes as well as each of the encoded register values.  This structure also contains the floating point rounding mode information.  For more information on the exacting contents and their respective data types, see the `RevInstTable.h` header file.  
 
 Now that we've decoded the necessary state and the simulation execution engine launches the function, we can start executing the target arithmetic.  For example, in the `zadd` function, we seek to add two unsigned integers of *XLEN* size.  Normally, this could be achieved using a simple `Rd = Rs1 + Rs2`.  However, recall from the RISC-V specification that arithmetic is performed in two's complement form.  As a result, we must utilize some utility functions to convert to/from two's complement form.  The `td_u32` and `td_u64` functions convert a value *from* two's complement *to* decimal form.  The `dt_u32` and `dt_u64` convert values from decimal form to two's complement.  As you can see in the `zadd` and `zsub` functions, we utilize the `Inst` payload to decode the register indices, the `RevRegFile` structure to retrieve the necesary register value and the `td_u32/64` functions to convert to decimal form.  We then perform the arithmetic, convert the value back to two's complement form and write it back to the register file.  The final step in the basic arithmetic functions is incrementing the PC.  The PC can be manually manipulated (eg, for branch operations), but this is normally done by incrementing the PC by the size of the instruction payload (in bytes).
 
 In the next functions, `zlb` and `zsb` we seek to load and store data to memory.  Just as we did above, we need to convert the input values to decimal form in order to perform the necessary address arithmetic.  We then utilize the `RevMem` object to write the desired number of bytes or read the desired number of bytes via the `ReadU8` and `WriteU8` routines.  The `RevMem` object provides a number of standard interfaces for writing common data types, arbitrary data and performing load reserve/store conditional operations.  Also note the use of the `SEXT` macro.  This performs sign extension on the incoming load value.  The infrastructure also provides a `ZEXT` macro for zero extension.  
 
 Finally, it is important to note the use of the `M->RandCost()` function.  Typically, RISC-V processor implementations do not hazard on memory store operations given the inherent weak memory ordering (or TSO).  However, for load operations, the processor is required to flag a hazard in order to ensure that the data returns before it is utilized in subsquent operations.  The `RandCost()` function provides the simulator the ability to add an arbitrary cost to load operations that is randomly generated in the range of `F->GetMinCost()` and `F->GetMaxCost()`.  These values are set at runtime by the user in the SST Python script.  In this manner, each load operation will generate a random *cost* and set its respective cost (in cycles).  
-
-A full listing of the completed implementation file is shown below.
-
-```c++
-//
-// _RV32Z_h_
-//
-// Copyright info
-//
-// See LICENSE in the top level directory for licensing details
-//
-
-#ifndef _SST_REVCPU_RV32Z_H_
-#define _SST_REVCPU_RV32Z_H_
-
-#include "RevInstTable.h"
-#include "RevExt.h"
-
-using namespace SST::RevCPU;
-
-namespace SST{
-  namespace RevCPU{
-    class RV32Z : public RevExt {
-
-    // RV32Z Implementation Functions
-    static bool zadd(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
-      if( F->IsRV32() ){
-        R->RV32[Inst.rd] = dt_u32(td_u32(R->RV32[Inst.rs1],32) + td_u32(R->RV32[Inst.rs2],32),32);
-        R->RV32_PC += Inst.instSize;
-      }else{
-        R->RV64[Inst.rd] = dt_u64(td_u64(R->RV64[Inst.rs1],64) + td_u64(R->RV64[Inst.rs2],64),64);
-        R->RV64_PC += Inst.instSize;
-      }
-      return true;
-    }
-
-    static bool zsub(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
-      if( F->IsRV32() ){
-        R->RV32[Inst.rd] = dt_u32(td_u32(R->RV32[Inst.rs1],32) - td_u32(R->RV32[Inst.rs2],32),32);
-        R->RV32_PC += Inst.instSize;
-      }else{
-        R->RV64[Inst.rd] = dt_u64(td_u64(R->RV64[Inst.rs1],64) - td_u64(R->RV64[Inst.rs2],64),64);
-        R->RV64_PC += Inst.instSize;
-      }
-      return true;
-    }
-
-    static bool zlb(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
-      if( F->IsRV32() ){
-        SEXT(R->RV32[Inst.rd],M->ReadU8( (uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),32);
-        R->RV32_PC += Inst.instSize;
-      }else{
-        SEXT(R->RV64[Inst.rd],M->ReadU8( (uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12)))),64);
-        R->RV64_PC += Inst.instSize;
-      }
-      // update the cost
-      R->cost += M->RandCost(F->GetMinCost(),F->GetMaxCost());
-      return true;
-    }
-
-    static bool zsb(RevFeature *F, RevRegFile *R,RevMem *M,RevInst Inst) {
-      if( F->IsRV32() ){
-        M->WriteU8((uint64_t)(R->RV32[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))), (uint8_t)(R->RV32[Inst.rs2]));
-        R->RV32_PC += Inst.instSize;
-      }else{
-        M->WriteU8((uint64_t)(R->RV64[Inst.rs1]+(int32_t)(td_u32(Inst.imm,12))), (uint8_t)(R->RV64[Inst.rs2]));
-        R->RV64_PC += Inst.instSize;
-      }
-      return true;
-    }
-
-    // RV32Z Instruction Table
-    std::vector<RevInstEntry> RV32ZTable = {
-    {"zadd %rd, %rs1, %rs2",   1, 0b0110011, 0b000,  0b0000000, RegGPR,     RegGPR,     RegGPR,     RegUNKNOWN, 0b0, FUnk, RVTypeR, &zadd },
-    {"zsub %rd, %rs1, %rs2",   1, 0b0110011, 0b000,  0b0100000, RegGPR,     RegGPR,     RegGPR,     RegUNKNOWN, 0b0, FUnk, RVTypeR, &zsub },
-    {"zlb %rd, $imm(%rs1)",    1, 0b0000011, 0b000,  0b0,       RegGPR,     RegGPR,     RegUNKNOWN, RegUNKNOWN, 0b0, FImm, RVTypeI, &zlb },
-    {"zsb %rs2, $imm(%rs1)",   1, 0b0100011, 0b000,  0b0,       RegIMM,     RegGPR,     RegGPR,     RegUNKNOWN, 0b0, FUnk, RVTypeS, &zsb }
-    };
-
-    public:
-      /// RV32Z: standard constructor
-      RV32Z( RevFeature *Feature,
-             RevRegFile *RegFile,
-             RevMem *RevMem,
-             SST::Output *Output )
-        : RevExt( "RV32Z", Feature, RegFile, RevMem, Output ) {
-          this->SetTable(RV32ZTable);
-        }
-
-      /// RV32Z: standard destructor
-      ~RV32Z() { }
-
-    }; // end class RV32I
-  } // namespace RevCPU
-} // namespace SST
-```
 
 ## Contributions
 We welcome outside contributions from corporate, acaddemic and individual developers.  However, 
@@ -383,13 +558,13 @@ rules are outlined as follows:
 * All code must adhere to the existing C++ coding style.  While we are somewhat flexible in basic style, you will 
 adhere to what is currently in place.  This includes camel case C++ methods and inline comments.  Uncommented, 
 complicated algorithmic constructs will be rejected.
-* We support compilaton and adherence to C++11 methods.  We do not currently accept C++14 and beyond.
+* We support compilaton and adherence to C++17 methods.
 * All new methods and variables contained within public, private and protected class methods must be commented 
 using the existing Doxygen-style formatting.  All new classes must also include Doxygen blocks in the new header 
 files.  Any pull requests that lack these features will be rejected.
 * All changes to functionality and/or the API infrastructure must be accompanied by complementary tests
 * All external pull requests **must** target the *devel* branch.  No external pull requests will be accepted 
-to the master branch.
+to the master or main branches.
 * All external pull requests must contain sufficient documentation in the pull request comments in order to 
 be accepted.
 * All pull requests will be reviewed by the core development staff.  Any necessary changes will be marked
@@ -399,3 +574,4 @@ Any failures in the test infrastructure will be noted in the pull request commen
 
 ## Authors
 * *John Leidel* - *Chief Scientist* - [Tactical Computing Labs](http://www.tactcomplabs.com)
+* *Lee Killough* - *Senior Principal Research Engineer* - [Tactical Computing Labs](http://www.tactcomplabs.com)

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -12,11 +12,13 @@
 #define _SST_REVCPU_REVINSTTABLE_H_
 
 #include <bitset>
-#include <string>
-#include <map>
-#include <cstdint>
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
+#include <map>
+#include <memory>
+#include <string>
 #include <type_traits>
 
 #include "RevMem.h"
@@ -295,7 +297,7 @@ struct RevInst {
   bool compressed     = 0; ///< RevInst: determines if the instruction is compressed
   uint32_t cost       = 0; ///< RevInst: the cost to execute this instruction, in clock cycles
   unsigned entry      = 0; ///< RevInst: Where to find this instruction in the InstTables
-  bool *hazard        = 0; ///< RevInst: signals a load hazard
+  std::shared_ptr<bool> hazard = nullptr; ///< RevInst: signals a load hazard
 
   explicit RevInst() = default; // prevent aggregate initialization
 
@@ -304,9 +306,6 @@ struct RevInst {
     return SignExt(imm, bits);
   }
 }; // RevInst
-
-static_assert(std::is_trivially_copyable_v<RevInst>,
-              "RevInst must be trivially copyable to be able to use memcpy() and memset()");
 
 #if 0
 

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -14,23 +14,22 @@
 #define __PAGE_SIZE__ 4096
 
 // -- C++ Headers
-#include <ctime>
-#include <vector>
 #include <algorithm>
+#include <cinttypes>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
-#include <random>
-#include <mutex>
-#include <cinttypes>
-#include <cstddef>
-#include <tuple>
-#include <map>
-#include <unordered_map>
-#include <list>
-#include <memory>
-#include <utility>
 #include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 // -- SST Headers
 #include "SST.h"
@@ -152,7 +151,7 @@ public:
 
   /// RevMem: read data from the target memory location
   bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void *Target,
-                bool *Hazard,
+                const std::shared_ptr<bool>& Hazard,
                 StandardMem::Request::flags_t flags);
 
   /// RevMem: DEPRECATED: read data from the target memory location
@@ -173,7 +172,7 @@ public:
   /// RevMem: template read memory interface
   template <typename T>
   bool ReadVal( unsigned Hart, uint64_t Addr, T *Target,
-                bool *Hazard,
+                const std::shared_ptr<bool>& Hazard,
                 StandardMem::Request::flags_t flags){
     return ReadMem(Hart, Addr, sizeof(T), Target, Hazard, flags);
   }
@@ -181,7 +180,8 @@ public:
   ///  RevMem: template LOAD RESERVE memory interface
   template <typename T>
   bool LR( unsigned Hart, uint64_t Addr, T *Target,
-           uint8_t aq, uint8_t rl, bool *Hazard,
+           uint8_t aq, uint8_t rl,
+           const std::shared_ptr<bool>& Hazard,
            StandardMem::Request::flags_t flags){
     return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, Hazard, flags);
   }
@@ -197,7 +197,7 @@ public:
   /// RevMem: template AMO memory interface
   template <typename T>
   bool AMOVal( unsigned Hart, uint64_t Addr, T *Data, T *Target,
-               bool *Hazard,
+               const std::shared_ptr<bool>& Hazard,
                StandardMem::Request::flags_t flags){
     return AMOMem(Hart, Addr, sizeof(T), Data, Target, Hazard, flags);
   }
@@ -227,7 +227,8 @@ public:
   // ----------------------------------------------------
   /// RevMem: Add a memory reservation for the target address
   bool LRBase(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, uint8_t aq, uint8_t rl, bool *Hazard,
+              void *Data, uint8_t aq, uint8_t rl,
+              const std::shared_ptr<bool>& Hazard,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Clear a memory reservation for the target address
@@ -237,7 +238,8 @@ public:
 
   /// RevMem: Initiated an AMO request
   bool AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, void *Target, bool *Hazard,
+              void *Data, void *Target,
+              const std::shared_ptr<bool>& Hazard,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Initiates a future operation [RV64P only]

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -12,18 +12,19 @@
 #define _SST_REVCPU_REVMEMCTRL_H_
 
 // -- C++ Headers
-#include <ctime>
-#include <vector>
-#include <list>
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
-#include <random>
-#include <map>
-#include <tuple>
+#include <ctime>
 #include <functional>
+#include <list>
+#include <map>
+#include <memory>
+#include <random>
+#include <tuple>
 #include <type_traits>
+#include <vector>
 
 // -- SST Headers
 #include "SST.h"
@@ -165,7 +166,7 @@ public:
   void setHart(unsigned H) { Hart = H ;}
 
   /// RevMemOp: set the hazard pointer
-  void setHazard(bool *H) { hazard = H;}
+  void setHazard(const std::shared_ptr<bool>& H) { hazard = H;}
 
   /// RevMemOp: retrieve the invalidate flag
   bool getInv() const { return Inv; }
@@ -180,7 +181,7 @@ public:
   unsigned getHart() const { return Hart; }
 
   /// RevMemOp: retrieve the hazard pointer
-  bool *getHazard() const { return hazard; }
+  std::shared_ptr<bool> getHazard() const { return hazard; }
 
   // RevMemOp: determine if the request is cache-able
   bool isCacheable() const { return (flags & 0b10) == 0; }
@@ -197,7 +198,7 @@ private:
   std::vector<uint8_t> membuf;          ///< RevMemOp: buffer
   StandardMem::Request::flags_t flags;  ///< RevMemOp: request flags
   void *target;                         ///< RevMemOp: target register pointer
-  bool *hazard;                         ///< RevMemOp: load hazard
+  std::shared_ptr<bool> hazard;         ///< RevMemOp: load hazard
 };
 
 // ----------------------------------------
@@ -235,7 +236,8 @@ public:
 
   /// RevMemCtrl: send a read request
   virtual bool sendREADRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                               uint32_t Size, void *target, bool *Hazard,
+                               uint32_t Size, void *target,
+                               const std::shared_ptr<bool>& Hazard,
                                StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a write request
@@ -246,12 +248,13 @@ public:
   /// RevMemCtrl: send an AMO request
   virtual bool sendAMORequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                               uint32_t Size, char *buffer, void *target,
-                              bool *Hazard,
+                              const std::shared_ptr<bool>& Hazard,
                               StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                                   uint32_t Size, void *target, bool *Hazard,
+                                   uint32_t Size, void *target,
+                                   const std::shared_ptr<bool>& Hazard,
                                    StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a writelock request
@@ -460,7 +463,8 @@ public:
 
   /// RevBasicMemCtrl: send a read request
   virtual bool sendREADRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                               uint32_t Size, void *target, bool *Hazard,
+                               uint32_t Size, void *target,
+                               const std::shared_ptr<bool>& Hazard,
                                StandardMem::Request::flags_t flags) override;
 
   /// RevBasicMemCtrl: send a write request
@@ -471,12 +475,13 @@ public:
   /// RevBasicMemCtrl: send an AMO request
   virtual bool sendAMORequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                               uint32_t Size, char *buffer, void *target,
-                              bool *Hazard,
+                              const std::shared_ptr<bool>& Hazard,
                               StandardMem::Request::flags_t flags) override;
 
   // RevBasicMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                                   uint32_t Size, void *target, bool *Hazard,
+                                   uint32_t Size, void *target,
+                                   const std::shared_ptr<bool>& Hazard,
                                    StandardMem::Request::flags_t flags) override;
 
   // RevBasicMemCtrl: send a writelock request

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -11,6 +11,8 @@
 #ifndef _SST_REVCPU_REVPREFETCHER_H_
 #define _SST_REVCPU_REVPREFETCHER_H_
 
+#include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "RevMem.h"
@@ -27,7 +29,7 @@ public:
     : mem(Mem), feature(Feature), depth(Depth){}
 
   /// RevPrefetcher: destructor
-  ~RevPrefetcher();
+  ~RevPrefetcher() = default;
 
   /// RevPrefetcher: fetch the next instruction
   bool InstFetch(uint64_t Addr, bool &Fetched, uint32_t &Inst);
@@ -40,14 +42,14 @@ private:
   RevFeature *feature;                        ///< RevFeature object
   unsigned depth;                             ///< Depth of each prefetcher stream
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
-  std::vector<uint32_t*> iStack;              ///< Vector of instruction vectors
-  std::vector<bool*> iHazard;                 ///< Vector of instruction cost vectors
+  std::vector<std::vector<uint32_t>> iStack; ///< Vector of instruction vectors
+  std::vector<std::vector<std::shared_ptr<bool>>> iHazard; ///< Vector of instruction cost vectors
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);
 
   /// deletes the target stream buffer
-  void DeleteStream(unsigned i);
+  void DeleteStream(size_t i);
 
   /// attempts to fetch the upper half of a 32bit word of an unaligned base address
   bool FetchUpper(uint64_t Addr, bool &Fetched, uint32_t &UInst);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -61,7 +61,7 @@ public:
            RevCoProc* CoProc, SST::Output *Output );
 
   /// RevProc: standard desctructor
-  ~RevProc();
+  ~RevProc() = default;
 
   /// RevProc: per-processor clock function
   bool ClockTick( SST::Cycle_t currentCycle );
@@ -196,10 +196,11 @@ private:
   RevCoProc* coProc;        ///< RevProc: attached co-processor
   RevLoader *loader;        ///< RevProc: loader object
   SST::Output *output;      ///< RevProc: output handler
-  RevFeature *feature;      ///< RevProc: feature handler
+  std::unique_ptr<RevFeature> featureUP; ///< RevProc: feature handler
+  RevFeature* feature;
   PanExec *PExec;           ///< RevProc: PAN exeuction context
   RevProcStats Stats{};     ///< RevProc: collection of performance stats
-  RevPrefetcher *sfetch;    ///< RevProc: stream instruction prefetcher
+  std::unique_ptr<RevPrefetcher> sfetch; ///< RevProc: stream instruction prefetcher
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecode RegFile
 
@@ -574,11 +575,11 @@ private:
 
   std::vector<RevInstEntry> InstTable;        ///< RevProc: target instruction table
 
-  std::vector<RevExt *> Extensions;           ///< RevProc: vector of enabled extensions
+  std::vector<std::unique_ptr<RevExt>> Extensions;           ///< RevProc: vector of enabled extensions
 
   //std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
   std::vector<std::pair<uint16_t, RevInst>> Pipeline;  ///< RevProc: pipeline of instructions
-  std::list<bool *> LoadHazards;                      ///< RevProc: list of allocated load hazards
+  std::list<std::shared_ptr<bool>> LoadHazards;        ///< RevProc: list of allocated load hazards
 
   std::map<std::string, unsigned> NameToEntry; ///< RevProc: instruction mnemonic to table entry mapping
   std::map<uint32_t, unsigned> EncToEntry;     ///< RevProc: instruction encoding to table entry mapping
@@ -589,10 +590,10 @@ private:
   ///           second = pair<Extension Index, Extension Entry>
 
   /// RevProc: creates a new pipeline load hazard and returns a pointer to it
-  bool *createLoadHazard();
+  std::shared_ptr<bool> createLoadHazard();
 
   /// RevProc: destroys the target load hazard object and removes it from the list
-  void destroyLoadHazard(bool *hazard);
+  void destroyLoadHazard(const std::shared_ptr<bool>& hazard);
 
   /// RevProc: splits a string into tokens
   void splitStr(const std::string& s, char c, std::vector<std::string>& v);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -579,8 +579,6 @@ private:
 
   //std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
   std::vector<std::pair<uint16_t, RevInst>> Pipeline;  ///< RevProc: pipeline of instructions
-  std::list<std::shared_ptr<bool>> LoadHazards;        ///< RevProc: list of allocated load hazards
-
   std::map<std::string, unsigned> NameToEntry; ///< RevProc: instruction mnemonic to table entry mapping
   std::map<uint32_t, unsigned> EncToEntry;     ///< RevProc: instruction encoding to table entry mapping
   std::map<uint32_t, unsigned> CEncToEntry;    ///< RevProc: compressed instruction encoding to table entry mapping
@@ -588,12 +586,6 @@ private:
   std::map<unsigned, std::pair<unsigned, unsigned>> EntryToExt;     ///< RevProc: instruction entry to extension object mapping
   ///           first = Master table entry number
   ///           second = pair<Extension Index, Extension Entry>
-
-  /// RevProc: creates a new pipeline load hazard and returns a pointer to it
-  std::shared_ptr<bool> createLoadHazard();
-
-  /// RevProc: destroys the target load hazard object and removes it from the list
-  void destroyLoadHazard(const std::shared_ptr<bool>& hazard);
 
   /// RevProc: splits a string into tokens
   void splitStr(const std::string& s, char c, std::vector<std::string>& v);

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -328,27 +328,24 @@ RevCPU::~RevCPU(){
   delete[] Enabled;
 
   // delete the processors objects
-  for( unsigned i=0; i<Procs.size(); i++ ){
+  for( size_t i = 0; i < Procs.size(); i++ ){
     delete Procs[i];
   }
 
-  for (unsigned i=0; i<CoProcs.size(); i++){
+  for (size_t i = 0; i < CoProcs.size(); i++){
     delete CoProcs[i];
   }
 
-  if( PExec )
-    delete PExec;
+  delete PExec;
 
   // delete the memory controller if present
-  if( Ctrl )
-    delete Ctrl;
+  delete Ctrl;
 
   // delete the memory object
   delete Mem;
 
   // delete the loader object
-  if( Loader )
-    delete Loader;
+  delete Loader;
 
   // delete the options object
   delete Opts;

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -148,9 +148,7 @@ bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
     ctrl->sendREADLOCKRequest(Hart, Addr, (uint64_t)(BaseMem),
                               Len, Target, Hazard, flags);
   }else{
-    for( unsigned i=0; i<Len; i++ ){
-      DataMem[i] = BaseMem[i];
-    }
+    memcpy(DataMem, BaseMem, Len);
     // clear the hazard
     *Hazard = false;
   }

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -110,7 +110,7 @@ bool RevMem::StatusFuture(uint64_t Addr){
 
 bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Target, uint8_t aq, uint8_t rl,
-                    bool *Hazard,
+                    const std::shared_ptr<bool>& Hazard,
                     StandardMem::Request::flags_t flags){
   for( auto it = LRSC.begin(); it != LRSC.end(); ++it ){
     if( (Hart == std::get<LRSC_HART>(*it)) &&
@@ -534,7 +534,7 @@ bool RevMem::FenceMem(unsigned Hart){
 
 bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Data, void *Target,
-                    bool *Hazard,
+                    const std::shared_ptr<bool>& Hazard,
                     StandardMem::Request::flags_t flags){
 #ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
@@ -780,7 +780,8 @@ bool RevMem::ReadMem( uint64_t Addr, size_t Len, void *Data ){
 }
 
 bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
-                     bool *Hazard, StandardMem::Request::flags_t flags){
+                     const std::shared_ptr<bool>& Hazard,
+                     StandardMem::Request::flags_t flags){
 #ifdef _REV_DEBUG_
   std::cout << "NEW READMEM: Reading " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -1429,9 +1429,10 @@ void RevBasicMemCtrl::handleWriteResp(StandardMem::WriteResp* ev){
       // split request exists, determine how to handle it
       if( getNumSplitRqsts(op) == 1 ){
         // this was the last request to service, delete the op
-        if( op->getHazard() != nullptr ){
+        auto Hazard = op->getHazard();
+        if( Hazard != nullptr ){
           // this was a write request for an AMO, clear the hazard
-          *(op->getHazard()) = false;
+          *Hazard = false;
         }
         delete op;
       }
@@ -1442,9 +1443,10 @@ void RevBasicMemCtrl::handleWriteResp(StandardMem::WriteResp* ev){
     }
 
     // no split request exists; handle as normal
-    if( op->getHazard() != nullptr ){
+    auto Hazard = op->getHazard();
+    if( Hazard != nullptr ){
       // this was a write request for an AMO, clear the hazard
-      *(op->getHazard()) = false;
+      *Hazard = false;
     }
     delete op;
     outstanding.erase(ev->getID());

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -225,7 +225,7 @@ bool RevBasicMemCtrl::sendREADRequest(unsigned Hart,
                                       uint64_t PAddr,
                                       uint32_t Size,
                                       void *target,
-                                      bool *Hazard,
+                                      const std::shared_ptr<bool>& Hazard,
                                       StandardMem::Request::flags_t flags){
   if( Size == 0 )
     return true;
@@ -259,7 +259,7 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
                                      uint32_t Size,
                                      char *buffer,
                                      void *target,
-                                     bool *Hazard,
+                                     const std::shared_ptr<bool>& Hazard,
                                      StandardMem::Request::flags_t flags){
 
   if( Size == 0 )
@@ -305,9 +305,9 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
     { RevCPU::RevFlag::F_AMOSWAP, RevBasicMemCtrl::MemCtrlStats::AMOSwapPending },
   };
 
-  for(auto& entry : table){
-    if(flags & uint32_t(entry.first)){
-      recordStat(entry.second, 1);
+  for(auto [flag, stat] : table){
+    if(flags & uint32_t(flag)){
+      recordStat(stat, 1);
       break;
     }
   }
@@ -319,7 +319,7 @@ bool RevBasicMemCtrl::sendREADLOCKRequest(unsigned Hart,
                                           uint64_t PAddr,
                                           uint32_t Size,
                                           void *target,
-                                          bool *Hazard,
+                                          const std::shared_ptr<bool>& Hazard,
                                           StandardMem::Request::flags_t flags){
   if( Size == 0 )
     return true;
@@ -1261,7 +1261,7 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
     for( unsigned i=0; i < op->getSize(); i++ ){
       std::cout << "               : data[" << i << "] = " << (unsigned)(ev->data[i]) << std::endl;
     }
-    std::cout << "hazard ptr = 0x" << std::hex << op->getHazard() << std::dec << std::endl;
+    std::cout << "hazard ptr = 0x" << std::hex << op->getHazard().get() << std::dec << std::endl;
     std::cout << "hazard value before processing = " << *op->getHazard() << std::endl;
     std::cout << "Address of the target register = 0x" << std::hex
               << (uint64_t *)(op->getTarget()) << std::dec << std::endl;
@@ -1296,8 +1296,10 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
         if( isAMO ){
           handleAMO(op);
         }
-        bool *Hazard = op->getHazard();
-        *Hazard = false;
+        auto Hazard = op->getHazard();
+        if( Hazard != nullptr ){
+          *Hazard = false;
+        }
         delete op;
       }
       outstanding.erase(ev->getID());
@@ -1317,7 +1319,7 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
     if( isAMO ){
       handleAMO(op);
     }
-    bool *Hazard = op->getHazard();
+    auto Hazard = op->getHazard();
     if( Hazard != nullptr ){
       *Hazard = false;
     }
@@ -1369,7 +1371,7 @@ void RevBasicMemCtrl::performAMO(std::tuple<unsigned, char *, void *, StandardMe
                               RevMemOp::MemOp::MemOpWRITE,
                               Tmp->getFlags());
 
-  bool *Hazard = Tmp->getHazard();
+  auto Hazard = Tmp->getHazard();
   Op->setHazard(Hazard);
   *Hazard = true;
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1708,18 +1708,6 @@ uint16_t RevProc::GetHartID()const{
   return nextID;
 }
 
-std::shared_ptr<bool> RevProc::createLoadHazard(){
-  auto LH = std::make_shared<bool>(false);
-  LoadHazards.push_back(LH);
-  return LH;
-}
-
-void RevProc::destroyLoadHazard(const std::shared_ptr<bool>& LH){
-  if( LH != nullptr ){
-    LoadHazards.remove(LH);
-  }
-}
-
 bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
   RevInst Inst;
 
@@ -1837,7 +1825,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       // -- BEGIN new pipelining implementation
       if( !PendingCtxSwitch ){
         Pipeline.push_back(std::make_pair(HartToExec, Inst));
-        Pipeline.back().second.hazard = createLoadHazard();
+        Pipeline.back().second.hazard = std::make_shared<bool>(false);
       }
 
       if( (Ext->GetName() == "RV32F") ||
@@ -2000,7 +1988,6 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
                       id, tID, ExecPC);
       Retired++;
       DependencyClear(tID, &(Pipeline.front().second));
-      destroyLoadHazard(Pipeline.front().second.hazard);
       Pipeline.erase(Pipeline.begin());
       GetRegFile(tID)->cost = 0;
     }else{


### PR DESCRIPTION
This turns the hazard pointers into `std::shared_ptr<bool>`, and uses reference counting to determine when to delete the underlying allocation.

This uses `std::unique_ptr` to hold objects which are allocated on the heap for the lifetime of the class, preventing the need to `delete` them in the destructor. The destruction of the `std::unique_ptr` object will automatically `delete` them.

There is no need to explicitly delete these smart pointers, since removing them as elements from a `std::vector`, `std::list` or other container, will automatically call their destructor, and in the case of `std::shared_ptr`, delete the memory when the reference count goes to zero.