### PR TITLE
Update Minimum Cmake Requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "DO NOT BUILD in-tree.")
 endif()
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.19)
 project(revcpu CXX)
 
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ current installation of the SST Core. The Rev building infrastructure assumes
 that the `sst-config` tool is installed and can be found in the current PATH
 environment.
 
+Rev relies on CMake for building the component from source. The minimum required
+version for this is `3.19`.
+
 ## Building
 
-Building the Rev SST component from source using CMake can be performed as follows:
+Building the Rev SST component from source using CMake (>= 3.19) can be performed as follows:
 
     git clone
     cd rev/build


### PR DESCRIPTION
- `OUTPUT_ERROR_IS_FATAL` requires 3.19
- All support for CMake < 3.5 is being dropped by CMake itself shortly so this change is needed regardless of the 3.19 req