### PR TITLE
Convert std::bind to lambda expressions which capture this

### DIFF
--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -140,7 +140,7 @@ struct RevRegFile {
   bool DPF_Scoreboard[_REV_NUM_REGS_]{};  ///< RevRegFile: Scoreboard for DPF RF to manage pipeline hazard
 
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue{};
-  std::function<void(MemReq)> MarkLoadComplete{};
+  std::function<void(const MemReq&)> MarkLoadComplete{};
 
   uint32_t RV32_PC{};                 ///< RevRegFile: RV32 PC
   uint64_t RV64_PC{};                 ///< RevRegFile: RV64 PC

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -27,9 +27,9 @@ namespace SST::RevCPU{
 class RevPrefetcher{
 public:
   /// RevPrefetcher: constructor
-  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth, 
+  RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth,
                 std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq,
-                std::function<void(MemReq)> func)
+                std::function<void(const MemReq&)> func)
     : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func){}
 
   /// RevPrefetcher: destructor
@@ -48,7 +48,7 @@ private:
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<std::vector<uint32_t>> iStack; ///< Vector of instruction vectors
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
-  std::function<void(MemReq)> MarkLoadAsComplete;
+  std::function<void(const MemReq&)> MarkLoadAsComplete;
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2366,7 +2366,7 @@ RevProc::ECALL_status_t RevProc::ECALL_LoadAndParseString(RevInst& inst,
     rtval = ECALL_status_t::SUCCESS;
   }else{
     //We are in the middle of the string - read one byte
-    MemReq req{straddr + ECALL.string.size(), 10, RevRegClass::RegGPR, HartToExec, MemOp::MemOpREAD, true, [=](const MemReq& r){this->MarkLoadComplete(r);}};
+    MemReq req{straddr + ECALL.string.size(), 10, RevRegClass::RegGPR, HartToExec, MemOp::MemOpREAD, true, [=](const MemReq& req){this->MarkLoadComplete(req);}};
     LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
     mem->ReadVal(HartToExec,
                  straddr + ECALL.string.size(),

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -56,8 +56,7 @@ RevProc::RevProc( unsigned Id,
     Depth = 16;
   }
 
-  std::function<void(MemReq)> f = std::bind(&RevProc::MarkLoadComplete, this, std::placeholders::_1);
-  sfetch = std::make_unique<RevPrefetcher>(Mem, feature, Depth, LSQueue, f);
+  sfetch = std::make_unique<RevPrefetcher>(Mem, feature, Depth, LSQueue, [=](const MemReq& req){ this->MarkLoadComplete(req); });
   if( !sfetch )
     output->fatal(CALL_INFO, -1,
                   "Error: failed to create the RevPrefetcher object for core=%u\n", id);
@@ -409,8 +408,7 @@ bool RevProc::Reset(){
 
     regFile->cost = 0;
 
-    regFile->MarkLoadComplete = std::bind(&RevProc::MarkLoadComplete, this, std::placeholders::_1);
-
+    regFile->MarkLoadComplete = [=](const MemReq& req){ this->MarkLoadComplete(req); };
   }
 
    Pipeline.clear();
@@ -2368,7 +2366,7 @@ RevProc::ECALL_status_t RevProc::ECALL_LoadAndParseString(RevInst& inst,
     rtval = ECALL_status_t::SUCCESS;
   }else{
     //We are in the middle of the string - read one byte
-    MemReq req (straddr + ECALL.string.size(), 10, RevRegClass::RegGPR, HartToExec, MemOp::MemOpREAD, true,  std::bind(&RevProc::MarkLoadComplete, this, std::placeholders::_1));
+    MemReq req{straddr + ECALL.string.size(), 10, RevRegClass::RegGPR, HartToExec, MemOp::MemOpREAD, true, [=](const MemReq& r){this->MarkLoadComplete(r);}};
     LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
     mem->ReadVal(HartToExec,
                  straddr + ECALL.string.size(),


### PR DESCRIPTION
This converts `std::bind` calls into lambda expressions which capture `this` using the `[=]` capture (captures all used local non-`static` non-`constexpr` variables by value by default).

Also clarify in the `std::function` declarations that the function takes a `const MemReq&` instead of simply a `MemReq`.
