### PR TITLE
Use templatized GetFP()/SetFP() instructions for both float and double, similar to GetX()/SetX()

### DIFF
--- a/documentation/ExtensionDevelopment.md
+++ b/documentation/ExtensionDevelopment.md
@@ -345,12 +345,14 @@ There are several helper functions to make generating instruction implementation
   void AdvancePC(const RevInst& Inst);
 ```
 ```c++
-  /// GetFP32: Get the 32-bit float value of a specific FP register
-  float GetFP32(const RevFeature* F, size_t rs) const;
+  /// GetFP: Get the specified FP register cast to a specific FP type
+  template<typename T>
+  float GetFP<T>(const RevFeature* F, size_t rs) const;
 ```
 ```c++
-  /// SetFP32: Set a specific FP register to a 32-bit float value
-  void SetFP32(const RevFeature* F, size_t rd, float value);
+  /// SetFP: Set the specified FP register to a specific value
+  template<typename T>
+  void SetFP(const RevFeature* F, size_t rd, T value);
 ```
 ```c++
   /// RevInst: Sign-extended immediate value

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -57,25 +57,25 @@ class RV32D : public RevExt{
   static constexpr auto& fsd = fstore<double>;
 
   static bool fmaddd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
+    R->SetFP(Inst.rd, std::fma(R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2), R->GetFP<double>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmsubd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], -R->DPF[Inst.rs3]);
+    R->SetFP(Inst.rd, std::fma(R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2), -R->GetFP<double>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmsubd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::fma(-R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
+    R->SetFP(Inst.rd, std::fma(-R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2), R->GetFP<double>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmaddd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = -std::fma(R->DPF[Inst.rs1], R->DPF[Inst.rs2], R->DPF[Inst.rs3]);
+    R->SetFP(Inst.rd, -std::fma(R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2), R->GetFP<double>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
@@ -91,48 +91,48 @@ class RV32D : public RevExt{
   static constexpr auto& fltd = fcondop<double, std::less>;
   static constexpr auto& fled = fcondop<double, std::less_equal>;
 
-  static constexpr auto& fcvtwd  = CvtFpToInt<double,  int32_t>;
+  static constexpr auto& fcvtwd  = CvtFpToInt<double, int32_t>;
   static constexpr auto& fcvtwud = CvtFpToInt<double, uint32_t>;
 
   static bool fsqrtd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::sqrt(R->DPF[Inst.rs1]);
+    R->SetFP(Inst.rd, std::sqrt(R->GetFP<double>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::copysign(R->DPF[Inst.rs1], R->DPF[Inst.rs2]);
+    R->SetFP(Inst.rd, std::copysign(R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjnd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = std::copysign(R->DPF[Inst.rs1], -R->DPF[Inst.rs2]);
+    R->SetFP(Inst.rd, std::copysign(R->GetFP<double>(Inst.rs1), -R->GetFP<double>(Inst.rs2)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjxd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    double rs1 = R->DPF[Inst.rs1], rs2 = R->DPF[Inst.rs2];
-    R->DPF[Inst.rd] = std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2);
+    double rs1 = R->GetFP<double>(Inst.rs1), rs2 = R->GetFP<double>(Inst.rs2);
+    R->SetFP(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtsd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = double{R->GetFP32(Inst.rs1)};
+    R->SetFP(Inst.rd, double{R->GetFP<float>(Inst.rs1)});
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, static_cast<float>(R->DPF[Inst.rs1]));
+    R->SetFP(Inst.rd, static_cast<float>(R->GetFP<double>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fclassd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    double fp64 = R->DPF[Inst.rs1];
+    double fp64 = R->GetFP<double>(Inst.rs1);
     uint64_t i64;
     memcpy(&i64, &fp64, sizeof(i64));
     bool quietNaN = (i64 & uint64_t{1}<<51) != 0;
@@ -142,13 +142,13 @@ class RV32D : public RevExt{
   }
 
   static bool fcvtdw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = static_cast<double>(R->GetX<int32_t>(Inst.rs1));
+    R->SetFP(Inst.rd, static_cast<double>(R->GetX<int32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtdwu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = static_cast<double>(R->GetX<uint32_t>(Inst.rs1));
+    R->SetFP(Inst.rd, static_cast<double>(R->GetX<uint32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -53,26 +53,26 @@ class RV32F : public RevExt{
   static constexpr auto& fsw = fstore<float>;
 
   static bool fmadds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
+    R->SetFP(Inst.rd, std::fmaf(R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2), R->GetFP<float>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmsubs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), -R->GetFP32(Inst.rs3)));
+    R->SetFP(Inst.rd, std::fmaf(R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2), -R->GetFP<float>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fnmsubs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst)
     {
-      R->SetFP32(Inst.rd, std::fmaf(-R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
+      R->SetFP(Inst.rd, std::fmaf(-R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2), R->GetFP<float>(Inst.rs3)));
       R->AdvancePC(Inst);
       return true;
     }
 
   static bool fnmadds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, -std::fmaf(R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2), R->GetFP32(Inst.rs3)));
+    R->SetFP(Inst.rd, -std::fmaf(R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2), R->GetFP<float>(Inst.rs3)));
     R->AdvancePC(Inst);
     return true;
   }
@@ -92,33 +92,33 @@ class RV32F : public RevExt{
   static constexpr auto& fcvtwus = CvtFpToInt<float, uint32_t>;
 
   static bool fsqrts(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, sqrtf( R->GetFP32(Inst.rs1) ));
+    R->SetFP(Inst.rd, sqrtf( R->GetFP<float>(Inst.rs1) ));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, std::copysign( R->GetFP32(Inst.rs1), R->GetFP32(Inst.rs2) ));
+    R->SetFP(Inst.rd, std::copysign( R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2) ));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjns(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, std::copysign( R->GetFP32(Inst.rs1), -R->GetFP32(Inst.rs2) ));
+    R->SetFP(Inst.rd, std::copysign( R->GetFP<float>(Inst.rs1), -R->GetFP<float>(Inst.rs2) ));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fsgnjxs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    float rs1 = R->GetFP32(Inst.rs1), rs2 = R->GetFP32(Inst.rs2);
-    R->SetFP32(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
+    float rs1 = R->GetFP<float>(Inst.rs1), rs2 = R->GetFP<float>(Inst.rs2);
+    R->SetFP(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmvxw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     int32_t i32;
-    float fp32 = R->GetFP32(Inst.rs1);      // The FP32 value
+    float fp32 = R->GetFP<float>(Inst.rs1);      // The FP32 value
     memcpy(&i32, &fp32, sizeof(i32));          // Reinterpreted as int32_t
     R->SetX(Inst.rd, i32);                  // Copied to the destination register
     R->AdvancePC(Inst);
@@ -129,13 +129,13 @@ class RV32F : public RevExt{
     float fp32;
     auto i32 = R->GetX<int32_t>(Inst.rs1);  // The X register as a 32-bit value
     memcpy(&fp32, &i32, sizeof(fp32));         // Reinterpreted as float
-    R->SetFP32(Inst.rd, fp32);              // Copied to the destination register
+    R->SetFP(Inst.rd, fp32);              // Copied to the destination register
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fclasss(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    float fp32 = R->GetFP32(Inst.rs1);
+    float fp32 = R->GetFP<float>(Inst.rs1);
     uint32_t i32;
     memcpy(&i32, &fp32, sizeof(i32));
     bool quietNaN = (i32 & uint32_t{1}<<22) != 0;
@@ -145,13 +145,13 @@ class RV32F : public RevExt{
   }
 
   static bool fcvtsw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, static_cast<float>(R->GetX<int32_t>(Inst.rs1)));
+    R->SetFP(Inst.rd, static_cast<float>(R->GetX<int32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtswu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, static_cast<float>(R->GetX<uint32_t>(Inst.rs1)));
+    R->SetFP(Inst.rd, static_cast<float>(R->GetX<uint32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }

--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -24,20 +24,21 @@ class RV64D : public RevExt {
   static constexpr auto& fcvtlud = CvtFpToInt<double, uint64_t>;
 
   static bool fcvtdl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = static_cast<double>(R->GetX<int64_t>(Inst.rs1));
+    R->SetFP(Inst.rd, static_cast<double>(R->GetX<int64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtdlu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->DPF[Inst.rd] = static_cast<double>(R->GetX<uint64_t>(Inst.rs1));
+    R->SetFP(Inst.rd, static_cast<double>(R->GetX<uint64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fmvxd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     uint64_t u64;
-    memcpy(&u64, &R->DPF[Inst.rs1], sizeof(u64));
+    double fp = R->GetFP<double>(Inst.rs1);
+    memcpy(&u64, &fp, sizeof(u64));
     R->SetX(Inst.rd, u64);
     R->AdvancePC(Inst);
     return true;
@@ -45,7 +46,9 @@ class RV64D : public RevExt {
 
   static bool fmvdx(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     uint64_t u64 = R->GetX<uint64_t>(Inst.rs1);
-    memcpy(&R->DPF[Inst.rs1], &u64, sizeof(double));
+    double fp;
+    memcpy(&fp, &u64, sizeof(fp));
+    R->SetFP(Inst.rs1, fp);
     R->AdvancePC(Inst);
     return true;
   }

--- a/include/insns/RV64F.h
+++ b/include/insns/RV64F.h
@@ -24,13 +24,13 @@ class RV64F : public RevExt {
   static constexpr auto& fcvtlus = CvtFpToInt<float, uint64_t>;
 
   static bool fcvtsl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, static_cast<float>(R->GetX<int64_t>(Inst.rs1)));
+    R->SetFP(Inst.rd, static_cast<float>(R->GetX<int64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
   static bool fcvtslu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
-    R->SetFP32(Inst.rd, static_cast<float>(R->GetX<uint64_t>(Inst.rs1)));
+    R->SetFP(Inst.rd, static_cast<float>(R->GetX<uint64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }


### PR DESCRIPTION
This provides `GetFP()` and `SetFP()` templated functions for getting/setting the Floating-Point registers, in the same way as `GetX()`/`SetX()` get/set the integer registers.

`GetFP<float>(reg)` and `SetFP(reg, float)` replace the old `GetFP32(reg)` and `SetFP32(reg, float)`.

`GetFP<double>(reg)` and `SetFP(reg, double)` alleviate the need to access `RegFile->DPF[reg]` directly except in memory loads/stores. `RV32D` and `RV64D` no longer need to be `friend` classes to `RevRegFile`.

The new functions will allow tracing of getting/setting FP registers to be easier.