### PR TITLE
Make AdvancePC only work on advancing PC past the current instruction

### DIFF
--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -281,15 +281,14 @@ public:
     }
   }
 
-  /// AdvancePC: Advance the program counter a certain number of bytes
-  template<typename T>
-  void AdvancePC(T bytes) {
+  /// AdvancePC: Advance the program counter to the next instruction
+  // Note: This does not create tracer events like SetPC() does
+  template<typename T> // Used to allow RevInst to be incomplete type right now
+  void AdvancePC(const T& Inst) {
     if ( IsRV32 ) {
-      RV32_PC += bytes;
-      TRACE_PC_WRITE(RV32_PC);
+      RV32_PC += Inst.instSize;
     }else{
-      RV64_PC += bytes;
-      TRACE_PC_WRITE(RV64_PC);
+      RV64_PC += Inst.instSize;
     }
   }
 

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -38,7 +38,7 @@ class RV32A : public RevExt {
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
     }
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -56,7 +56,7 @@ class RV32A : public RevExt {
             Inst.aq, Inst.rl,
             REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
     }
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -111,7 +111,7 @@ class RV32A : public RevExt {
     }
     // update the cost
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -58,25 +58,25 @@ class RV32D : public RevExt{
 
   static bool fmaddd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmsubd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], -R->DPF[Inst.rs3]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmsubd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::fma(-R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmaddd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = -std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -96,38 +96,38 @@ class RV32D : public RevExt{
 
   static bool fsqrtd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::sqrt(R->DPF[Inst.rs1]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::copysign(R->DPF[Inst.rs1], R->DPF[Inst.rs2]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjnd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = std::copysign(R->DPF[Inst.rs1], -R->DPF[Inst.rs2]);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjxd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     double rs1 = R->DPF[Inst.rs1], rs2 = R->DPF[Inst.rs2];
     R->DPF[Inst.rd] = std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtsd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = double{R->GetFP32(Inst.rs1)};
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, static_cast<float>(R->DPF[Inst.rs1]));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -137,19 +137,19 @@ class RV32D : public RevExt{
     memcpy(&i64, &fp64, sizeof(i64));
     bool quietNaN = (i64 & uint64_t{1}<<51) != 0;
     R->SetX(Inst.rd, fclass(fp64, quietNaN));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtdw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = static_cast<double>(R->GetX<int32_t>(Inst.rs1));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtdwu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = static_cast<double>(R->GetX<uint32_t>(Inst.rs1));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -54,26 +54,26 @@ class RV32F : public RevExt{
 
   static bool fmadds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmsubs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), -R->GetFP32(Inst.rs3)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmsubs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst)
     {
       R->SetFP32(Inst.rd, std::fmaf(-R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
-      R->AdvancePC(Inst.instSize);
+      R->AdvancePC(Inst);
       return true;
     }
 
   static bool fnmadds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, -std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -93,26 +93,26 @@ class RV32F : public RevExt{
 
   static bool fsqrts(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, sqrtf( R->GetFP32(Inst.rs1) ));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, std::copysign( R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2) ));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjns(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, std::copysign( R->GetFP32(Inst.rs1), -R->GetFP32(Inst.rs2) ));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjxs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     float rs1 = R->GetFP32(Inst.rs1), rs2 = R->GetFP32(Inst.rs2);
     R->SetFP32(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -121,7 +121,7 @@ class RV32F : public RevExt{
     float fp32 = R->GetFP32(Inst.rs1);      // The FP32 value
     memcpy(&i32, &fp32, sizeof(i32));          // Reinterpreted as int32_t
     R->SetX(Inst.rd, i32);                  // Copied to the destination register
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -130,7 +130,7 @@ class RV32F : public RevExt{
     auto i32 = R->GetX<int32_t>(Inst.rs1);  // The X register as a 32-bit value
     memcpy(&fp32, &i32, sizeof(fp32));         // Reinterpreted as float
     R->SetFP32(Inst.rd, fp32);              // Copied to the destination register
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -140,19 +140,19 @@ class RV32F : public RevExt{
     memcpy(&i32, &fp32, sizeof(i32));
     bool quietNaN = (i32 & uint32_t{1}<<22) != 0;
     R->SetX(Inst.rd, fclass(fp32, quietNaN));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtsw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, static_cast<float>(R->GetX<int32_t>(Inst.rs1)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtswu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, static_cast<float>(R->GetX<uint32_t>(Inst.rs1)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -31,7 +31,7 @@ class RV32I : public RevExt {
     // if Inst.imm == 0; this is a HINT instruction
     // this is effectively a NOP
     if( Inst.imm == 0x00 ){
-      R->AdvancePC(Inst.instSize);
+      R->AdvancePC(Inst);
       return true;
     }
     //Inst.imm = (Inst.imm & 0b011111111)*4;
@@ -254,20 +254,20 @@ class RV32I : public RevExt {
   // Standard instructions
   static bool lui(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetX(Inst.rd, static_cast<int32_t>(Inst.imm << 12));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool auipc(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     auto ui = static_cast<int32_t>(Inst.imm << 12);
     R->SetX(Inst.rd, ui + R->GetPC());
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool jal(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetX(Inst.rd, R->GetPC() + Inst.instSize);
-    R->AdvancePC(Inst.ImmSignExt(21));
+    R->SetPC(R->GetPC() + Inst.ImmSignExt(21));
     return true;
   }
 
@@ -325,13 +325,13 @@ class RV32I : public RevExt {
 
   static bool fence(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->FenceMem(F->GetHartToExec());
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;  // temporarily disabled
   }
 
   static bool fencei(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     M->FenceMem(F->GetHartToExec());
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;  // temporarily disabled
   }
 
@@ -354,42 +354,42 @@ class RV32I : public RevExt {
      * So we don't have to worry about setting `mtvec` reg
      */
 
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool ebreak(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrc(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrwi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrsi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool csrrci(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -28,7 +28,7 @@ class RV64A : public RevExt {
           &R->RV64[Inst.rd],
           Inst.aq, Inst.rl, req,
           REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -39,7 +39,7 @@ class RV64A : public RevExt {
           &R->RV64[Inst.rd],
           Inst.aq, Inst.rl,
           REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -73,7 +73,7 @@ class RV64A : public RevExt {
               req,
               flags);
 
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
 
     // update the cost
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());

--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -25,13 +25,13 @@ class RV64D : public RevExt {
 
   static bool fcvtdl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = static_cast<double>(R->GetX<int64_t>(Inst.rs1));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtdlu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->DPF[Inst.rd] = static_cast<double>(R->GetX<uint64_t>(Inst.rs1));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
@@ -39,14 +39,14 @@ class RV64D : public RevExt {
     uint64_t u64;
     memcpy(&u64, &R->DPF[Inst.rs1], sizeof(u64));
     R->SetX(Inst.rd, u64);
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmvdx(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     uint64_t u64 = R->GetX<uint64_t>(Inst.rs1);
     memcpy(&R->DPF[Inst.rs1], &u64, sizeof(double));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/include/insns/RV64F.h
+++ b/include/insns/RV64F.h
@@ -25,13 +25,13 @@ class RV64F : public RevExt {
 
   static bool fcvtsl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, static_cast<float>(R->GetX<int64_t>(Inst.rs1)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtslu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     R->SetFP32(Inst.rd, static_cast<float>(R->GetX<uint64_t>(Inst.rs1)));
-    R->AdvancePC(Inst.instSize);
+    R->AdvancePC(Inst);
     return true;
   }
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1296,7 +1296,7 @@ RevInst RevProc::DecodeInst(){
                   Inst );
   }
 
-  // Trace capture fetched instruction 
+  // Trace capture fetched instruction
   if (Tracer) Tracer->SetFetchedInsn(PC, Inst);
 
   // Stage 1a: handle the crack fault injection
@@ -1755,7 +1755,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       mem->SetTracer(Tracer);
       RegFile->SetTracer(Tracer);
       #endif
-    
+
       // execute the instruction
       if( !Ext->Execute(EToE.second, Pipeline.back().second, HartToExec, RegFile) ){
         output->fatal(CALL_INFO, -1,
@@ -2386,7 +2386,7 @@ void RevProc::ExecEcall(RevInst& inst){
     // For now, rewind the PC and keep executing the ECALL until we
     // have completed
     if(EcallStatus::SUCCESS != status){
-      RegFile->AdvancePC( -int32_t(inst.instSize) );
+      RegFile->SetPC( RegFile->GetPC() - inst.instSize );
     }
   } else {
     output->fatal(CALL_INFO, -1, "Ecall Code = %" PRIu64 " not found", EcallCode);


### PR DESCRIPTION
Make `AdvancePC()` only work on advancing `PC` past the current instruction; require using `SetPC()` for all other `PC` changes.

This prevents tracer output from excessively outputting every `PC` update, while still tracing events such as _taken_ branches and the initialization of `PC` during thread creation.

The signature of `AdvancePC()` has been changed, to prevent using it the old way, and to allow the new way to only pass `Inst` instead of `Inst.instSize`.

Also bring the documentation up to date with the latest function signatures.

**Note:**

> The template definition of `AdvancePC()` is used so that it can be defined before `RevInst`, which is defined in another header, is a _complete type_. It is predeclared only as `struct RevInst;` in `RevRegFile.h`. If the `Inst` parameter was not _dependent_ on a template parameter such as `T`, then `Inst.instSize` would require `Inst` to be a _complete type_ at the time of `AdvancePC()`'s definition. `RevInst` is defined in `RevInstTable.h`, and `RevInstTable.h` `#include`'s `RevRegFile.h` before `RevInst` is defined. `RevInstTable` depends much more on `RevRegFile.h` than the converse -- `RevRegFile.h` only depends on `RevInst` being forward-declared and allowed to be an incomplete type while `RevRegFile.h` is parsed.
