### PR TITLE
Pipeline scoreboard and stall mgmt from co-processor

### DIFF
--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -31,14 +31,16 @@
 #include "RevFeature.h"
 #include "RevMem.h"
 #include "RevInstTable.h"
+#include "RevProcPasskey.h"
+#include "RevProc.h"
 
 namespace SST::RevCPU{
-
+class RevProc;
 // ----------------------------------------
 // RevCoProc
 // ----------------------------------------
-struct RevCoProc : SST::SubComponent {
-
+class RevCoProc : public SST::SubComponent {
+public:
   SST_ELI_REGISTER_SUBCOMPONENT_API(SST::RevCPU::RevCoProc);
   SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the attached co-processor", "0" });
 
@@ -51,9 +53,17 @@ struct RevCoProc : SST::SubComponent {
   virtual bool Reset() = 0;                           /// RevCoProc: Reset - called on startup
   virtual bool Teardown() = 0;                        /// RevCoProc: Teardown - called when associated RevProc completes
   virtual bool ClockTick(SST::Cycle_t cycle) = 0;     /// RevCoProc: Clock - can be called by SST or by overriding RevCPU
+//  virtual void DependencySet(uint16_t HartID, uint16_t RegNum, bool isFloat, bool value = true); 
+//  virtual void DependencyClear(uint16_t HartID, uint16_t RegNum, bool isFloat){
+//    DependencySet(HartID, RegNum, isFloat, false);
+//  }
+
+  void SetParent(RevProc* parentPtr){parent = parentPtr;}
+  RevProcPasskey<RevCoProc> CreatePasskey(){return RevProcPasskey<RevCoProc>();}
 
 protected:
   SST::Output *output;                                ///< RevCoProc: sst output object
+  RevProc* parent;
 }; // class RevCoProc
 
 // ----------------------------------------
@@ -110,6 +120,7 @@ public:
   ///                   also signal to SST that the co-processor is done if ClockTick is registered
   ///                   to SSTCore vs. being driven by RevCPU
   virtual bool Teardown() { return Reset(); };
+
 
 private:
   struct RevCoProcInst {

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -44,26 +44,24 @@ public:
   SST_ELI_REGISTER_SUBCOMPONENT_API(SST::RevCPU::RevCoProc);
   SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the attached co-processor", "0" });
 
-  /// RevCoProc: default constructor
+  /// RevCoProc: Constructor
   RevCoProc( ComponentId_t id, Params& params);
 
   /// RevCoProc: default destructor
-  virtual ~RevCoProc();                               /// RevCoProc: Destructor
+  virtual ~RevCoProc();                               ///< RevCoProc: Destructor
   virtual bool IssueInst(RevFeature *F, RevRegFile *R, RevMem *M, uint32_t Inst) = 0;          /// RevCoProc: Instruction Interface to RevCore
-  virtual bool Reset() = 0;                           /// RevCoProc: Reset - called on startup
-  virtual bool Teardown() = 0;                        /// RevCoProc: Teardown - called when associated RevProc completes
-  virtual bool ClockTick(SST::Cycle_t cycle) = 0;     /// RevCoProc: Clock - can be called by SST or by overriding RevCPU
-//  virtual void DependencySet(uint16_t HartID, uint16_t RegNum, bool isFloat, bool value = true); 
-//  virtual void DependencyClear(uint16_t HartID, uint16_t RegNum, bool isFloat){
-//    DependencySet(HartID, RegNum, isFloat, false);
-//  }
+  virtual bool Reset() = 0;                           ///< RevCoProc: Reset - called on startup
+  virtual bool Teardown() = 0;                        ///< RevCoProc: Teardown - called when associated RevProc completes
+  virtual bool ClockTick(SST::Cycle_t cycle) = 0;     ///< RevCoProc: Clock - can be called by SST or by overriding RevCPU
 
-  void SetParent(RevProc* parentPtr){parent = parentPtr;}
-  RevProcPasskey<RevCoProc> CreatePasskey(){return RevProcPasskey<RevCoProc>();}
+  void SetParent(RevProc* parentPtr){parent = parentPtr;} /// RevCoProc: Set the pointer back to the main RevProc this is attached to
 
 protected:
   SST::Output *output;                                ///< RevCoProc: sst output object
-  RevProc* parent;
+  RevProc     *parent;                                ///< RevCoProc: Pointer to RevProc this CoProc is attached to
+
+  ///< RevCoProc: Create the passkey object - this allows access to otherwise private members within RevProc 
+  RevProcPasskey<RevCoProc> CreatePasskey(){return RevProcPasskey<RevCoProc>();}
 }; // class RevCoProc
 
 // ----------------------------------------
@@ -140,6 +138,8 @@ private:
 
   /// Queue of instructions sent from attached RevProc
   std::queue<RevCoProcInst> InstQ;
+
+  SST::Cycle_t cycleCount;
 
 }; //class RevSimpleCoProc
 

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -53,6 +53,7 @@ public:
   virtual bool Reset() = 0;                           ///< RevCoProc: Reset - called on startup
   virtual bool Teardown() = 0;                        ///< RevCoProc: Teardown - called when associated RevProc completes
   virtual bool ClockTick(SST::Cycle_t cycle) = 0;     ///< RevCoProc: Clock - can be called by SST or by overriding RevCPU
+  virtual bool IsDone() = 0;                          ///< RevCoProc: Returns true when co-processor has completed execution - used for proper exiting of associated RevProc
 
 protected:
   SST::Output*   output;                                ///< RevCoProc: sst output object
@@ -117,6 +118,8 @@ public:
   ///                   to SSTCore vs. being driven by RevCPU
   virtual bool Teardown() { return Reset(); };
 
+  /// RevSimpleCoProc: Returns true if instruction queue is empty
+  virtual bool IsDone(){ return InstQ.empty();}
 
 private:
   struct RevCoProcInst {

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -41,11 +41,11 @@ class RevProc;
 // ----------------------------------------
 class RevCoProc : public SST::SubComponent {
 public:
-  SST_ELI_REGISTER_SUBCOMPONENT_API(SST::RevCPU::RevCoProc);
+  SST_ELI_REGISTER_SUBCOMPONENT_API(SST::RevCPU::RevCoProc, RevProc*);
   SST_ELI_DOCUMENT_PARAMS({ "verbose", "Set the verbosity of output for the attached co-processor", "0" });
 
   /// RevCoProc: Constructor
-  RevCoProc( ComponentId_t id, Params& params);
+  RevCoProc( ComponentId_t id, Params& params, RevProc* parent);
 
   /// RevCoProc: default destructor
   virtual ~RevCoProc();                               ///< RevCoProc: Destructor
@@ -54,11 +54,9 @@ public:
   virtual bool Teardown() = 0;                        ///< RevCoProc: Teardown - called when associated RevProc completes
   virtual bool ClockTick(SST::Cycle_t cycle) = 0;     ///< RevCoProc: Clock - can be called by SST or by overriding RevCPU
 
-  void SetParent(RevProc* parentPtr){parent = parentPtr;} /// RevCoProc: Set the pointer back to the main RevProc this is attached to
-
 protected:
-  SST::Output *output;                                ///< RevCoProc: sst output object
-  RevProc     *parent;                                ///< RevCoProc: Pointer to RevProc this CoProc is attached to
+  SST::Output*   output;                                ///< RevCoProc: sst output object
+  RevProc* const parent;                                  ///< RevCoProc: Pointer to RevProc this CoProc is attached to
 
   ///< RevCoProc: Create the passkey object - this allows access to otherwise private members within RevProc 
   RevProcPasskey<RevCoProc> CreatePasskey(){return RevProcPasskey<RevCoProc>();}
@@ -98,7 +96,7 @@ public:
   };
 
   /// RevSimpleCoProc: constructor
-  RevSimpleCoProc(ComponentId_t id, Params& params);
+  RevSimpleCoProc(ComponentId_t id, Params& params, RevProc* parent);
 
   /// RevSimpleCoProc: destructor
   virtual ~RevSimpleCoProc();

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -63,7 +63,7 @@ public:
   RevProc( unsigned Id, RevOpts *Opts, RevMem *Mem, RevLoader *Loader,
            std::vector<std::shared_ptr<RevThread>>& AssignedThreads,
            std::function<uint32_t()> GetNewThreadID,
-           RevCoProc* CoProc, SST::Output *Output );
+           SST::Output *Output );
 
   /// RevProc: standard desctructor
   ~RevProc() = default;
@@ -157,6 +157,9 @@ public:
 
   ///< RevProc: Get pointer to Load / Store queue used to track memory operations
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> GetLSQueue(){ return LSQueue; }
+
+  ///< RevProc: Add a co-processor to the RevProc
+  void SetCoProc(RevCoProc* coproc);
 
 //--------------- External Interface for use with Co-Processor -------------------------
   ///< RevProc: Allow a co-processor to manipulate the scoreboard by setting a bit. Note the RevProcPassKey may only

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -162,12 +162,16 @@ public:
   ///< RevProc: Allow a co-processor to manipulate the scoreboard by setting a bit. Note the RevProcPassKey may only
   ///  be created by a RevCoProc (or a class derived from RevCoProc) so this funciton may not be called from even within
   ///  RevProc
-  void ExternalDepSet(RevProcPasskey<RevCoProc>, uint16_t HartID, uint16_t RegNum, bool isFloat, bool value = true);
+  void ExternalDepSet(RevProcPasskey<RevCoProc>, uint16_t HartID, uint16_t RegNum, bool isFloat, bool value = true){
+    DependencySet(HartID, RegNum, isFloat, value);
+  }
 
   ///< RevProc: Allow a co-processor to manipulate the scoreboard by clearing a bit. Note the RevProcPassKey may only
   ///  be created by a RevCoProc (or a class derived from RevCoProc) so this funciton may not be called from even within
   ///  RevProc 
-  void ExternalDepClear(RevProcPasskey<RevCoProc>, uint16_t HartID, uint16_t RegNum, bool isFloat);
+  void ExternalDepClear(RevProcPasskey<RevCoProc>, uint16_t HartID, uint16_t RegNum, bool isFloat){
+    DependencyClear(HartID, RegNum, isFloat);
+  }
 
   ///< RevProc: Allow a co-processor to stall the pipeline of this proc and hold it in a stall condition
   ///  unitl ExternalReleaseHart() is called. Note the RevProcPassKey may only
@@ -221,6 +225,8 @@ private:
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecode RegFile
+
+  std::bitset<_REV_HART_COUNT_> CoProcStallReq;
 
   /// RevProc: Get a pointer to the register file loaded into Hart w/ HartID
   // RevRegFile* GetRegFile(uint16_t HartID);

--- a/include/RevProcPasskey.h
+++ b/include/RevProcPasskey.h
@@ -11,7 +11,8 @@
 
 #ifndef __REV_PROC_PASSKEY__
 #define __REV_PROC_PASSKEY__
-
+namespace SST::RevCPU{
+  
 template<typename T>
 class RevProcPasskey{
   private:
@@ -20,5 +21,5 @@ class RevProcPasskey{
   RevProcPasskey(const RevProcPasskey&) {};
   RevProcPasskey& operator=(const RevProcPasskey&) = delete;
 };
-
+}
 #endif

--- a/include/RevProcPasskey.h
+++ b/include/RevProcPasskey.h
@@ -1,0 +1,24 @@
+//
+// _RevProcPasskey_h_
+//
+// Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+
+#ifndef __REV_PROC_PASSKEY__
+#define __REV_PROC_PASSKEY__
+
+template<typename T>
+class RevProcPasskey{
+  private:
+  friend T;
+  RevProcPasskey() {};
+  RevProcPasskey(const RevProcPasskey&) {};
+  RevProcPasskey& operator=(const RevProcPasskey&) = delete;
+};
+
+#endif

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -255,6 +255,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
     Procs.reserve(Procs.size() + numCores);
     for( unsigned i=0; i<numCores; i++ ){
       Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), CoProcs[i], &output ) );
+      CoProcs[i]->SetParent(Procs.back());
     }
   }else{
     // Create the processor objects

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -243,25 +243,27 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
   AssignedThreads.resize(numCores);
   EnableCoProc = params.find<bool>("enableCoProc", 0);
   if(EnableCoProc){
+
+    // Create the processor objects
+    Procs.reserve(Procs.size() + numCores);
+    for( unsigned i=0; i<numCores; i++ ){
+      Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), &output ) );
+    //  CoProcs[i]->SetParent(Procs.back());
+    }
     // Create the co-processor objects
     for( unsigned i=0; i<numCores; i++){
-      RevCoProc* CoProc = loadUserSubComponent<RevCoProc>("co_proc");
+      RevCoProc* CoProc = loadUserSubComponent<RevCoProc>("co_proc", SST::ComponentInfo::SHARE_NONE, Procs[i]);
       if (!CoProc) {
         output.fatal(CALL_INFO, -1, "Error : failed to inintialize the co-processor subcomponent\n");
       }
       CoProcs.push_back(CoProc);
-    }
-    // Create the processor objects
-    Procs.reserve(Procs.size() + numCores);
-    for( unsigned i=0; i<numCores; i++ ){
-      Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), CoProcs[i], &output ) );
-      CoProcs[i]->SetParent(Procs.back());
+      Procs[i]->SetCoProc(CoProc);
     }
   }else{
     // Create the processor objects
     Procs.reserve(Procs.size() + numCores);
     for( unsigned i=0; i<numCores; i++ ){
-      Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), NULL, &output ) );
+      Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), &output ) );
     }
   }
 

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -248,7 +248,6 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
     Procs.reserve(Procs.size() + numCores);
     for( unsigned i=0; i<numCores; i++ ){
       Procs.push_back( new RevProc( i, Opts, Mem, Loader, AssignedThreads.at(i), this->GetNewTID(), &output ) );
-    //  CoProcs[i]->SetParent(Procs.back());
     }
     // Create the co-processor objects
     for( unsigned i=0; i<numCores; i++){

--- a/src/RevCoProc.cc
+++ b/src/RevCoProc.cc
@@ -17,24 +17,22 @@ using namespace RevCPU;
 // ---------------------------------------------------------------
 // RevCoProc
 // ---------------------------------------------------------------
-RevCoProc::RevCoProc(ComponentId_t id, Params& params)
-  : SubComponent(id), output(nullptr) {
+RevCoProc::RevCoProc(ComponentId_t id, Params& params, RevProc* parent)
+  : SubComponent(id), output(nullptr), parent(parent) {
 
   uint32_t verbosity = params.find<uint32_t>("verbose");
   output = new SST::Output("[RevCoProc @t]: ", verbosity, 0, SST::Output::STDOUT);
-  parent = nullptr;
 }
 
 RevCoProc::~RevCoProc(){
   delete output;
-  parent = nullptr;
 }
 
 // ---------------------------------------------------------------
 // RevSimpleCoProc
 // ---------------------------------------------------------------
-RevSimpleCoProc::RevSimpleCoProc(ComponentId_t id, Params& params)
-  : RevCoProc(id, params), num_instRetired(0) {
+RevSimpleCoProc::RevSimpleCoProc(ComponentId_t id, Params& params, RevProc* parent)
+  : RevCoProc(id, params, parent), num_instRetired(0) {
 
   std::string ClockFreq = params.find<std::string>("clock", "1Ghz");
   cycleCount = 0;

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1984,7 +1984,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       }
     }else if( GetPC() == 0x00ull ) {
       auto& Thread = GetThreadOnHart(HartToDecode);
-      if( !ThreadHasDependencies(Thread->GetThreadID()) ){
+      if( !ThreadHasDependencies(Thread->GetThreadID()) && ((nullptr == coProc) || (coProc && coProc->IsDone())) ){
         Thread->SetState(ThreadState::DONE);
         HART_CTE[HartToDecode] = false;
         HART_CTS[HartToDecode] = false;
@@ -1992,7 +1992,8 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       }
     }
 
-    if( HartToExec != _REV_INVALID_HART_ID_ && HartHasThread(HartToExec) && !ThreadHasDependencies(GetActiveThreadID()) ){
+    if( HartToExec != _REV_INVALID_HART_ID_ && HartHasThread(HartToExec) && !ThreadHasDependencies(GetActiveThreadID()) \
+        && ((nullptr == coProc) || (coProc && coProc->IsDone())) ){
       HART_CTE[HartToExec] = false;
       HART_CTS[HartToExec] = false;
       GetThreadOnHart(HartToExec)->SetState(ThreadState::DONE);

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1630,7 +1630,7 @@ void RevProc::ExternalStallHart(RevProcPasskey<RevCoProc>, uint16_t HartID){
     CoProcStallReq.set(HartID);
   }else{
     output->fatal(CALL_INFO, -1,
-                  "Core %u ; CoProc Request: Cannot stall Hart %d as the ID is invalid\n",
+                  "Core %u ; CoProc Request: Cannot stall Hart %" PRIu32 " as the ID is invalid\n",
                   id, HartID);
   }
 }
@@ -1640,7 +1640,7 @@ void RevProc::ExternalReleaseHart(RevProcPasskey<RevCoProc>, uint16_t HartID){
     CoProcStallReq.reset(HartID);
   }else{
     output->fatal(CALL_INFO, -1,
-                  "Core %u ; CoProc Request: Cannot release Hart %d as the ID is invalid\n",
+                  "Core %u ; CoProc Request: Cannot release Hart %" PRIu32 " as the ID is invalid\n",
                   id, HartID);
   }
 }


### PR DESCRIPTION
**Summary**

- Adding new functionality to allow `RevCoProc` to Set / Clear scoreboard bits
- Adding new functionality to allow `RevCoProc` to stall the pipeline for a given Hart for an indefinite amount of time
- Both of the above functions are achieved with new public (but not that public) member functions on RevProc
- `RevCoProc` now has a pointer back to its associated `RevProc`
- Changing constructors for `RevProc` and `RevCoProc` to allow a future feature of one `RevProc` with many `RevCoProcs` to be implemented more easily


**Details**

The scoreboards are private members of `RevProc` and `RevCoProc` operates as a independent subcomponent and cannot directly access these fields. `Friends` was a cumbersome model and would have ended up requiring `RevCoProc` to have complete access to all `RevProcs` data members.  To get around this, I used the Passkey pattern. There is a new class (and header) `RevProcPasskey<T>`.  A specialized version of this class can _only_  be constructed by RevCoProc or its derived classes and is a parameter to the new public functions allowing scoreboard manipulation and pipeline stalling.

The constructor changes swap the relationship between CoProc and Proc. You now require a `RevProc` pointer when constructing a `RevCoProc` - which makes sense as you would never have a CoProc without a Proc.   `RevProc`  no longer takes a pointer to a single `RevCoProc` but is instead assigned through a Set function. This functionality could be extended to have `RevProc` maintain a `vector` of `RevCoProc` objects to support multiple attached co-processors.