### PR TITLE
Improved hazarding logic + Hart terminology cleanup

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -1,0 +1,85 @@
+//
+// _Rev_Common_h_
+//
+// Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef __REV_COMMON__
+#define __REV_COMMON__
+
+#include <functional>
+
+
+#ifndef _REV_INVALID_HART_ID_
+#define _REV_INVALID_HART_ID_ (uint16_t)~(uint16_t(0))
+#endif
+
+#define _INVALID_ADDR_ 0xFFFFFFFFFFFFFFFF
+
+namespace SST{
+  namespace RevCPU{
+
+    enum RevRegClass : int { ///< Rev CPU Register Classes
+      RegUNKNOWN    = 0,     ///< RevRegClass: Unknown register file
+      RegIMM        = 1,     ///< RevRegClass: Treat the reg class like an immediate: S-Format
+      RegGPR        = 2,     ///< RevRegClass: GPR reg file
+      RegCSR        = 3,     ///< RevRegClass: CSR reg file
+      RegFLOAT      = 4,     ///< RevRegClass: Float register file
+    };
+
+    enum MemOp{
+      MemOpREAD           = 0,
+      MemOpWRITE          = 1,
+      MemOpFLUSH          = 2,
+      MemOpREADLOCK       = 3,
+      MemOpWRITEUNLOCK    = 4,
+      MemOpLOADLINK       = 5,
+      MemOpSTORECOND      = 6,
+      MemOpCUSTOM         = 7,
+      MemOpFENCE          = 8,
+      MemOpAMO            = 9
+    };
+
+    auto make_lsq_hash = [] (uint8_t destReg, RevRegClass regType, uint16_t HartID){ return uint64_t((regType << (16 + 8)) | (destReg << 16) | HartID);};
+
+
+    class MemReq {
+      public:
+      MemReq(uint64_t addr, uint16_t dest, RevRegClass regclass, 
+             uint16_t hart, MemOp req, bool outstanding, std::function<void(MemReq)> func) :
+        Addr(addr), DestReg(dest), RegType(regclass), Hart(hart), ReqType(req), isOutstanding(outstanding), MarkLoadComplete(func)
+      {};
+      MemReq():
+        Addr(_INVALID_ADDR_), DestReg(0), RegType(RegUNKNOWN), Hart(_REV_INVALID_HART_ID_), 
+        ReqType(MemOpCUSTOM), isOutstanding(false)
+      {LSQueue.reset();};
+
+      void Set(uint64_t addr, uint16_t dest, RevRegClass regclass, uint16_t hart, MemOp req, bool outstanding,
+      std::shared_ptr<std::unordered_map<uint64_t, MemReq>> q)
+      {
+        Addr = addr; DestReg = dest; RegType = regclass; Hart = hart; 
+        ReqType = req; isOutstanding = outstanding;
+        LSQueue = q;
+      }; 
+      uint64_t    Addr;
+      uint16_t    DestReg;
+      RevRegClass RegType;
+      uint16_t    Hart;
+      MemOp       ReqType;
+      bool        isOutstanding;
+      std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
+      std::function<void(MemReq)> MarkLoadComplete;
+    //  std::function<void((MemOp req)>) SetComplete;
+      // add lambda that clears the dependency bit directly so we don't need to search the hash
+    };
+
+    //auto mark_mem_op_complete = [] (MemReq req)
+
+  }//namespace RevCPU
+}//namespace SST
+
+#endif

--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -55,15 +55,15 @@ namespace SST{
       {};
       MemReq():
         Addr(_INVALID_ADDR_), DestReg(0), RegType(RegUNKNOWN), Hart(_REV_INVALID_HART_ID_), 
-        ReqType(MemOpCUSTOM), isOutstanding(false)
-      {LSQueue.reset();};
+        ReqType(MemOpCUSTOM), isOutstanding(false), MarkLoadComplete(nullptr)
+      {};
 
       void Set(uint64_t addr, uint16_t dest, RevRegClass regclass, uint16_t hart, MemOp req, bool outstanding,
-      std::shared_ptr<std::unordered_map<uint64_t, MemReq>> q)
+      std::function<void(MemReq)> func)
       {
         Addr = addr; DestReg = dest; RegType = regclass; Hart = hart; 
         ReqType = req; isOutstanding = outstanding;
-        LSQueue = q;
+        MarkLoadComplete = func;
       }; 
       uint64_t    Addr;
       uint16_t    DestReg;
@@ -71,7 +71,7 @@ namespace SST{
       uint16_t    Hart;
       MemOp       ReqType;
       bool        isOutstanding;
-      std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
+      //std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
       std::function<void(MemReq)> MarkLoadComplete;
     //  std::function<void((MemOp req)>) SetComplete;
       // add lambda that clears the dependency bit directly so we don't need to search the hash

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -95,15 +95,22 @@ public:
   /// HasCompressed: Returns whether RV32 or RV64 "C" is enabled
   bool HasCompressed() const { return IsModeEnabled(RV_C); }
 
-  /// GetHart: Retrieve the hart of the target object
-  auto GetHart() const { return Hart; }
+  /// GetProcID: Retrieve the ProcID of the target object
+  auto GetProcID() const { return ProcID; }
+
+  /// GetHartToExec: Retrieve the current executing Hart
+  auto GetHartToExec() const { return HartToExec; }
+
+  /// SetHartToExec: Set the current executing Hart
+  void SetHartToExec(unsigned hart) { HartToExec = hart; }
 
 private:
   std::string machine;      ///< RevFeature: feature string
   SST::Output *output;      ///< RevFeature: output handler
   unsigned MinCost;         ///< RevFeature: min memory cost
   unsigned MaxCost;         ///< RevFeature: max memory cost
-  unsigned Hart;            ///< RevFeature: RISC-V CPU ID, aka "hart"
+  unsigned ProcID;          ///< RevFeature: RISC-V Proc ID
+  unsigned HartToExec;      ///< RevFeature: The current executing Hart on RevProc
   RevFeatureType features;  ///< RevFeature: feature elements
   unsigned xlen;            ///< RevFeature: RISC-V Xlen
 

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -505,7 +505,7 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(int32_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT32 :
                    RevCPU::RevFlag::F_ZEXT32) : REVMEM_FLAGS(0);
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
     R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
@@ -518,7 +518,7 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(int64_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT64 :
                    RevCPU::RevFlag::F_ZEXT64) : REVMEM_FLAGS(0);
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
     R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
@@ -552,7 +552,7 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(double) ?
       REVMEM_FLAGS(RevCPU::RevFlag::F_BOXNAN) : REVMEM_FLAGS(0);
 
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
     R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
@@ -566,7 +566,7 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
       BoxNaN(&R->DPF[Inst.rd], &R->DPF[Inst.rd]);
     }
   }else{
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
     R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -504,9 +504,9 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(int32_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT32 :
                    RevCPU::RevFlag::F_ZEXT32) : REVMEM_FLAGS(0);
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
-    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
-    M->ReadVal(F->GetHart(),
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHartToExec(), MemOpREAD, true, R->MarkLoadComplete);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHartToExec()), req});
+    M->ReadVal(F->GetHartToExec(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV32[Inst.rd]),
                req,
@@ -516,9 +516,9 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(int64_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT64 :
                    RevCPU::RevFlag::F_ZEXT64) : REVMEM_FLAGS(0);
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
-    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
-    M->ReadVal(F->GetHart(),
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHartToExec(), MemOpREAD, true, R->MarkLoadComplete);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHartToExec()), req});
+    M->ReadVal(F->GetHartToExec(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV64[Inst.rd]),
                req,
@@ -534,7 +534,7 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
 /// Store template
 template<typename T>
 bool store(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-  M->Write(F->GetHart(),
+  M->Write(F->GetHartToExec(),
            R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
            R->GetX<T>(F, Inst.rs2));
   R->AdvancePC(F, Inst.instSize);
@@ -549,9 +549,9 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     static constexpr auto flags = sizeof(T) < sizeof(double) ?
       REVMEM_FLAGS(RevCPU::RevFlag::F_BOXNAN) : REVMEM_FLAGS(0);
 
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
-    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
-    M->ReadVal(F->GetHart(),
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHartToExec(), MemOpREAD, true, R->MarkLoadComplete);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHartToExec()), req});
+    M->ReadVal(F->GetHartToExec(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<T*>(&R->DPF[Inst.rd]),
                req,
@@ -562,9 +562,9 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
       BoxNaN(&R->DPF[Inst.rd], &R->DPF[Inst.rd]);
     }
   }else{
-    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->MarkLoadComplete);
-    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
-    M->ReadVal(F->GetHart(),
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHartToExec(), MemOpREAD, true, R->MarkLoadComplete);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHartToExec()), req});
+    M->ReadVal(F->GetHartToExec(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                &R->SPF[Inst.rd],
                req,
@@ -585,7 +585,7 @@ bool fstore(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
   }else{
     val = R->GetFP32(F, Inst.rs2);
   }
-  M->Write(F->GetHart(), R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), val);
+  M->Write(F->GetHartToExec(), R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), val);
   R->AdvancePC(F, Inst.instSize);
   return true;
 }

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -21,6 +21,7 @@
 
 #include "RevMem.h"
 #include "RevFeature.h"
+#include "../common/include/RevCommon.h"
 
 #ifndef _REV_NUM_REGS_
 #define _REV_NUM_REGS_ 32
@@ -38,9 +39,7 @@
 #define _REV_HART_COUNT_ 1
 #endif
 
-#ifndef _REV_INVALID_HART_ID_
-#define _REV_INVALID_HART_ID_ (uint16_t)~(uint16_t(0))
-#endif
+
 
 // Register Decoding Macros
 #define DECODE_RD(x)    (((x)>>(7))&(0b11111))
@@ -138,6 +137,9 @@ struct RevRegFile {
   bool SPF_Scoreboard[_REV_NUM_REGS_];  ///< RevRegFile: Scoreboard for SPF RF to manage pipeline hazard
   bool DPF_Scoreboard[_REV_NUM_REGS_];  ///< RevRegFile: Scoreboard for DPF RF to manage pipeline hazard
 
+  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
+  std::function<void(MemReq)> MarkLoadComplete;
+
   uint32_t RV32_PC;                 ///< RevRegFile: RV32 PC
   uint64_t RV64_PC;                 ///< RevRegFile: RV64 PC
   uint64_t FCSR;                    ///< RevRegFile: FCSR
@@ -147,6 +149,8 @@ struct RevRegFile {
   unsigned Entry;                   ///< RevRegFile: Instruction entry
 
   explicit RevRegFile() = default;  // prevent aggregate initialization
+
+
 
   /// GetX: Get the specifed X register cast to a specific integral type
   template<typename T>
@@ -224,8 +228,8 @@ struct RevRegFile {
   }
 }; // RevRegFile
 
-static_assert(std::is_trivially_copyable_v<RevRegFile>,
-              "RevRegFile must be trivially copyable to be able to use memcpy() and memset()");
+/*static_assert(std::is_trivially_copyable_v<RevRegFile>,
+              "RevRegFile must be trivially copyable to be able to use memcpy() and memset()");*/
 
 inline std::bitset<_REV_HART_COUNT_> HART_CTS; ///< RevProc: Thread is clear to start (proceed with decode)
 inline std::bitset<_REV_HART_COUNT_> HART_CTE; ///< RevProc: Thread is clear to execute (no register dependencides)
@@ -251,13 +255,7 @@ enum RevInstF : int {    ///< Rev CPU Instruction Formats
   RVCTypeCJ     = 18,    ///< RevInstF: Compressed CJ-Type
 };
 
-enum RevRegClass : int { ///< Rev CPU Register Classes
-  RegUNKNOWN    = 0,     ///< RevRegClass: Unknown register file
-  RegIMM        = 1,     ///< RevRegClass: Treat the reg class like an immediate: S-Format
-  RegGPR        = 2,     ///< RevRegClass: GPR reg file
-  RegCSR        = 3,     ///< RevRegClass: CSR reg file
-  RegFLOAT      = 4,     ///< RevRegClass: Float register file
-};
+
 
 enum RevImmFunc : int {  ///< Rev Immediate Values
   FUnk          = 0,     ///< RevRegClass: Imm12 is not used
@@ -502,30 +500,36 @@ unsigned fclass(T val, bool quietNaN = true) {
 /// Load template
 template<typename T>
 bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+   MemReq req = MemReq();
   if( sizeof(T) < sizeof(int64_t) && F->IsRV32() ){
     static constexpr auto flags = sizeof(T) < sizeof(int32_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT32 :
                    RevCPU::RevFlag::F_ZEXT32) : REVMEM_FLAGS(0);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV32[Inst.rd]),
                Inst.hazard,
+               req,
                flags);
     R->SetX(F, Inst.rd, static_cast<T>(R->RV32[Inst.rd]));
   }else{
     static constexpr auto flags = sizeof(T) < sizeof(int64_t) ?
       REVMEM_FLAGS(std::is_signed_v<T> ? RevCPU::RevFlag::F_SEXT64 :
                    RevCPU::RevFlag::F_ZEXT64) : REVMEM_FLAGS(0);
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV64[Inst.rd]),
                Inst.hazard,
+               req,
                flags);
     R->SetX(F, Inst.rd, static_cast<T>(R->RV64[Inst.rd]));
   }
   // update the cost
   R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
-
   R->AdvancePC(F, Inst.instSize);
   return true;
 }
@@ -543,14 +547,18 @@ bool store(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
 /// Floating-point load template
 template<typename T>
 bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+   MemReq req = MemReq();
   if(std::is_same_v<T, double> || F->HasD()){
     static constexpr auto flags = sizeof(T) < sizeof(double) ?
       REVMEM_FLAGS(RevCPU::RevFlag::F_BOXNAN) : REVMEM_FLAGS(0);
 
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<T*>(&R->DPF[Inst.rd]),
                Inst.hazard,
+               req,
                flags);
 
     // Box float value into 64-bit FP register
@@ -558,15 +566,17 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
       BoxNaN(&R->DPF[Inst.rd], &R->DPF[Inst.rd]);
     }
   }else{
+    req.Set(R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12), Inst.rd, RevRegClass::RegFLOAT, F->GetHart(), MemOpREAD, true, R->LSQueue);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegFLOAT, F->GetHart()), req});
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                &R->SPF[Inst.rd],
                Inst.hazard,
+               req,
                REVMEM_FLAGS(0));
   }
   // update the cost
   R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
-
   R->AdvancePC(F, Inst.instSize);
   return true;
 }

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -293,7 +293,6 @@ struct RevInst {
   bool compressed     = 0; ///< RevInst: determines if the instruction is compressed
   uint32_t cost       = 0; ///< RevInst: the cost to execute this instruction, in clock cycles
   unsigned entry      = 0; ///< RevInst: Where to find this instruction in the InstTables
-  bool *hazard        = 0; ///< RevInst: signals a load hazard
 
   explicit RevInst() = default; // prevent aggregate initialization
 
@@ -510,7 +509,6 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV32[Inst.rd]),
-               Inst.hazard,
                req,
                flags);
     R->SetX(F, Inst.rd, static_cast<T>(R->RV32[Inst.rd]));
@@ -523,7 +521,6 @@ bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<std::make_unsigned_t<T>*>(&R->RV64[Inst.rd]),
-               Inst.hazard,
                req,
                flags);
     R->SetX(F, Inst.rd, static_cast<T>(R->RV64[Inst.rd]));
@@ -557,7 +554,6 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                reinterpret_cast<T*>(&R->DPF[Inst.rd]),
-               Inst.hazard,
                req,
                flags);
 
@@ -571,7 +567,6 @@ bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->ReadVal(F->GetHart(),
                R->GetX<uint64_t>(F, Inst.rs1) + Inst.ImmSignExt(12),
                &R->SPF[Inst.rd],
-               Inst.hazard,
                req,
                REVMEM_FLAGS(0));
   }

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -39,14 +39,13 @@
 #include "RevOpts.h"
 #include "RevMemCtrl.h"
 #include "RevRand.h"
+#include "../common/include/RevCommon.h"
 
 #ifndef _REVMEM_BASE_
 #define _REVMEM_BASE_ 0x00000000
 #endif
 
 #define REVMEM_FLAGS(x) (static_cast<StandardMem::Request::flags_t>(x))
-
-#define _INVALID_ADDR_ 0xFFFFFFFFFFFFFFFF
 
 #define _STACK_SIZE_ (size_t{1024*1024})
 
@@ -153,6 +152,7 @@ public:
   /// RevMem: read data from the target memory location
   bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void *Target,
                 bool *Hazard,
+                MemReq req,
                 StandardMem::Request::flags_t flags);
 
   /// RevMem: DEPRECATED: read data from the target memory location
@@ -174,8 +174,9 @@ public:
   template <typename T>
   bool ReadVal( unsigned Hart, uint64_t Addr, T *Target,
                 bool *Hazard,
+                MemReq req,
                 StandardMem::Request::flags_t flags){
-    return ReadMem(Hart, Addr, sizeof(T), Target, Hazard, flags);
+    return ReadMem(Hart, Addr, sizeof(T), Target, Hazard, req, flags);
   }
 
   ///  RevMem: template LOAD RESERVE memory interface
@@ -198,8 +199,9 @@ public:
   template <typename T>
   bool AMOVal( unsigned Hart, uint64_t Addr, T *Data, T *Target,
                bool *Hazard,
+               MemReq req,
                StandardMem::Request::flags_t flags){
-    return AMOMem(Hart, Addr, sizeof(T), Data, Target, Hazard, flags);
+    return AMOMem(Hart, Addr, sizeof(T), Data, Target, Hazard, req, flags);
   }
 
   // ----------------------------------------------------
@@ -237,7 +239,7 @@ public:
 
   /// RevMem: Initiated an AMO request
   bool AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, void *Target, bool *Hazard,
+              void *Data, void *Target, bool *Hazard, MemReq req,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Initiates a future operation [RV64P only]

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -151,7 +151,6 @@ public:
 
   /// RevMem: read data from the target memory location
   bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void *Target,
-                bool *Hazard,
                 MemReq req,
                 StandardMem::Request::flags_t flags);
 
@@ -173,18 +172,17 @@ public:
   /// RevMem: template read memory interface
   template <typename T>
   bool ReadVal( unsigned Hart, uint64_t Addr, T *Target,
-                bool *Hazard,
                 MemReq req,
                 StandardMem::Request::flags_t flags){
-    return ReadMem(Hart, Addr, sizeof(T), Target, Hazard, req, flags);
+    return ReadMem(Hart, Addr, sizeof(T), Target, req, flags);
   }
 
   ///  RevMem: template LOAD RESERVE memory interface
   template <typename T>
   bool LR( unsigned Hart, uint64_t Addr, T *Target,
-           uint8_t aq, uint8_t rl, bool *Hazard, MemReq req,
+           uint8_t aq, uint8_t rl, MemReq req,
            StandardMem::Request::flags_t flags){
-    return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, Hazard, req, flags);
+    return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, req, flags);
   }
 
   ///  RevMem: template STORE CONDITIONAL memory interface
@@ -198,10 +196,9 @@ public:
   /// RevMem: template AMO memory interface
   template <typename T>
   bool AMOVal( unsigned Hart, uint64_t Addr, T *Data, T *Target,
-               bool *Hazard,
                MemReq req,
                StandardMem::Request::flags_t flags){
-    return AMOMem(Hart, Addr, sizeof(T), Data, Target, Hazard, req, flags);
+    return AMOMem(Hart, Addr, sizeof(T), Data, Target, req, flags);
   }
 
   // ----------------------------------------------------
@@ -229,7 +226,7 @@ public:
   // ----------------------------------------------------
   /// RevMem: Add a memory reservation for the target address
   bool LRBase(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, uint8_t aq, uint8_t rl, bool *Hazard, MemReq req,
+              void *Data, uint8_t aq, uint8_t rl, MemReq req,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Clear a memory reservation for the target address
@@ -239,7 +236,7 @@ public:
 
   /// RevMem: Initiated an AMO request
   bool AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, void *Target, bool *Hazard, MemReq req,
+              void *Data, void *Target, MemReq req,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Initiates a future operation [RV64P only]

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -182,9 +182,9 @@ public:
   ///  RevMem: template LOAD RESERVE memory interface
   template <typename T>
   bool LR( unsigned Hart, uint64_t Addr, T *Target,
-           uint8_t aq, uint8_t rl, bool *Hazard,
+           uint8_t aq, uint8_t rl, bool *Hazard, MemReq req,
            StandardMem::Request::flags_t flags){
-    return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, Hazard, flags);
+    return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, Hazard, req, flags);
   }
 
   ///  RevMem: template STORE CONDITIONAL memory interface
@@ -229,7 +229,7 @@ public:
   // ----------------------------------------------------
   /// RevMem: Add a memory reservation for the target address
   bool LRBase(unsigned Hart, uint64_t Addr, size_t Len,
-              void *Data, uint8_t aq, uint8_t rl, bool *Hazard,
+              void *Data, uint8_t aq, uint8_t rl, bool *Hazard, MemReq req,
               StandardMem::Request::flags_t flags);
 
   /// RevMem: Clear a memory reservation for the target address

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -30,6 +30,7 @@
 
 // -- RevCPU Headers
 #include "RevOpts.h"
+#include "../common/include/RevCommon.h"
 
 namespace SST::RevCPU{
 
@@ -167,6 +168,9 @@ public:
   /// RevMemOp: set the hazard pointer
   void setHazard(bool *H) { hazard = H;}
 
+  ///RevMemOp: set the originating memory request
+  void setMemReq(MemReq req) { procReq = req;}
+
   /// RevMemOp: retrieve the invalidate flag
   bool getInv() const { return Inv; }
 
@@ -181,6 +185,9 @@ public:
 
   /// RevMemOp: retrieve the hazard pointer
   bool *getHazard() const { return hazard; }
+
+  /// RevMemOp: Get the originating proc memory request
+  MemReq getMemReq() const { return procReq; }
 
   // RevMemOp: determine if the request is cache-able
   bool isCacheable() const { return (flags & 0b10) == 0; }
@@ -198,6 +205,7 @@ private:
   StandardMem::Request::flags_t flags;  ///< RevMemOp: request flags
   void *target;                         ///< RevMemOp: target register pointer
   bool *hazard;                         ///< RevMemOp: load hazard
+  MemReq procReq;                       ///< RevMemOp: original request from RevProc
 };
 
 // ----------------------------------------
@@ -235,7 +243,7 @@ public:
 
   /// RevMemCtrl: send a read request
   virtual bool sendREADRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                               uint32_t Size, void *target, bool *Hazard,
+                               uint32_t Size, void *target, MemReq req,
                                StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a write request
@@ -246,12 +254,12 @@ public:
   /// RevMemCtrl: send an AMO request
   virtual bool sendAMORequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                               uint32_t Size, char *buffer, void *target,
-                              bool *Hazard,
+                              MemReq req,
                               StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                                   uint32_t Size, void *target, bool *Hazard,
+                                   uint32_t Size, void *target, MemReq req,
                                    StandardMem::Request::flags_t flags) = 0;
 
   /// RevMemCtrl: send a writelock request
@@ -460,7 +468,7 @@ public:
 
   /// RevBasicMemCtrl: send a read request
   virtual bool sendREADRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                               uint32_t Size, void *target, bool *Hazard,
+                               uint32_t Size, void *target, MemReq req,
                                StandardMem::Request::flags_t flags) override;
 
   /// RevBasicMemCtrl: send a write request
@@ -471,12 +479,12 @@ public:
   /// RevBasicMemCtrl: send an AMO request
   virtual bool sendAMORequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                               uint32_t Size, char *buffer, void *target,
-                              bool *Hazard,
+                              MemReq req,
                               StandardMem::Request::flags_t flags) override;
 
   // RevBasicMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(unsigned Hart, uint64_t Addr, uint64_t PAddr,
-                                   uint32_t Size, void *target, bool *Hazard,
+                                   uint32_t Size, void *target, MemReq req,
                                    StandardMem::Request::flags_t flags) override;
 
   // RevBasicMemCtrl: send a writelock request

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -165,9 +165,6 @@ public:
   /// RevMemOp: set the hart
   void setHart(unsigned H) { Hart = H ;}
 
-  /// RevMemOp: set the hazard pointer
-  void setHazard(bool *H) { hazard = H;}
-
   ///RevMemOp: set the originating memory request
   void setMemReq(MemReq req) { procReq = req;}
 
@@ -182,9 +179,6 @@ public:
 
   /// RevMemOp: retrieve the hart
   unsigned getHart() const { return Hart; }
-
-  /// RevMemOp: retrieve the hazard pointer
-  bool *getHazard() const { return hazard; }
 
   /// RevMemOp: Get the originating proc memory request
   MemReq getMemReq() const { return procReq; }
@@ -204,7 +198,6 @@ private:
   std::vector<uint8_t> membuf;          ///< RevMemOp: buffer
   StandardMem::Request::flags_t flags;  ///< RevMemOp: request flags
   void *target;                         ///< RevMemOp: target register pointer
-  bool *hazard;                         ///< RevMemOp: load hazard
   MemReq procReq;                       ///< RevMemOp: original request from RevProc
 };
 

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -25,8 +25,10 @@ namespace SST::RevCPU{
 class RevPrefetcher{
 public:
   /// RevPrefetcher: constructor
-  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth, std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq)
-    : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq){}
+  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth, 
+                std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq,
+                std::function<void(MemReq)> func)
+    : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func){}
 
   /// RevPrefetcher: destructor
   ~RevPrefetcher();
@@ -45,7 +47,7 @@ private:
   std::vector<uint32_t*> iStack;              ///< Vector of instruction vectors
   std::vector<bool*> iHazard;                 ///< Vector of instruction cost vectors
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
-
+  std::function<void(MemReq)> MarkLoadAsComplete;
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -45,7 +45,6 @@ private:
   unsigned depth;                             ///< Depth of each prefetcher stream
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<uint32_t*> iStack;              ///< Vector of instruction vectors
-  std::vector<bool*> iHazard;                 ///< Vector of instruction cost vectors
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
   std::function<void(MemReq)> MarkLoadAsComplete;
 

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -12,6 +12,8 @@
 #define _SST_REVCPU_REVPREFETCHER_H_
 
 #include <vector>
+#include <memory>
+#include <unordered_map>
 
 #include "RevMem.h"
 #include "RevFeature.h"
@@ -23,8 +25,8 @@ namespace SST::RevCPU{
 class RevPrefetcher{
 public:
   /// RevPrefetcher: constructor
-  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth)
-    : mem(Mem), feature(Feature), depth(Depth){}
+  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth, std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq)
+    : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq){}
 
   /// RevPrefetcher: destructor
   ~RevPrefetcher();
@@ -42,6 +44,8 @@ private:
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<uint32_t*> iStack;              ///< Vector of instruction vectors
   std::vector<bool*> iHazard;                 ///< Vector of instruction cost vectors
+  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
+
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -583,7 +583,6 @@ private:
 
   //std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevProc: pipeline of instructions
   std::vector<std::pair<uint16_t, RevInst>> Pipeline;  ///< RevProc: pipeline of instructions
-  std::list<bool *> LoadHazards;                      ///< RevProc: list of allocated load hazards
 
   std::map<std::string, unsigned> NameToEntry; ///< RevProc: instruction mnemonic to table entry mapping
   std::map<uint32_t, unsigned> EncToEntry;     ///< RevProc: instruction encoding to table entry mapping
@@ -592,12 +591,6 @@ private:
   std::map<unsigned, std::pair<unsigned, unsigned>> EntryToExt;     ///< RevProc: instruction entry to extension object mapping
   ///           first = Master table entry number
   ///           second = pair<Extension Index, Extension Entry>
-
-  /// RevProc: creates a new pipeline load hazard and returns a pointer to it
-  bool *createLoadHazard();
-
-  /// RevProc: destroys the target load hazard object and removes it from the list
-  void destroyLoadHazard(bool *hazard);
 
   /// RevProc: splits a string into tokens
   void splitStr(const std::string& s, char c, std::vector<std::string>& v);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -713,6 +713,8 @@ private:
   /// RevProc: Check scoreboard for pipeline hazards
   bool DependencyCheck(uint16_t HartID, const RevInst* Inst) const;
 
+  bool DependencyCheck(uint16_t HartID, uint16_t RegNum, RevRegClass RegType) const;
+
   /// RevProc: Set or clear scoreboard based on instruction destination
   void DependencySet(uint16_t HartID, const RevInst* Inst, bool value = true){
     DependencySet(HartID, Inst->rd, InstTable[Inst->entry].rdClass == RegFLOAT, value);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -706,8 +706,6 @@ private:
   /// RevProc: Check scoreboard for pipeline hazards
   bool DependencyCheck(uint16_t HartID, const RevInst* Inst) const;
 
-  bool DependencyCheck(uint16_t HartID, uint16_t RegNum, RevRegClass RegType) const;
-
   /// RevProc: Set or clear scoreboard based on instruction destination
   void DependencySet(uint16_t HartID, const RevInst* Inst, bool value = true){
     DependencySet(HartID, Inst->rd, InstTable[Inst->entry].rdClass == RegFLOAT, value);

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -49,6 +49,7 @@
 #include "RevThreadCtx.h"
 #include "../common/syscalls/SysFlags.h"
 #include "RevRand.h"
+#include "../common/include/RevCommon.h"
 
 #define _PAN_FWARE_JUMP_            0x0000000000010000
 
@@ -175,6 +176,8 @@ public:
   ///< RevProc: PIDs & corresponding RevThreadCtx objects (Software Threads)
   std::unordered_map<uint32_t, std::shared_ptr<RevThreadCtx>> ThreadTable;
 
+  void MarkLoadComplete(MemReq req);
+
 private:
   bool Halted;              ///< RevProc: determines if the core is halted
   bool Stalled;             ///< RevProc: determines if the core is stalled on instruction fetch
@@ -200,6 +203,8 @@ private:
   PanExec *PExec;           ///< RevProc: PAN exeuction context
   RevProcStats Stats{};     ///< RevProc: collection of performance stats
   RevPrefetcher *sfetch;    ///< RevProc: stream instruction prefetcher
+
+  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecode RegFile
 

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -67,20 +67,27 @@ class RV32A : public RevExt {
       flags |= uint32_t(RevCPU::RevFlag::F_RL);
     }
 
+    MemReq req;
     if( F->IsRV32() ){
+      req.Set(R->RV32[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
       M->AMOVal(F->GetHart(),
                 R->RV32[Inst.rs1],
                 &R->RV32[Inst.rs2],
                 &R->RV32[Inst.rd],
                 Inst.hazard,
+                req,
                 flags);
     }else{
       flags |= uint32_t(RevCPU::RevFlag::F_SEXT64);
+      req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
       M->AMOVal(F->GetHart(),
                 R->RV64[Inst.rs1],
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rs2]),
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rd]),
                 Inst.hazard,
+                req,
                 flags);
     }
     // update the cost

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -69,7 +69,7 @@ class RV32A : public RevExt {
 
     MemReq req;
     if( F->IsRV32() ){
-      req.Set(R->RV32[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+      req.Set(R->RV32[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
       R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
       M->AMOVal(F->GetHart(),
                 R->RV32[Inst.rs1],
@@ -80,7 +80,7 @@ class RV32A : public RevExt {
                 flags);
     }else{
       flags |= uint32_t(RevCPU::RevFlag::F_SEXT64);
-      req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+      req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
       R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
       M->AMOVal(F->GetHart(),
                 R->RV64[Inst.rs1],

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -27,14 +27,14 @@ class RV32A : public RevExt {
       R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
       M->LR(F->GetHart(), uint64_t(R->RV32[Inst.rs1]),
             &R->RV32[Inst.rd],
-            Inst.aq, Inst.rl, Inst.hazard, req,
+            Inst.aq, Inst.rl, req,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
     }else{
       req.Set(R->RV64[Inst.rs1], Inst.rd, RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
       R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
       M->LR(F->GetHart(), R->RV64[Inst.rs1],
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rd]),
-            Inst.aq, Inst.rl, Inst.hazard, req,
+            Inst.aq, Inst.rl, req,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
     }
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
@@ -80,7 +80,6 @@ class RV32A : public RevExt {
                 R->RV32[Inst.rs1],
                 &R->RV32[Inst.rs2],
                 &R->RV32[Inst.rd],
-                Inst.hazard,
                 req,
                 flags);
     }else{
@@ -91,7 +90,6 @@ class RV32A : public RevExt {
                 R->RV64[Inst.rs1],
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rs2]),
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rd]),
-                Inst.hazard,
                 req,
                 flags);
     }

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -23,16 +23,16 @@ class RV32A : public RevExt {
   static bool lrw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     MemReq req;
     if( F->IsRV32() ){
-      req.Set(uint64_t(R->RV32[Inst.rs1]), Inst.rd, RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
+      req.Set(uint64_t(R->RV32[Inst.rs1]), Inst.rd, RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete);
       R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
-      M->LR(F->GetHart(), uint64_t(R->RV32[Inst.rs1]),
+      M->LR(F->GetHartToExec(), uint64_t(R->RV32[Inst.rs1]),
             &R->RV32[Inst.rd],
             Inst.aq, Inst.rl, req,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
     }else{
-      req.Set(R->RV64[Inst.rs1], Inst.rd, RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
+      req.Set(R->RV64[Inst.rs1], Inst.rd, RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete);
       R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
-      M->LR(F->GetHart(), R->RV64[Inst.rs1],
+      M->LR(F->GetHartToExec(), R->RV64[Inst.rs1],
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rd]),
             Inst.aq, Inst.rl, req,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
@@ -44,13 +44,13 @@ class RV32A : public RevExt {
 
   static bool scw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     if( F->IsRV32() ){
-      M->SC(F->GetHart(), R->RV32[Inst.rs1],
+      M->SC(F->GetHartToExec(), R->RV32[Inst.rs1],
             &R->RV32[Inst.rs2],
             &R->RV32[Inst.rd],
             Inst.aq, Inst.rl,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
     }else{
-      M->SC(F->GetHart(), R->RV64[Inst.rs1],
+      M->SC(F->GetHartToExec(), R->RV64[Inst.rs1],
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rs2]),
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rd]),
             Inst.aq, Inst.rl,
@@ -74,9 +74,9 @@ class RV32A : public RevExt {
 
     MemReq req;
     if( F->IsRV32() ){
-      req.Set(R->RV32[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
-      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
-      M->AMOVal(F->GetHart(),
+      req.Set(R->RV32[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete);
+      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHartToExec()), req});
+      M->AMOVal(F->GetHartToExec(),
                 R->RV32[Inst.rs1],
                 &R->RV32[Inst.rs2],
                 &R->RV32[Inst.rd],
@@ -84,9 +84,9 @@ class RV32A : public RevExt {
                 flags);
     }else{
       flags |= uint32_t(RevCPU::RevFlag::F_SEXT64);
-      req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
-      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHart()), req});
-      M->AMOVal(F->GetHart(),
+      req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete);
+      R->LSQueue->insert({make_lsq_hash(Inst.rd, RevRegClass::RegGPR, F->GetHartToExec()), req});
+      M->AMOVal(F->GetHartToExec(),
                 R->RV64[Inst.rs1],
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rs2]),
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rd]),

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -353,13 +353,13 @@ class RV32I : public RevExt {
   static constexpr auto& sra  = oper<ShiftRight,    OpKind::Reg>;
 
   static bool fence(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    M->FenceMem(F->GetHart());
+    M->FenceMem(F->GetHartToExec());
     R->AdvancePC(F, Inst.instSize);
     return true;  // temporarily disabled
   }
 
   static bool fencei(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    M->FenceMem(F->GetHart());
+    M->FenceMem(F->GetHartToExec());
     R->AdvancePC(F, Inst.instSize);
     return true;  // temporarily disabled
   }

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -54,11 +54,14 @@ class RV64A : public RevExt {
       flags |= uint32_t(RevCPU::RevFlag::F_RL);
     }
 
+    MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RegGPR, F->GetHart()), req});
     M->AMOVal(F->GetHart(),
               R->RV64[Inst.rs1],
               &R->RV64[Inst.rs2],
               &R->RV64[Inst.rd],
               Inst.hazard,
+              req,
               flags);
 
     R->AdvancePC(F, Inst.instSize);

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -21,9 +21,9 @@ namespace SST::RevCPU{
 class RV64A : public RevExt {
 
   static bool lrd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    MemReq req(R->RV64[Inst.rs1],Inst.rd, RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete );
+    MemReq req(R->RV64[Inst.rs1],Inst.rd, RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete );
     R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart),req});
-    M->LR(F->GetHart(),
+    M->LR(F->GetHartToExec(),
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rd],
           Inst.aq, Inst.rl, req,
@@ -33,7 +33,7 @@ class RV64A : public RevExt {
   }
 
   static bool scd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    M->SC(F->GetHart(),
+    M->SC(F->GetHartToExec(),
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rs2],
           &R->RV64[Inst.rd],
@@ -56,9 +56,9 @@ class RV64A : public RevExt {
       flags |= uint32_t(RevCPU::RevFlag::F_RL);
     }
 
-    MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
-    R->LSQueue->insert({make_lsq_hash(Inst.rd, RegGPR, F->GetHart()), req});
-    M->AMOVal(F->GetHart(),
+    MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExec(), MemOpAMO, true, R->MarkLoadComplete);
+    R->LSQueue->insert({make_lsq_hash(Inst.rd, RegGPR, F->GetHartToExec()), req});
+    M->AMOVal(F->GetHartToExec(),
               R->RV64[Inst.rs1],
               &R->RV64[Inst.rs2],
               &R->RV64[Inst.rd],

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -26,7 +26,7 @@ class RV64A : public RevExt {
     M->LR(F->GetHart(),
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rd],
-          Inst.aq, Inst.rl, Inst.hazard, req,
+          Inst.aq, Inst.rl, req,
           REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
     R->AdvancePC(F, Inst.instSize);
     return true;
@@ -62,7 +62,6 @@ class RV64A : public RevExt {
               R->RV64[Inst.rs1],
               &R->RV64[Inst.rs2],
               &R->RV64[Inst.rd],
-              Inst.hazard,
               req,
               flags);
 

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -54,7 +54,7 @@ class RV64A : public RevExt {
       flags |= uint32_t(RevCPU::RevFlag::F_RL);
     }
 
-    MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->LSQueue);
+    MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete);
     R->LSQueue->insert({make_lsq_hash(Inst.rd, RegGPR, F->GetHart()), req});
     M->AMOVal(F->GetHart(),
               R->RV64[Inst.rs1],

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -21,10 +21,12 @@ namespace SST::RevCPU{
 class RV64A : public RevExt {
 
   static bool lrd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+    MemReq req(R->RV64[Inst.rs1],Inst.rd, RegGPR, F->GetHart(), MemOpAMO, true, R->MarkLoadComplete );
+    R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart),req});
     M->LR(F->GetHart(),
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rd],
-          Inst.aq, Inst.rl, Inst.hazard,
+          Inst.aq, Inst.rl, Inst.hazard, req,
           REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
     R->AdvancePC(F, Inst.instSize);
     return true;

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -21,10 +21,10 @@ RevFeature::RevFeature( std::string Machine,
                         unsigned Max,
                         unsigned Id )
   : machine(std::move(Machine)), output(Output), MinCost(Min), MaxCost(Max),
-    Hart(Id), features(RV_UNKNOWN), xlen(0) {
+    ProcID(Id), features(RV_UNKNOWN), xlen(0), HartToExec(0){
   output->verbose(CALL_INFO, 6, 0,
                   "Core %u ; Initializing feature set from machine string=%s\n",
-                  Hart,
+                  ProcID,
                   machine.c_str());
   if( !ParseMachineModel() )
     output->fatal(CALL_INFO, -1,
@@ -44,8 +44,8 @@ bool RevFeature::ParseMachineModel(){
     return false;
   mac += 4;
 
-  output->verbose(CALL_INFO, 6, 0, "Core %u ; Setting XLEN to %u\n", Hart, xlen);
-  output->verbose(CALL_INFO, 6, 0, "Core %u ; Architecture string=%s\n", Hart, mac);
+  output->verbose(CALL_INFO, 6, 0, "Core %u ; Setting XLEN to %u\n", ProcID, xlen);
+  output->verbose(CALL_INFO, 6, 0, "Core %u ; Architecture string=%s\n", ProcID, mac);
 
   static constexpr std::pair<std::string_view, uint32_t> table[] = {
     { "E",          RV_E                                                      },

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -810,8 +810,10 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
         DataMem[Cur] = BaseMem[i];
         Cur++;
       }
-      // clear the hazard
-      req.MarkLoadComplete(req);
+      // clear the hazard - if this was an AMO operation then we will clear outside of this function in AMOMem()
+      if(MemOpAMO != req.ReqType){
+        req.MarkLoadComplete(req);
+      }
     }
 #ifdef _REV_DEBUG_
     std::cout << "Warning: Reading off end of page... " << std::endl;
@@ -823,8 +825,10 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
       for( unsigned i=0; i<Len; i++ ){
         DataMem[i] = BaseMem[i];
       }
-      // clear the hazard
-      req.MarkLoadComplete(req);
+      // clear the hazard- if this was an AMO operation then we will clear outside of this function in AMOMem()
+      if(MemOpAMO != req.ReqType){
+        req.MarkLoadComplete(req);
+      }
     }
   }
 

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -820,11 +820,7 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
       }
       // clear the hazard
       *Hazard = false;
-      auto it = req.LSQueue->find(make_lsq_hash(req.DestReg, req.RegType, req.Hart));
-      if(it == req.LSQueue->end()){
-        output->fatal(CALL_INFO, 11, "Failed to locate load in LSQueue\n");
-      }
-      it->second.isOutstanding = false;
+      req.MarkLoadComplete(req);
     }
 #ifdef _REV_DEBUG_
     std::cout << "Warning: Reading off end of page... " << std::endl;
@@ -838,11 +834,7 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
       }
       // clear the hazard
       *Hazard = false;
-      auto it = req.LSQueue->find(make_lsq_hash(req.DestReg, req.RegType, req.Hart));
-      if(it == req.LSQueue->end()){
-        output->fatal(CALL_INFO, 11, "Failed to locate load in LSQueue\n");
-      }
-      it->second.isOutstanding = false;
+      req.MarkLoadComplete(req);
     }
   }
 

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -1312,8 +1312,12 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
     if( isAMO ){
       handleAMO(op);
     }
+    
     MemReq r = op->getMemReq();
-    r.MarkLoadComplete(r);
+    //if this is an AMO op then we cleared the load in the handleAMO() function, so do not clear again
+    if(MemOpAMO != r.ReqType){
+      r.MarkLoadComplete(r);
+    }
     delete op;
     outstanding.erase(ev->getID());
     delete ev;

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -177,7 +177,7 @@ void RevPrefetcher::Fill(uint64_t Addr){
 
   // now fill it
   for( unsigned y=0; y<depth; y++ ){
-    MemReq req (Addr+(y*4), 0, RevRegClass::RegGPR, feature->GetHart(), MemOpREAD, true, LSQueue );
+    MemReq req (Addr+(y*4), 0, RevRegClass::RegGPR, feature->GetHart(), MemOpREAD, true, MarkLoadAsComplete);
     LSQueue->insert({make_lsq_hash(0, RevRegClass::RegGPR, feature->GetHart()), req});
     mem->ReadVal( feature->GetHart(), Addr+(y*4),
                   &iStack[x][y],

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -177,11 +177,13 @@ void RevPrefetcher::Fill(uint64_t Addr){
 
   // now fill it
   for( unsigned y=0; y<depth; y++ ){
+    MemReq req (Addr+(y*4), 0, RevRegClass::RegGPR, feature->GetHart(), MemOpREAD, true, LSQueue );
+    LSQueue->insert({make_lsq_hash(0, RevRegClass::RegGPR, feature->GetHart()), req});
     mem->ReadVal( feature->GetHart(), Addr+(y*4),
                   &iStack[x][y],
                   &iHazard[x][y],
+                  req,
                   REVMEM_FLAGS(0x00) );
-
   }
 }
 

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -173,9 +173,9 @@ void RevPrefetcher::Fill(uint64_t Addr){
 
   // now fill it
   for( unsigned y=0; y<depth; y++ ){
-    MemReq req (Addr+(y*4), 0, RevRegClass::RegGPR, feature->GetHart(), MemOpREAD, true, MarkLoadAsComplete);
-    LSQueue->insert({make_lsq_hash(0, RevRegClass::RegGPR, feature->GetHart()), req});
-    mem->ReadVal( feature->GetHart(), Addr+(y*4),
+    MemReq req (Addr+(y*4), 0, RevRegClass::RegGPR, feature->GetHartToExec(), MemOpREAD, true, MarkLoadAsComplete);
+    LSQueue->insert({make_lsq_hash(0, RevRegClass::RegGPR, feature->GetHartToExec()), req});
+    mem->ReadVal( feature->GetHartToExec(), Addr+(y*4),
                   &iStack[x][y],
                   req,
                   REVMEM_FLAGS(0x00) );

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -15,8 +15,6 @@ RevPrefetcher::~RevPrefetcher(){
   // delete all the existing streams
   for(auto* s : iStack)
       delete[] s;
-  for(auto* h : iHazard)
-      delete[] h;
 }
 
 bool RevPrefetcher::IsAvail(uint64_t Addr){
@@ -166,13 +164,11 @@ void RevPrefetcher::Fill(uint64_t Addr){
   // allocate a new stream buffer
   baseAddr.push_back(Addr);
   iStack.push_back( new uint32_t[depth] );
-  iHazard.push_back( new bool[depth] );
 
   // initialize it
   unsigned x = baseAddr.size()-1;
   for( unsigned y = 0; y<depth; y++ ){
     iStack[x][y] = REVPREF_INIT_ADDR;
-    iHazard[x][y] = true;
   }
 
   // now fill it
@@ -181,7 +177,6 @@ void RevPrefetcher::Fill(uint64_t Addr){
     LSQueue->insert({make_lsq_hash(0, RevRegClass::RegGPR, feature->GetHart()), req});
     mem->ReadVal( feature->GetHart(), Addr+(y*4),
                   &iStack[x][y],
-                  &iHazard[x][y],
                   req,
                   REVMEM_FLAGS(0x00) );
   }
@@ -195,9 +190,7 @@ void RevPrefetcher::DeleteStream(unsigned i){
 
   // delete it
   delete [] iStack[i];
-  delete [] iHazard[i];
   iStack.erase(iStack.begin() + i);
-  iHazard.erase(iHazard.begin() + i);
   baseAddr.erase(baseAddr.begin() + i);
 }
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1753,7 +1753,7 @@ void RevProc::MarkLoadComplete(MemReq req){
     LSQueue->erase(it);
   }else if(0 != req.DestReg){ //instruction pre-fetch fills target r0, we can ignore these
     output->fatal(CALL_INFO, -1,
-               "Core %u ; Hart %u; Cannot find outstanding load for reg %u from address %" PRIu64 "\n",
+               "Core %u ; Hart %u; Cannot find outstanding load for reg %u from address %" PRIx64 "\n",
                 id, req.Hart, req.DestReg, req.Addr);
   }
 }
@@ -1816,6 +1816,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
 
     //Determine the active thread
     HartToDecode = GetHartID();
+    feature->SetHartToExec(HartToDecode);
 
     if( !PrefetchInst() ){
       Stalled = true;
@@ -2733,7 +2734,7 @@ RevProc::ECALL_status_t RevProc::ECALL_getcwd(RevInst& inst){
   auto BufAddr = RegFile->GetX<uint64_t>(feature, 10);
   auto size = RegFile->GetX<uint64_t>(feature, 11);
   auto CWD = std::filesystem::current_path();
-  mem->WriteMem(feature->GetHart(), BufAddr, size, CWD.c_str());
+  mem->WriteMem(feature->GetHartToExec(), BufAddr, size, CWD.c_str());
 
   // Returns null-terminated string in buf
   // (no need to set x10 since it's already got BufAddr)
@@ -3120,7 +3121,7 @@ RevProc::ECALL_status_t RevProc::ECALL_read(RevInst& inst){
   int rc = read(fd, &TmpBuf[0], BufSize);
 
   // Write that data to the buffer inside of Rev
-  mem->WriteMem(feature->GetHart(), BufAddr, BufSize, &TmpBuf[0]);
+  mem->WriteMem(feature->GetHartToExec(), BufAddr, BufSize, &TmpBuf[0]);
 
   RegFile->SetX(feature, 10, rc);
   return ECALL_status_t::SUCCESS;

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1658,35 +1658,7 @@ void RevProc::HandleALUFault(unsigned width){
                   "FAULT:ALU: ALU fault injected into next retire cycle\n");
 }
 
-bool RevProc::DependencyCheck(uint16_t HartID, uint16_t RegNum, RevRegClass RegType) const{
-
-  const auto* regFile = GetRegFile(HartID);
-
-  if((0 != RegNum) && (regFile->LSQueue->count(make_lsq_hash(RegNum, RegType, HartID))) > 0){ return true;}
-    if(RegNum < _REV_NUM_REGS_){
-    switch(RegType){
-      case RegFLOAT:
-        if(feature->HasD()){
-          if(regFile->DPF_Scoreboard[RegNum]) return true;
-        }else{
-          if(regFile->SPF_Scoreboard[RegNum]) return true;
-        }
-        break;
-
-      case RegGPR:
-        if(feature->IsRV32()){
-          if(regFile->RV32_Scoreboard[RegNum]) return true;
-        }else {
-          if(regFile->RV64_Scoreboard[RegNum]) return true;
-        }
-        break;
-
-      default:
-        break;
-      }
-    }
-}
-    bool RevProc::DependencyCheck(uint16_t HartID, const RevInst* I) const {
+bool RevProc::DependencyCheck(uint16_t HartID, const RevInst* I) const {
 
   const auto* E = &InstTable[I->entry];
   const auto* regFile = GetRegFile(HartID);


### PR DESCRIPTION
Adding a Load / Store queue to Rev (although, truthfully we only track loads, but that is another matter) to replace the bool* Hazard logic.  There now is a single LSQueue per RevProc implemented as an unordered_map. A shared_ptr to LSQueue is provided to each RegFile. 

Pipeline stalls are now handled through the existing DependencyCheck() method - the LS Queue is checked if any instruction source registers are currently the target of an in-flight read. Pipeline execution will continue until a dependent register is found.

Replacing the bool* that was once passed with every call to ReadVal() there is now a new POD class, MemReq. This tracks the destination register, address to be read, as well as the Hart the request originated from. 

To use this new bookkeeping: *Prior* to calling ReadVal(), create a MemReq and add to the LSQueue. The hash is computed through a lambda make_lsq_hash().  Note that an unordered map will overwrite an existing hash table entry if you give it two identical keys.  Currently we do not check on insert if a value was overwritten, but can add that if we want more defensive coding. It is a matter of checking the return value.

Clearing the outstanding load is accomplished by the RevProc::MarkLoadAsComplete() function. All MemReq objects have a pointer to this member function, so as the memory system completes the writeback to the RegFile it calls this function directly to mark the Load as complete and clear the Dependency Scoreboard.  If you attempt to clear a load that is not in the LS Queue an error is thrown.

Finally, the RevFeature::GetHart was not being used consistently.  There is now a GetProcID and a GetHartToExec - these were previously collapsed. 