### PR TITLE
Use ABI names for registers instead of raw numbers; start working on FP status/rounding mode

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -11,8 +11,10 @@
 #ifndef __REV_COMMON__
 #define __REV_COMMON__
 
-#include <functional>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <type_traits>
 
 #ifndef _REV_NUM_REGS_
 #define _REV_NUM_REGS_ 32
@@ -29,6 +31,19 @@
 #define _INVALID_ADDR_ (~uint64_t{0})
 
 namespace SST::RevCPU{
+
+/// Zero-extend value of bits size
+template<typename T>
+constexpr auto ZeroExt(T val, size_t bits){
+  return static_cast<std::make_unsigned_t<T>>(val) & ~(~std::make_unsigned_t<T>{0} << bits);
+}
+
+/// Sign-extend value of bits size
+template<typename T>
+constexpr auto SignExt(T val, size_t bits){
+  auto signbit = std::make_unsigned_t<T>{1} << (bits-1);
+  return static_cast<std::make_signed_t<T>>((ZeroExt(val, bits) ^ signbit) - signbit);
+}
 
 enum class RevRegClass : uint8_t { ///< Rev CPU Register Classes
   RegUNKNOWN  = 0,           ///< RevRegClass: Unknown register file

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -40,14 +40,6 @@
 #define DECODE_RL(x)    (((x)>>(25))&(0b1))
 #define DECODE_AQ(x)    (((x)>>(26))&(0b1))
 
-// RV{32,64}{F,D} macros
-#define FCSR_NX(x)  ((x)&(0b1))             // FCSR: NX field
-#define FCSR_UF(x)  (((x)&(0b10))>>1)       // FCSR: UF field
-#define FCSR_OF(x)  (((x)&(0b100))>>2)      // FCSR: OF field
-#define FCSR_DZ(x)  (((x)&(0b1000))>>3)     // FCSR: DZ field
-#define FCSR_NV(x)  (((x)&(0b10000))>>4)    // FCSR: NV field
-#define FCSR_FRM(x) (((x)&(0b11100000))>>5) // FCSR: FRM field
-
 #define FRM_RNE   0b000                     // Rounding mode: Round to Nearest, ties to Even
 #define FRM_RTZ   0b001                     // Rounding mode: Round towards Zero
 #define FRM_RDN   0b010                     // Rounding mode: Round Down (towards -INF)
@@ -74,6 +66,15 @@ enum EXCEPTION_CAUSE : uint32_t {
   STORE_AMO_PAGE_FAULT      = 15,
 };
 
+/// Floating-Point Rounding Mode
+enum class RndMode : uint8_t {
+  RNE = 0,   // Round to Nearest, ties to Even
+  RTZ = 1,   // Round towards Zero
+  RDN = 2,   // Round Down (towards -Inf)
+  RUP = 3,   // Round Up (towards +Inf)
+  RMM = 4,   // Round to Nearest, ties to Max Magnitude
+  DYN = 7,   // In instruction's rm field, selects dynamic rounding mode; invalid in FCSR
+};
 
 inline std::bitset<_REV_HART_COUNT_> HART_CTS; ///< RevProc: Thread is clear to start (proceed with decode)
 inline std::bitset<_REV_HART_COUNT_> HART_CTE; ///< RevProc: Thread is clear to execute (no register dependencides)

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -1,5 +1,5 @@
 //
-// _RevInstTable_h_
+// _RevRegFile_h_
 //
 // Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -28,6 +28,8 @@
 
 namespace SST::RevCPU{
 
+struct RevInst;
+
 /// BoxNaN: Store a boxed float inside a double
 inline void BoxNaN(double* dest, const void* value){
   uint32_t i32;
@@ -48,7 +50,17 @@ enum class RevReg {
   fs8  = 24, fs9 = 25, fs10 = 26, fs11 = 27, ft8 = 28, ft9 = 29, ft10 = 30, ft11 = 31,
 };
 
-struct RevInst;
+/// Floating-point control register
+// fcsr.NX, fcsr.UF, fcsr.OF, fcsr.DZ, fcsr.NV, fcsr.frm
+struct FCSR{
+  uint32_t NX  : 1;
+  uint32_t UF  : 1;
+  uint32_t OF  : 1;
+  uint32_t DZ  : 1;
+  uint32_t NV  : 1;
+  uint32_t frm : 3;
+  uint32_t     : 24;
+};
 
 class RevRegFile {
 public:
@@ -65,17 +77,7 @@ private:
     uint64_t RV64_PC{};                 ///< RevRegFile: RV64 PC
   };
 
-  /// Floating-point control register
-  // fcsr.frm, fcsr.fflags, fcsr.NX, fcsr.UF, fcsr.OF, fcsr.DZ, fcsr.NV
-  struct FCSR{
-    uint32_t NX  : 1;
-    uint32_t UF  : 1;
-    uint32_t OF  : 1;
-    uint32_t DZ  : 1;
-    uint32_t NV  : 1;
-    uint32_t frm : 3;
-    uint32_t     : 24;
-  } fcsr{}; ///< RevRegFile: FCSR
+  FCSR fcsr{}; ///< RevRegFile: FCSR
 
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue{};
   std::function<void(const MemReq&)> MarkLoadCompleteFunc{};
@@ -181,7 +183,7 @@ public:
   }
 
   /// Invoke the MarkLoadComplete function
-  void MarkLoadComplete(const MemReq& req){
+  void MarkLoadComplete(const MemReq& req) const {
     MarkLoadCompleteFunc(req);
   }
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -28,19 +28,6 @@
 
 namespace SST::RevCPU{
 
-/// Zero-extend value of bits size
-template<typename T>
-constexpr auto ZeroExt(T val, size_t bits){
-  return static_cast<std::make_unsigned_t<T>>(val) & ~(~std::make_unsigned_t<T>{0} << bits);
-}
-
-/// Sign-extend value of bits size
-template<typename T>
-constexpr auto SignExt(T val, size_t bits){
-  auto signbit = std::make_unsigned_t<T>{1} << (bits-1);
-  return static_cast<std::make_signed_t<T>>((ZeroExt(val, bits) ^ signbit) - signbit);
-}
-
 /// BoxNaN: Store a boxed float inside a double
 inline void BoxNaN(double* dest, const void* value){
   uint32_t i32;
@@ -48,6 +35,18 @@ inline void BoxNaN(double* dest, const void* value){
   uint64_t i64 = uint64_t{i32} | ~uint64_t{0} << 32; // Boxed NaN value
   memcpy(dest, &i64, sizeof(double));                // Store in FP64 register
 }
+
+/// RISC-V Register Mneumonics
+enum class RevReg {
+  zero =  0, ra  =  1, sp   =  2, gp   =  3, tp  =  4, t0  =  5, t1   =  6, t2   =  7,
+  s0   =  8, s1  =  9, a0   = 10, a1   = 11, a2  = 12, a3  = 13, a4   = 14, a5   = 15,
+  a6   = 16, a7  = 17, s2   = 18, s3   = 19, s4  = 20, s5  = 21, s6   = 22, s7   = 23,
+  s8   = 24, s9  = 25, s10  = 26, s11  = 27, t3  = 28, t4  = 29, t5   = 30, t6   = 31,
+  ft0  =  0, ft1 =  1, ft2  =  2, ft3  =  3, ft4 =  4, ft5 =  5, ft6  =  6, ft7  =  7,
+  fs0  =  8, fs1 =  9, fa0  = 10, fa1  = 11, fa2 = 12, fa3 = 13, fa4  = 14, fa5  = 15,
+  fa6  = 16, fa7 = 17, fs2  = 18, fs3  = 19, fs4 = 20, fs5 = 21, fs6  = 22, fs7  = 23,
+  fs8  = 24, fs9 = 25, fs10 = 26, fs11 = 27, ft8 = 28, ft9 = 29, ft10 = 30, ft11 = 31,
+};
 
 struct RevInst;
 
@@ -66,7 +65,17 @@ private:
     uint64_t RV64_PC{};                 ///< RevRegFile: RV64 PC
   };
 
-  uint64_t FCSR{};                    ///< RevRegFile: FCSR
+  /// Floating-point control register
+  // fcsr.frm, fcsr.fflags, fcsr.NX, fcsr.UF, fcsr.OF, fcsr.DZ, fcsr.NV
+  struct FCSR{
+    uint32_t NX  : 1;
+    uint32_t UF  : 1;
+    uint32_t OF  : 1;
+    uint32_t DZ  : 1;
+    uint32_t NV  : 1;
+    uint32_t frm : 3;
+    uint32_t     : 24;
+  } fcsr{}; ///< RevRegFile: FCSR
 
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue{};
   std::function<void(const MemReq&)> MarkLoadCompleteFunc{};
@@ -207,22 +216,22 @@ public:
   }
 
   /// GetX: Get the specifed X register cast to a specific integral type
-  template<typename T>
-  T GetX(size_t rs) const {
+  template<typename T, typename U>
+  T GetX(U rs) const {
     if( IsRV32 ){
-      return rs ? T(RV32[rs]) : T(0);
+      return RevReg(rs) != RevReg::zero ? T(RV32[size_t(rs)]) : 0;
     }else{
-      return rs ? T(RV64[rs]) : T(0);
+      return RevReg(rs) != RevReg::zero ? T(RV64[size_t(rs)]) : 0;
     }
   }
 
   /// SetX: Set the specifed X register to a specific value
-  template<typename T>
-  void SetX(size_t rd, T val) {
+  template<typename T, typename U>
+  void SetX(U rd, T val) {
     if( IsRV32 ){
-      RV32[rd] = rd ? uint32_t(val) : uint32_t{0};
+      RV32[size_t(rd)] = RevReg(rd) != RevReg::zero ? uint32_t(val) : 0;
     }else{
-      RV64[rd] = rd ? uint64_t(val) : uint64_t{0};
+      RV64[size_t(rd)] = RevReg(rd) != RevReg::zero ? uint64_t(val) : 0;
     }
   }
 
@@ -256,10 +265,11 @@ public:
   }
 
   /// GetFP32: Get the 32-bit float value of a specific FP register
-  float GetFP32(size_t rs) const {
+  template<typename U>
+  float GetFP32(U rs) const {
     if( HasD ){
       uint64_t i64;
-      memcpy(&i64, &DPF[rs], sizeof(i64));   // The FP64 register's value
+      memcpy(&i64, &DPF[size_t(rs)], sizeof(i64));   // The FP64 register's value
       if (~i64 >> 32)                        // Check for boxed NaN
         return NAN;                          // Return NaN if it's not boxed
       auto i32 = static_cast<uint32_t>(i64); // For endian independence
@@ -267,17 +277,18 @@ public:
       memcpy(&fp32, &i32, sizeof(fp32));     // The bottom half of FP64
       return fp32;                           // Reinterpreted as FP32
     } else {
-      return SPF[rs];                        // The FP32 register's value
+      return SPF[size_t(rs)];                // The FP32 register's value
     }
   }
 
   /// SetFP32: Set a specific FP register to a 32-bit float value
-  void SetFP32(size_t rd, float value)
+  template<typename U>
+  void SetFP32(U rd, float value)
     {
       if( HasD ){
-        BoxNaN(&DPF[rd], &value);  // Store NaN-boxed in FP64 register
+        BoxNaN(&DPF[size_t(rd)], &value);    // Store NaN-boxed in FP64 register
       } else {
-        SPF[rd] = value;           // Store in FP32 register
+        SPF[size_t(rd)] = value;             // Store in FP32 register
       }
     }
 

--- a/include/RevThread.h
+++ b/include/RevThread.h
@@ -57,11 +57,11 @@ public:
     : ThreadID(ThreadID), ParentThreadID(ParentThreadID), StackPtr(StackPtr),
       FirstPC(FirstPC), ThreadMem(ThreadMem), Feature(Feature), RegFile(Feature){
     // Set the stack pointer
-    RegFile.SetX(2, StackPtr );
+    RegFile.SetX(RevReg::sp, StackPtr);
 
     // Set the thread pointer
     ThreadPtr = ThreadMem->getTopAddr();
-    RegFile.SetX(4, ThreadPtr);
+    RegFile.SetX(RevReg::tp, ThreadPtr);
 
     // Set the PC
     RegFile.SetPC(FirstPC);

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -2526,8 +2526,8 @@ bool RevCPU::clockTick( SST::Cycle_t currentCycle ){
 void RevCPU::InitThread(std::shared_ptr<RevThread>& ThreadToInit){
 
   auto gp = Loader->GetSymbolAddr("__global_pointer$");
-  ThreadToInit->GetRegFile()->SetX(3, gp);
-  ThreadToInit->GetRegFile()->SetX(8, gp);
+  ThreadToInit->GetRegFile()->SetX(RevReg::gp, gp);
+  ThreadToInit->GetRegFile()->SetX(RevReg::s0, gp);
 
   uint32_t TID = ThreadToInit->GetThreadID();
   // Check if this ThreadID has already been assigned... if so... something has gone horribly wrong
@@ -2619,8 +2619,8 @@ void RevCPU::CheckBlockedThreads(){
 void RevCPU::SetupArgs(uint32_t ThreadIDToSetup, RevFeature* feature){
   auto Argv = Opts->GetArgv();
   // setup argc
-  Threads.at(ThreadIDToSetup)->GetRegFile()->SetX(10, Argv.size());
-  Threads.at(ThreadIDToSetup)->GetRegFile()->SetX(11, Mem->GetStackTop() + 60);
+  Threads.at(ThreadIDToSetup)->GetRegFile()->SetX(RevReg::a0, Argv.size());
+  Threads.at(ThreadIDToSetup)->GetRegFile()->SetX(RevReg::a1, Mem->GetStackTop() + 60);
   return;
 }
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1827,7 +1827,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
         // Ecall found
         output->verbose(CALL_INFO, 6, 0,
                         "Core %u; HartID %d; ThreadID %" PRIu32 " - Exception Raised: ECALL with code = %lu\n",
-                        id, HartToExec, GetActiveThreadID(), RegFile->GetX<uint64_t>(17));
+                        id, HartToExec, GetActiveThreadID(), RegFile->GetX<uint64_t>(RevReg::a7));
 #ifdef _REV_DEBUG_
         //        std::cout << "Hart "<< HartToExec << " found ecall with code: "
         //                  << cRegFile->RV64[17] << std::endl;
@@ -2040,7 +2040,7 @@ void RevProc::CreateThread(uint32_t NewTID, uint64_t firstPC, void* arg){
                                 feature);
 
   // Copy the arg to the new threads a0 register
-  NewThread->GetRegFile()->SetX(10, reinterpret_cast<uintptr_t>(arg));
+  NewThread->GetRegFile()->SetX(RevReg::a0, reinterpret_cast<uintptr_t>(arg));
 
   NewThreadInfo.emplace(NewThread);
 
@@ -2423,7 +2423,7 @@ RevProc::ECALL_status_t RevProc::ECALL_LoadAndParseString(RevInst& inst,
  */
 void RevProc::ExecEcall(RevInst& inst){
   // a7 register = ecall code
-  auto EcallCode = RegFile->GetX<uint64_t>(17);
+  auto EcallCode = RegFile->GetX<uint64_t>(RevReg::a7);
   auto it = Ecalls.find(EcallCode);
   if( it != Ecalls.end() ){
     // call the function


### PR DESCRIPTION
Move `ZeroExt()` and `SignExt()` functions to `common/include/RevCommon.h` since they are `inline` `constexpr` functions usable everywhere, and do not belong to any particular part of Rev. They replace all of the former macros which did sign- and zero-extension.

Remove unused `FCSR_*` macros since the new design makes them unnecessary (not finalized yet -- another solution besides hard-coded macro constants will be used).

Add `enum` `class` `RndMode` describing FP rounding mode (static or dynamic). May help fix [FCVT problem](https://github.com/tactcomplabs/rev/issues/134).

Add `RevReg` `enum` `class` to describe registers by name instead of value (e.g. `RevReg::a0` instead of `10`; `RevReg::sp` instead of `2`).

Start developing `FCSR` class, which describes floating-point state as `fcsr` member of `RevRegFile`.

Broaden `RevRegFile::GetX` and `RevRegFile::SetX` to accept registers as either integers or `RevReg` enum types.

Same for `RevRegFile::GetFP32` and `RevRegFile::SetFP32`.

Use `RevReg::*` ABI register names instead of hard-coded numbers in the source code.
