### PR TITLE
VERY minor cmake & gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-src/librevcpu.so
+*.so
+*.dylib
 *.exe
 *.csv
 .cache/clangd/index

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,12 +149,6 @@ if(NOT INSTRUCTIONS_PATH)
   message(STATUS "INSTRUCTIONS_PATH set to ${INSTRUCTIONS_PATH}")
 endif()
 
-# RevCPU syscalls path
-if(NOT SYSCALLS_PATH)
-  set(SYSCALLS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/syscalls")
-  message(STATUS "SYSCALLS_PATH set to ${SYSCALLS_PATH}")
-endif()
-
 #------------------------------------------------------------------------
 #-- TESTING
 #------------------------------------------------------------------------


### PR DESCRIPTION
1. Removed the previous `SYSCALL_PATH` variable that was used to indicate the directory that held all of the implementation files for each of the syscalls. Never really served a purpose back then and now that the new implementations of the system calls are in a single file `RevSysCalls.h` there's no reason to have it

2. Added `*.dylib` to the `.gitignore` so we have parity between git status on mac & linux