### PR TITLE
Add lg() function for base-2 logarithm of integers

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -48,19 +48,16 @@ constexpr auto SignExt(T val, size_t bits){
 /// Base-2 logarithm of integers
 template<typename T>
 constexpr int lg(T x){
-  // We select the __builtin_clz which takes integers the same size as x
-  if(x){
-    if constexpr(sizeof(T) == sizeof(int)){
-      return 8*sizeof(T)-1 - __builtin_clz(x);
-    }else if constexpr(sizeof(T) == sizeof(long)){
-      return 8*sizeof(T)-1 - __builtin_clzl(x);
-    }else if constexpr(sizeof(T) == sizeof(long long)){
-      return 8*sizeof(T)-1 - __builtin_clzll(x);
-    }else{
-      static_assert(sizeof(T) == 0, "Unhandled type in lg()");
-    }
+  static_assert(std::is_integral_v<T>);
+
+  // We select the __builtin_clz which takes integers no smaller than x
+  if constexpr(sizeof(x) <= sizeof(int)){
+    return x ? 8*sizeof(int)-1 - __builtin_clz(x) : -1;
+  }else if constexpr(sizeof(x) <= sizeof(long)){
+    return x ? 8*sizeof(long)-1 - __builtin_clzl(x) : -1;
+  }else{
+    return x ? 8*sizeof(long long)-1 - __builtin_clzll(x) : -1;
   }
-  return -1;
 }
 
 enum class RevRegClass : uint8_t { ///< Rev CPU Register Classes

--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -45,6 +45,24 @@ constexpr auto SignExt(T val, size_t bits){
   return static_cast<std::make_signed_t<T>>((ZeroExt(val, bits) ^ signbit) - signbit);
 }
 
+/// Base-2 logarithm of integers
+template<typename T>
+constexpr int lg(T x){
+  // We select the __builtin_clz which takes integers the same size as x
+  if(x){
+    if constexpr(sizeof(T) == sizeof(int)){
+      return 8*sizeof(T)-1 - __builtin_clz(x);
+    }else if constexpr(sizeof(T) == sizeof(long)){
+      return 8*sizeof(T)-1 - __builtin_clzl(x);
+    }else if constexpr(sizeof(T) == sizeof(long long)){
+      return 8*sizeof(T)-1 - __builtin_clzll(x);
+    }else{
+      static_assert(sizeof(T) == 0, "Unhandled type in lg()");
+    }
+  }
+  return -1;
+}
+
 enum class RevRegClass : uint8_t { ///< Rev CPU Register Classes
   RegUNKNOWN  = 0,           ///< RevRegClass: Unknown register file
   RegIMM      = 1,           ///< RevRegClass: Treat the reg class like an immediate: S-Format

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -24,7 +24,7 @@ RevMem::RevMem( uint64_t MemSize, RevOpts *Opts, RevMemCtrl *Ctrl, SST::Output *
   : memSize(MemSize), opts(Opts), ctrl(Ctrl), output(Output) {
   // Note: this constructor assumes the use of the memHierarchy backend
   pageSize = 262144; //Page Size (in Bytes)
-  addrShift = int(log(pageSize) / log(2.0));
+  addrShift = lg(pageSize);
   nextPage = 0;
 
   // We initialize StackTop to the size of memory minus 1024 bytes
@@ -43,7 +43,7 @@ RevMem::RevMem( uint64_t MemSize, RevOpts *Opts, SST::Output *Output )
   // allocate the backing memory, zeroing it
   physMem = new char [memSize]{};
   pageSize = 262144; //Page Size (in Bytes)
-  addrShift = int(log(pageSize) / log(2.0));
+  addrShift = lg(pageSize);
   nextPage = 0;
 
   if( !physMem )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Check for RISCV Compiler
 if(NOT RVCC)
   set(RVCC "$ENV{RVCC}")
-endif()  
+endif()
 if(RVCC)
   message(STATUS "RVCC set to ${RVCC}")
 else()
@@ -93,7 +93,7 @@ add_test(NAME TEST_BIG_LOOP COMMAND run_big_loop.sh WORKING_DIRECTORY "${CMAKE_C
 set_tests_properties(TEST_BIG_LOOP
   PROPERTIES
     ENVIRONMENT "RVCC=${RVCC}"
-    TIMEOUT 90
+    TIMEOUT 180
     PASS_REGULAR_EXPRESSION "${passRegex}"
     LABELS "all;rv64"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Check for RISCV Compiler
 if(NOT RVCC)
   set(RVCC "$ENV{RVCC}")
-endif()
+endif()  
 if(RVCC)
   message(STATUS "RVCC set to ${RVCC}")
 else()
@@ -93,7 +93,7 @@ add_test(NAME TEST_BIG_LOOP COMMAND run_big_loop.sh WORKING_DIRECTORY "${CMAKE_C
 set_tests_properties(TEST_BIG_LOOP
   PROPERTIES
     ENVIRONMENT "RVCC=${RVCC}"
-    TIMEOUT 180
+    TIMEOUT 90
     PASS_REGULAR_EXPRESSION "${passRegex}"
     LABELS "all;rv64"
 )


### PR DESCRIPTION
This adds a `lg()` function which returns the base-2 logarithm of integers, using the `__builtin_clz*` functions.

~~(Also increases `big_loop` test timeout to make CI tests pass.)~~
