### PR TITLE
adding feature to disable manual coprocessor clocking

### DIFF
--- a/include/RevCPU.h
+++ b/include/RevCPU.h
@@ -118,6 +118,7 @@ public:
     {"RDMAPerCycle",    "Number of RDMA messages per cycle to inject",  "1"},
     {"testIters",       "Number of PAN test messages to send",          "255"},
     {"splash",          "Display the splash logo",                      "0"},
+    {"disable_coproc_clock",  "Disables the manual clocking of coprocessor subcomponents", "0"},
     )
 
   // -------------------------------------------------------
@@ -301,6 +302,8 @@ private:
   bool EnableMemFaults;               ///< RevCPU: Enable memory faults (bit flips)
   bool EnableRegFaults;               ///< RevCPU: Enable register faults
   bool EnableALUFaults;               ///< RevCPU: Enable ALU faults
+
+  bool DisableCoprocClock;            ///< RevCPU: Disables manual coproc clocking
 
   bool ReadyForRevoke;                ///< RevCPU: Is the CPU ready for revocation?
   bool RevokeHasArrived;              ///< RevCPU: Determines whether the REVOKE command has arrived

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -40,6 +40,7 @@ const char pan_splash_msg[] = "\
 RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
   : SST::Component(id), testStage(0), PrivTag(0), address(-1), PrevAddr(_PAN_RDMA_MAILBOX_),
     EnableNIC(false), EnablePAN(false), EnablePANStats(false), EnableMemH(false),
+    DisableCoprocClock(false),
     ReadyForRevoke(false), Nic(nullptr), PNic(nullptr), PExec(nullptr), Ctrl(nullptr),
     ClockHandler(nullptr) {
 
@@ -73,14 +74,16 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
   // If the PAN tests are enabled, override the number cores and force them to '0'
   numCores = params.find<unsigned>("numCores", "1");
   numHarts = params.find<uint16_t>("numHarts", "1");
-  
+
   // Make sure someone isn't trying to have more than 65536 harts per core
   if( numHarts > _MAX_HARTS_ ){
     output.fatal(CALL_INFO, -1, "Error: number of harts must be <= %" PRIu32 "\n", _MAX_HARTS_);
   }
   if( EnablePANTest )
     numCores = 1; // force the PAN test to use a single core
-  output.verbose(CALL_INFO, 1, 0, "Building Rev with %" PRIu32 " cores and %" PRIu32 " hart(s) on each core \n", numCores, numHarts);
+  output.verbose(CALL_INFO, 1, 0,
+                 "Building Rev with %" PRIu32 " cores and %" PRIu32 " hart(s) on each core \n",
+                 numCores, numHarts);
 
   // read the binary executable name
   Exe = params.find<std::string>("program", "a.out");
@@ -355,6 +358,8 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
     TLBMissesPerCore.push_back( registerStatistic<uint64_t>("TLBMissesPerCore", "core_" + std::to_string(s)));
   }
 
+  // determine whether we need to enable/disable manual coproc clocking
+  DisableCoprocClock = params.find<bool>("disable_coproc_clock", 0);
 
   // setup the PAN execution contexts
   if( EnablePAN ){
@@ -418,10 +423,6 @@ RevCPU::~RevCPU(){
 
   // delete the options object
   delete Opts;
-
-  // delete the clock handler object
-  delete ClockHandler;
-
 }
 
 void RevCPU::DecodeFaultWidth(const std::string& width){
@@ -2433,7 +2434,9 @@ bool RevCPU::clockTick( SST::Cycle_t currentCycle ){
         output.verbose(CALL_INFO, 5, 0, "Closing Processor %zu at Cycle: %" PRIu64 "\n",
                        i, currentCycle);
       }
-      if(EnableCoProc && !CoProcs[i]->ClockTick(currentCycle)){
+      if(EnableCoProc &&
+         !CoProcs[i]->ClockTick(currentCycle) &&
+         !DisableCoprocClock){
         output.verbose(CALL_INFO, 5, 0, "Closing Co-Processor %zu at Cycle: %" PRIu64 "\n",
                        i, currentCycle);
 


### PR DESCRIPTION
This adds a `disable_coproc_clock` parameter that when set to `true` disables the manual clocking of coprocessor subcomponents from the top level RevCPU.  Also note that this PR fixes Issue #159 and removes the explicit deletion of the ClockHandler object as the SST-Core garbage collects this item.