### PR TITLE
Fix coProc stall when back to back instructions are issued

### DIFF
--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1686,7 +1686,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
     // If the next instruction is our special bounce address
     // DO NOT decode it.  It will decode to a bogus instruction.
     // We do not want to retire this instruction until we're ready
-    if( (GetPC() != _PAN_FWARE_JUMP_) && (!Stalled) ){
+    if( (GetPC() != _PAN_FWARE_JUMP_) && (!Stalled) && !CoProcStallReq[HartToDecode]){
       Inst = DecodeInst();
       Inst.entry = RegFile->GetEntry();
     }

--- a/test/coproc_ex/ex1.c
+++ b/test/coproc_ex/ex1.c
@@ -17,5 +17,6 @@ int main(int argc, char **argv){
   int i = 9;
   i = i + argc;
   asm volatile("ADDIW a0, a0, 0");
+  asm volatile("ADDIW a0, a0, 0");
   return i;
 }


### PR DESCRIPTION
Quick fix to prevent instructions from being decoded when the co-processor stalls the pipeline. This prevents an infinite stall from occurring when back to back co-proc instructions are issued.  Updated the coproc test to issue multiple instructions 