### PR TITLE
REV: Add clock_gettime syscall

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <time.h>
 
 // The following is required to build on MacOS
 // because sigval & siginfo_t are already defined
@@ -258,6 +259,8 @@ typedef struct __user_cap_header_struct {
   uint32_t version;
   int pid;
 } *cap_user_header_t;
+
+#define __kernel_timespec timespec
 
 typedef struct __user_cap_data_struct {
   uint32_t effective;

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -85,6 +85,9 @@ public:
   /// RevProc: retrieve the local PC for the correct feature set
   uint64_t GetPC() const { return RegFile->GetPC(); }
 
+  /// RevProc: set time converter for RTC
+  void SetTimeConverter(TimeConverter* tc) { timeConverter = tc; }
+
   /// RevProc: Debug mode read a register
   bool DebugReadReg(unsigned Idx, uint64_t *Value) const;
 
@@ -232,6 +235,7 @@ private:
   std::unique_ptr<RevPrefetcher> sfetch; ///< RevProc: stream instruction prefetcher
 
   std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
+  TimeConverter* timeConverter;          ///< RevProc: Time converter for RTC
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecode RegFile
 

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -225,6 +225,10 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
     }
   }
   #endif
+  // Setup timeConverter
+  for( size_t i=0; i<Procs.size(); i++){
+    Procs[i]->SetTimeConverter(timeConverter);
+  }
 
   // Initial thread setup
   uint32_t MainThreadID = id+1; // Prevents having MainThreadID == 0 which is reserved for INVALID

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1195,6 +1195,18 @@ EcallStatus RevProc::ECALL_clock_gettime(RevInst& inst){
   output->verbose(CALL_INFO, 2, 0,
                   "ECALL: clock_gettime called by thread %" PRIu32
                   " on hart %" PRIu32 "\n", GetActiveThreadID(), HartToExec);
+  struct timespec src, *tp = (struct timespec *) RegFile->GetX<uint64_t>(RevReg::a1);
+
+  if (timeConverter == nullptr) {
+    RegFile->SetX(RevReg::a0, EINVAL);
+    return EcallStatus::SUCCESS;
+  }
+  memset(&src, 0, sizeof(*tp));
+  SimTime_t x = timeConverter->convertToCoreTime(Stats.totalCycles);
+  src.tv_sec = x / 1000000000000ull;
+  src.tv_nsec = (x / 1000) % 1000000000ull;
+  mem->WriteMem(HartToExec, (size_t)tp, sizeof(*tp), &src);
+  RegFile->SetX(RevReg::a0, 0);
   return EcallStatus::SUCCESS;
 }
 

--- a/test/syscalls/clock_gettime/Makefile
+++ b/test/syscalls/clock_gettime/Makefile
@@ -1,0 +1,25 @@
+#
+# Makefile
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+.PHONY: src
+
+EXAMPLE=clock_gettime
+#CC=riscv64-unknown-elf-gcc
+CC="${RVCC}"
+#ARCH=rv64g
+ARCH=rv64imafdc
+
+all: $(EXAMPLE).exe
+$(EXAMPLE).exe: $(EXAMPLE).c
+	$(CC) -march=$(ARCH) -O0 -o $(EXAMPLE).exe $(EXAMPLE).c -static
+clean:
+	rm -Rf $(EXAMPLE).exe
+
+#-- EOF

--- a/test/syscalls/clock_gettime/clock_gettime.c
+++ b/test/syscalls/clock_gettime/clock_gettime.c
@@ -1,0 +1,24 @@
+#include "../../../common/syscalls/syscalls.h"
+#define assert(x) if(!(x)) { asm(".byte 0; .byte 0; .byte 0; .byte 0"); }
+
+int main(int argc, char *argv[]) {
+  int sum = 0;
+  struct __kernel_timespec s, e;
+
+  int ret = rev_clock_gettime(0, &s);
+  assert(ret == 0);
+
+  /*
+   * Dummy code that is the subject of measurement.
+   * We use argc to discourage compiler from removing
+   * dead code.
+   */
+  for(int i = 0; i < 100 * argc; i++)
+    sum++;
+
+  ret = rev_clock_gettime(0, &e);
+  assert(ret == 0);
+ 
+  assert((e.tv_nsec - s.tv_nsec) >= 0);
+  return sum;
+}

--- a/test/syscalls/clock_gettime/rev-test.py
+++ b/test/syscalls/clock_gettime/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 1,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                 # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "clock_gettime.exe",              # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF


### PR DESCRIPTION
Wire clock_gettime to the cycle counter to be able to use it to measure time intervals in various
segments of workloads. Since REV core is not aware of the clock it is running at we have to propagate timeConverter to each of the cores in RevProc, to
convert cycles to real time. Clockid argument is not supported - we simply ignore it.

Add a test with usage example of the "new" syscall.