### PR TITLE
Add function to query whether any scoreboard bits are set

### DIFF
--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -690,6 +690,12 @@ private:
   /// RevProc: Determine next thread to execute
   uint16_t GetHartID() const;
 
+  /// RevProc: Whether any scoreboard bits are set
+  bool AnyDependency(uint16_t HartID, bool isFloat) const {
+    const RevRegFile* regFile = GetRegFile(HartID);
+    return isFloat ? regFile->FP_Scoreboard.any() : regFile->RV_Scoreboard.any();
+  }
+
   /// RevProc: Check scoreboard for pipeline hazards
   bool DependencyCheck(uint16_t HartID, const RevInst* Inst) const;
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -11,6 +11,7 @@
 #ifndef _SST_REVCPU_REVREGFILE_H_
 #define _SST_REVCPU_REVREGFILE_H_
 
+#include <bitset>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -92,15 +93,8 @@ private:
     double DPF[_REV_NUM_REGS_]{};       ///< RevRegFile: RVxxD register file
   };
 
-  union{  // Anonymous union. We zero-initialize the largest member
-    bool RV32_Scoreboard[_REV_NUM_REGS_];   ///< RevRegFile: Scoreboard for RV32I RF to manage pipeline hazard
-    bool RV64_Scoreboard[_REV_NUM_REGS_]{}; ///< RevRegFile: Scoreboard for RV64I RF to manage pipeline hazard
-  };
-
-  union{  // Anonymous union. We zero-initialize the largest member
-    bool SPF_Scoreboard[_REV_NUM_REGS_];    ///< RevRegFile: Scoreboard for SPF RF to manage pipeline hazard
-    bool DPF_Scoreboard[_REV_NUM_REGS_]{};  ///< RevRegFile: Scoreboard for DPF RF to manage pipeline hazard
-  };
+  std::bitset<_REV_NUM_REGS_> RV_Scoreboard{}; ///< RevRegFile: Scoreboard for RV32/RV64 RF to manage pipeline hazard
+  std::bitset<_REV_NUM_REGS_> FP_Scoreboard{}; ///< RevRegFile: Scoreboard for SPF/DPF RF to manage pipeline hazard
 
   // Supervisor Mode CSRs
 #if 0 // not used

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1591,18 +1591,10 @@ bool RevProc::DependencyCheck(uint16_t HartID, const RevInst* I) const {
     if(reg < _REV_NUM_REGS_){
       switch(regClass){
       case RevRegClass::RegFLOAT:
-        if(feature->HasD()){
-          if(regFile->DPF_Scoreboard[reg]) return true;
-        }else{
-          if(regFile->SPF_Scoreboard[reg]) return true;
-        }
+        if(regFile->FP_Scoreboard[reg]) return true;
         break;
       case RevRegClass::RegGPR:
-        if(feature->IsRV32()){
-          if(regFile->RV32_Scoreboard[reg]) return true;
-        }else {
-          if(regFile->RV64_Scoreboard[reg]) return true;
-        }
+        if(regFile->RV_Scoreboard[reg]) return true;
         break;
       default:
         break;
@@ -1617,20 +1609,12 @@ void RevProc::DependencySet(uint16_t HartID, uint16_t RegNum,
                             bool isFloat, bool value){
   RevRegFile* regFile = GetRegFile(HartID);
   if(isFloat){
-    if(RegNum < _REV_NUM_REGS_){
-      if(feature->HasD()){
-        regFile->DPF_Scoreboard[RegNum] = value;
-      }else{
-        regFile->SPF_Scoreboard[RegNum] = value;
-      }
+    if( RegNum < _REV_NUM_REGS_ ){
+      regFile->FP_Scoreboard[RegNum] = value;
     }
   }else{
-    if(RegNum != 0 && RegNum < _REV_NUM_REGS_){
-      if(feature->IsRV32()){
-        regFile->RV32_Scoreboard[RegNum] = value;
-      }else{
-        regFile->RV64_Scoreboard[RegNum] = value;
-      }
+    if( RegNum < _REV_NUM_REGS_ && RegNum != 0 ){
+      regFile->RV_Scoreboard[RegNum] = value;
     }
   }
 }


### PR DESCRIPTION
Switch to using `std::bitset` and single scoreboard registers (no `union`s).

The 32/64-bit scoreboard registers used the same space and size, so the `union`s were redundant.

With `std::bitset` there are built-in functions for testing whether any or all bits are set.

Also takes 1/8th the space of an array of `bool`.