### PR TITLE
JAL fix

### DIFF
--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -267,7 +267,7 @@ class RV32I : public RevExt {
 
   static bool jal(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetX(Inst.rd, R->GetPC() + Inst.instSize);
-    R->AdvancePC(Inst.ImmSignExt(20));
+    R->AdvancePC(Inst.ImmSignExt(21));
     return true;
   }
 

--- a/test/isa/CMakeLists.txt
+++ b/test/isa/CMakeLists.txt
@@ -43,6 +43,7 @@ foreach(testSrc ${TEST_SRCS})
   set_tests_properties( ${testName}
         PROPERTIES
         ENVIRONMENT "RVASM=${testName}; RVCC=${RVCC}"
+        TIMEOUT 30
         LABELS "all;rv64"
         PASS_REGULAR_EXPRESSION "${passRegex}")
 endforeach(testSrc)

--- a/test/isa/jal.c
+++ b/test/isa/jal.c
@@ -1,0 +1,44 @@
+/*
+ * jal.c
+ *
+ * RISC-V ISA: RV32I
+ *
+ * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * All Rights Reserved
+ * contact@tactcomplabs.com
+ *
+ * See LICENSE in the top level directory for licensing details
+ *
+ */
+
+int main(){
+  asm(
+    " mv t1, ra\n"
+    " j 3f\n"
+
+    "1:\n"
+    "  ret\n"
+    " .zero 0x80000-0x8\n"
+    "2:\n"
+    " ret\n"
+    " .zero 0x80000-0x8\n"
+    "3:\n"
+    " jal 1b\n"
+    " jal 2b\n"
+    " jal 4f\n"
+    " jal 5f\n"
+    " j 6f\n"
+    " ret\n"
+    " .zero 0x80000-0x4\n"
+    "4:\n"
+    " ret\n"
+    " .zero 0x80000-0x10\n"
+    "5:\n"
+    " ret\n"
+
+    "6:\n"
+    " mv ra, t1\n"
+    : : : "t1");
+
+    return 0;
+}


### PR DESCRIPTION
 `JAL` instruction implementation was only considering the bottom 20 bits of the immediate offset, even though the decoder had already shifted the 20-bit immediate offset left one bit.

Added tests for all combinations of the top two most-significant bits of `JAL` offset.

Fixes https://github.com/tactcomplabs/rev/issues/144