### PR TITLE
Post-build script which detects undefined symbols in Rev shared libraries

### DIFF
--- a/scripts/test_undefined_symbols.sh
+++ b/scripts/test_undefined_symbols.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if ! [ -f "$1" ]; then
+   cat>&2 <<EOF
+usage: $0 librevcpu.so
+
+Tests for unresolved Rev symbols in shared library
+EOF
+   exit 1
+fi
+
+if ldd -r "$1" 2>&1 | c++filt | grep "\bundefined\b.*\bSST::RevCPU::" >&2; then
+    exit 1
+else
+    exit 0
+fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,10 +25,9 @@ set(RevCPUSrcs
   )
 
 add_library(revcpu SHARED ${RevCPUSrcs})
-target_include_directories(revcpu PRIVATE ${REVCPU_INCLUDE_PATH})
-target_include_directories(revcpu PUBLIC ${SST_INSTALL_DIR}/include)
+target_include_directories(revcpu PRIVATE ${REVCPU_INCLUDE_PATH} PUBLIC ${SST_INSTALL_DIR}/include)
 
 install(TARGETS revcpu DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
-install (CODE "execute_process(COMMAND sst-register revcpu revcpu_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
-
+install(CODE "execute_process(COMMAND sst-register revcpu revcpu_LIBDIR=${CMAKE_CURRENT_SOURCE_DIR})")
+install(CODE "execute_process(COMMAND_ERROR_IS_FATAL ANY COMMAND_ECHO STDERR COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/test_undefined_symbols.sh ${CMAKE_CURRENT_SOURCE_DIR}/librevcpu.so)")
 # EOF


### PR DESCRIPTION
This script detects unresolved symbols in `librevcpu.so` whose name contains `SST::RevCPU::`.

Undefined symbols without the substring `SST::RevCPU::` are not diagnosed.

When this script is run on on an earier build of `threads` this error is detected, which normally is hidden by SST, causing strange runtime failures which are hard to diagnose. Here is the build error output if it is caught, pointing to the `SST::RevCPU::RevProc::InitThreadTable` symbol which was referenced but not defined in `librevcpu.so`.
```
[100%] Linking CXX shared library librevcpu.so
[100%] Built target revcpu
Install the project...
-- Install configuration: "Debug"
-- Installing: /home/lkillough/rev/src/librevcpu.so '/home/lkillough/rev/src/../scripts/test_undefined_symbols.sh' '/home/lkillough/rev/src/librevcpu.so'
undefined symbol: SST::RevCPU::RevProc::InitThreadTable()       (/home/lkillough/rev/src/librevcpu.so)
CMake Error at src/cmake_install.cmake:77 (execute_process):
  execute_process failed command indexes:

    1: "Child return code: 1"

Call Stack (most recent call first):
  cmake_install.cmake:47 (include)
```
