### PR TITLE
Fix EcallState to be a reference instead of a local variable

### DIFF
--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -125,8 +125,9 @@ public:
   RevMem& GetMem() const { return *mem; }
 
   // Get the hart ids of the threads that changed state
-  // TODO: Maybe ThreadIDs? 
+  // TODO: Maybe ThreadIDs?
   std::queue<std::shared_ptr<RevThread>>& GetThreadsThatChangedState() { return ThreadsThatChangedState; }
+  const std::queue<std::shared_ptr<RevThread>>& GetThreadsThatChangedState() const { return ThreadsThatChangedState; }
 
   /// RevProc: SpawnThread creates a new thread and returns its ThreadID
   void CreateThread(uint32_t NewTid, uint64_t fn, void* arg);
@@ -143,7 +144,7 @@ public:
   std::queue<std::shared_ptr<RevThread>> NewThreadInfo;
 
   /// RevProc: Gets the thread that is currently executing on the HartToExec
-  /// TODO: Make this safe 
+  /// TODO: Make this safe
   const std::shared_ptr<RevThread>& GetThreadOnHart(uint16_t HartID){ return AssignedThreads.at(Harts.at(HartID)->GetAssignedThreadID()); }
 
   // TODO: Make this safe
@@ -154,7 +155,7 @@ public:
 
   std::queue<uint16_t> HART_CTS; ///< RevProc: Thread is clear to start (proceed with decode)
   std::queue<uint16_t> HART_CTE; ///< RevProc: Thread is clear to execute (no register dependencides)
-  
+
   ///< RevProc: Get this Proc's feature
   RevFeature* GetRevFeature() const { return feature; }
 
@@ -163,9 +164,9 @@ public:
 
   ///< RevProc: Get pointer to Load / Store queue used to track memory operations
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> GetLSQueue(){ return LSQueue; }
-  
-  // TODO: Document & Organize Thread stuff 
-  void AssignThread(const uint32_t& ThreadID); 
+
+  // TODO: Document & Organize Thread stuff
+  void AssignThread(const uint32_t& ThreadID);
 
 private:
   bool Halted;              ///< RevProc: determines if the core is halted
@@ -195,7 +196,7 @@ private:
   // TODO: Add comment & potential error handling
   std::shared_ptr<RevThread>& ActiveThread(uint16_t HartID){ return AssignedThreads.at(Harts.at(HartID)->GetAssignedThreadID()); }
 
-  
+
   // Function pointer to the GetNewThreadID function in RevCPU (monotonically increasing thread ID counter)
   std::function<uint32_t()> GetNewThreadID;
 
@@ -218,7 +219,7 @@ private:
 
   /// RevProc: Get a pointer to the register file loaded into Hart w/ HartID
   // RevRegFile* GetRegFile(uint16_t HartID);
- 
+
   ///< RevProc: Utility function for system calls that involve reading a string from memory
   EcallStatus EcallLoadAndParseString(RevInst& inst, uint64_t straddr, std::function<void()>);
 

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -2663,7 +2663,7 @@ void RevCPU::UpdateThreadAssignments(uint32_t ProcID){
 // and handle appropriately
 void RevCPU::CheckForThreadStateChanges(uint32_t ProcID){
   // Handle any thread state changes for this core
-  // NOTE: At this point we handle EVERY thread that changed state 
+  // NOTE: At this point we handle EVERY thread that changed state
   while( !Procs[ProcID]->GetThreadsThatChangedState().empty() ){
     auto Thread = Procs[ProcID]->GetThreadsThatChangedState().front();
     // Handle the thread that changed state based on the new state
@@ -2715,10 +2715,12 @@ void RevCPU::CheckForThreadStateChanges(uint32_t ProcID){
 
       // Add it to the thread queue to be scheduled
       ThreadQueue.emplace_back(Thread->GetThreadID());
-                     
+      break;
+
     case ThreadState::RUNNING:
       output.verbose(CALL_INFO, 11, 0, "Thread %" PRIu32 " on Core %" PRIu32 " is RUNNING\n", Thread->GetThreadID(), ProcID);
       break;
+
     case ThreadState::READY:
       // If this happens we are not setting state when assigning thread somewhere
       output.fatal(CALL_INFO, 99, "Error: Thread %" PRIu32 " on Core %" PRIu32 " is assigned but is in START state... This is a bug\n",
@@ -2730,7 +2732,7 @@ void RevCPU::CheckForThreadStateChanges(uint32_t ProcID){
       break;
     }
     // Pop the thread that changed state
-    // TODO: Getter is supposed to be const 
+    // TODO: Getter is supposed to be const
     Procs[ProcID]->GetThreadsThatChangedState().pop();
   }
   return;

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -13,8 +13,8 @@ using namespace SST::RevCPU;
 EcallStatus RevProc::EcallLoadAndParseString(RevInst& inst,
                                              uint64_t straddr,
                                              std::function<void()> action){
-  auto rtval = EcallStatus::ERROR;
-  auto EcallState = Harts.at(inst.hart)->GetEcallState();
+  auto  rtval = EcallStatus::ERROR;
+  auto& EcallState = Harts.at(inst.hart)->GetEcallState();
 
   // we don't know how long the path string is so read a byte (char)
   // at a time and search for the string terminator character '\0'


### PR DESCRIPTION
Fix `EcallState` to be a reference instead of a local variable so that it actually modifies the referenced state rather than a local copy of it.

Add `const` version of `GetThreadsThatChangedState()`  (there was a comment suggesting a `const` version should be available).

Add `break` to `switch` `case` to prevent fallthrough warning (=error). If fall-through is desired, then `[[fallthrough]]` [attribute can be specified](https://en.cppreference.com/w/cpp/language/attributes/fallthrough) before next `case`.

Minor whitespace changes because my `emacs` configuration automatically removes trailing whitespace at the ends of lines.