### PR TITLE
Colorize undefined symbols printed on output

### DIFF
--- a/scripts/test_undefined_symbols.sh
+++ b/scripts/test_undefined_symbols.sh
@@ -1,16 +1,31 @@
 #!/bin/sh
 
+exec >&2
+
 if ! [ -f "$1" ]; then
-   cat>&2 <<EOF
-usage: $0 librevcpu.so
+  cat<<EOF
+Usage: $0 <sharedlib>
 
 Tests for unresolved Rev symbols in shared library
 EOF
-   exit 1
+  exit 1
 fi
 
-if ldd -r "$1" 2>&1 | c++filt | grep "\bundefined\b.*\bSST::RevCPU::" >&2; then
-    exit 1
+if [ -z ${NO_COLOR+x} ] && tty -s; then
+  RED="\033[41;97m\n"
+  END="\033[0m"
 else
-    exit 0
+  RED=
+  END=
 fi
+
+printf "${RED}"
+if ldd -r "$1" 2>&1 | c++filt | grep "\bundefined\b.*\bSST::RevCPU::"; then
+  echo ""
+  rc=1
+else
+  rc=0
+fi
+printf "${END}"
+
+exit $rc

--- a/scripts/test_undefined_symbols.sh
+++ b/scripts/test_undefined_symbols.sh
@@ -12,20 +12,21 @@ EOF
 fi
 
 if [ -z ${NO_COLOR+x} ] && tty -s; then
-  RED="\033[41;97m\n"
+  RED="\033[91m"
   END="\033[0m"
 else
   RED=
   END=
 fi
 
-printf "${RED}"
+printf "\n${RED}"
 if ldd -r "$1" 2>&1 | c++filt | grep "\bundefined\b.*\bSST::RevCPU::"; then
-  echo ""
   rc=1
 else
   rc=0
 fi
 printf "${END}"
+
+[ "$rc" -ne 0 ] && echo ""
 
 exit $rc


### PR DESCRIPTION
This colorizes the output on terminals so that any unresolved symbols are printed in bright red background.

