### PR TITLE
Relative header fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,90 +1,58 @@
 # RevCPU Top-Level CMake
-#
-# Copyright (C) 2017-2022 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
-#
 # See LICENSE in the top level directory for licensing details
-#
 
+# Prevent in-source builds
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
   message(FATAL_ERROR "DO NOT BUILD in-tree.")
 endif()
 
+# Minimum required version of CMake and project information
 cmake_minimum_required(VERSION 3.19)
 project(revcpu CXX)
 
-
-#---------------------------------------------------------------------------
-#-- CMAKE ARGS
-#---------------------------------------------------------------------------
-# Tests requiring blas headers - Default: OFF
+# Options for enabling tests
 option(CTEST_BLAS_REQUIRED_TESTS "Enable tests which require BLAS headers" OFF)
-# Tests requiring 32-bit enabled compiler - Default: ON
 option(CTEST_MULTILIB_TESTS "Enable 32-bit tests" ON)
 
-
-
-#---------------------------------------------------------------------------
-#-- SETUP PATHS - This will be relevant as soon as SST supports sane CMake
-#---------------------------------------------------------------------------
-# Setup the path to the SST installation directory
-#set(SST_INSTALL_DIR "" CACHE PATH "SST installation directory")
+# SST Setup
+# TODO: Update when SST supports coherent CMake support
 execute_process(COMMAND sst-config --prefix
                 OUTPUT_VARIABLE SST_INSTALL_DIR
                 OUTPUT_STRIP_TRAILING_WHITESPACE
-                )
+)
 set(SST_INCLUDE_DIR "${SST_INSTALL_DIR}/include")
 if(NOT (EXISTS "${SST_INSTALL_DIR}"))
   message(FATAL_ERROR " SST_INSTALL_DIR (${SST_INSTALL_DIR}) is invalid.")
 endif()
-
 include_directories(SST_SRC ${SST_INSTALL_DIR})
-# find_package(SST REQUIRED CONFIG) # NOTE: Pipe dream for when SST has coherent CMake support
 
-#------------------------------------------------------------------------
-#-- LOAD THE CONFIGURATION
-#------------------------------------------------------------------------
-# Sanity check the path
+# SST Configuration Sanity Check
 find_program(SST sst)
-if(NOT SST)
-  message(FATAL_ERROR "No sst binary found in path")
-endif()
-
 find_program(SST_CONFIG sst-config)
-if(NOT SST_CONFIG)
-  message(FATAL_ERROR "No sst-config binary found in path")
+if(NOT SST OR NOT SST_CONFIG)
+  message(FATAL_ERROR "No SST binary or sst-config binary found in path")
 endif()
 
-set(REV_BASE "${CMAKE_CURRENT_SOURCE_DIR}")
-set(ENV{REV_BASE} "${REV_BASE}")
-message(STATUS "REV_BASE set to ${REV_BASE}")
-
-#------------------------------------------------------------------------
-#-- DERIVE SST ENV
-#------------------------------------------------------------------------
+# SST Environment Derivation
 execute_process(COMMAND sst-config --CXX
                 OUTPUT_VARIABLE CXX
                 OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-message (CXX="${CXX}")
 execute_process(COMMAND sst-config --ELEMENT_CXXFLAGS
-  OUTPUT_VARIABLE SST_CXXFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE SST_CXXFLAGS
+                OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 set(CXXFLAGS "${SST_CXXFLAGS}  -fno-stack-protector")
-message (CXXFLAGS="${CXXFLAGS}")
-
 execute_process(COMMAND sst-config --ELEMENT_LDFLAGS
-  OUTPUT_VARIABLE SST_LDFLAGS
-  OUTPUT_STRIP_TRAILING_WHITESPACE
+                OUTPUT_VARIABLE SST_LDFLAGS
+                OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 set(LDFLAGS "${SST_LDFLAGS}  -fno-stack-protector")
-message (LDFLAGS="${LDFLAGS}")
 
-#------------------------------------------------------------------------
-#-- DISASM
-#------------------------------------------------------------------------
+# Tracer Configuration
 option(REV_TRACER "Enable tracer compilation" ON)
 message (REV_TRACER="${REV_TRACER}")
 if(REV_TRACER)
@@ -99,13 +67,11 @@ if(REV_TRACER)
     add_compile_definitions("REV_USE_SPIKE")
   endif()
 else()
-   # requires cmake 3.12
+  # requires cmake 3.12
   add_compile_definitions(NO_REV_TRACER)
 endif()
 
-#------------------------------------------------------------------------
-#-- COMPILER OPTIONS
-#------------------------------------------------------------------------
+# Compiler Options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(WERROR_FLAG "")
   set(FP_MODE_FLAG "-ffp-model=strict")
@@ -118,13 +84,9 @@ set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG}
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 
-#------------------------------------------------------------------------
-#-- FIND PACKAGES
-#------------------------------------------------------------------------
 # Find SST packages
 find_package(SST REQUIRED CONFIG)
 message(STATUS "Found SST execute_process(COMMAND sst --version)")
-# message(STATUS "Using SSTConfig.cmake in: ${SST_DIR}")
 include_directories(${SST_INCLUDE_DIRS})
 add_definitions(${SST_DEFINITIONS})
 
@@ -147,46 +109,32 @@ if(BUILD_DOCUMENTATION)
     VERBATIM)
 
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/html DESTINATION share/doc)
-  # install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/man DESTINATION share/man) # NOTE: No
-
-
-
 
 endif()
-  # find_package(DOXYGEN Doxygen)
-# option(BUILD_DOCUMENTATION "Create and install the doxygen-ized API documentation (requires Doxygen)" ${DOXYGEN_FOUND})
 
-
-#------------------------------------------------------------------------
-#-- REVCPU PATHS
-#------------------------------------------------------------------------
-# RevCPU include path
-if(NOT REVCPU_INCLUDE_PATH)
-  set(REVCPU_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
-  message(STATUS "REVCPU_INCLUDE_PATH set to ${REVCPU_INCLUDE_PATH}")
+# Testing
+option(REV_ENABLE_TESTING "Enable Testing" ON)
+if(REV_ENABLE_TESTING)
+  enable_testing()
 endif()
 
-# RevCPU instructions path
-if(NOT INSTRUCTIONS_PATH)
-  set(INSTRUCTIONS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/insns")
-  message(STATUS "INSTRUCTIONS_PATH set to ${INSTRUCTIONS_PATH}")
-endif()
+# RevCPU Paths
+set(REVCPU_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE PATH "RevCPU include path")
+set(INSTRUCTIONS_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/insns" CACHE PATH "Instructions path")
 
-#------------------------------------------------------------------------
-#-- TESTING
-#------------------------------------------------------------------------
-# Enable Testing
-option(REV_ENABLE_TESTING "Enable Testing")
-enable_testing()
+# Include Directories
+include_directories(
+    ${REVCPU_INCLUDE_PATH}
+    ${CMAKE_SOURCE_DIR}/common/include
+    ${SST_INCLUDE_DIRS}
+)
 
-
+# Subdirectories
 add_subdirectory(src)
-add_subdirectory(include)
+add_subdirectory(common)
 add_subdirectory(test)
 
-#------------------------------------------------------------------------
-#-- CUSTOM COMMANDS
-#------------------------------------------------------------------------
+# Custom Commands
 add_custom_target(uninstall COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/scripts/uninstall.sh")
 
 # EOF

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,2 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/syscalls)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -8,6 +8,9 @@
 // See LICENSE in the top level directory for licensing details
 //
 //
+#ifndef _SYSCALLS_H_
+#define _SYSCALLS_H_
+
 
 #include <stdint.h>
 #include <stddef.h>
@@ -3808,3 +3811,5 @@ int rev_pthread_join( rev_pthread_t thread ){
   return rc;
 }
 #endif //SYSCALL_TYPES_ONLY
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(RevCPUSrcs
   RevThread.cc
   )
 
+add_subdirectory(../common common)
 add_library(revcpu SHARED ${RevCPUSrcs})
 target_include_directories(revcpu PRIVATE ${REVCPU_INCLUDE_PATH} PUBLIC ${SST_INSTALL_DIR}/include)
 

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevCPU.h"
+#include "RevCPU.h"
 #include "RevMem.h"
 #include "RevThread.h"
 #include <cmath>
@@ -212,7 +212,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params )
       Opts->GetMachineModel(0,diasmType); // TODO first param is core
       if (trc->SetDisassembler(diasmType))
         output.verbose(CALL_INFO, 1, 0, "Warning: tracer could not find disassembler. Using REV default\n");
-      
+
       trc->SetTraceSymbols(Loader->GetTraceSymbols());
 
       // tracer user controls - cycle on and off. Ignored unless > 0
@@ -858,7 +858,7 @@ void RevCPU::CheckForThreadStateChanges(uint32_t ProcID){
 
         // -- 3b.
         AssignedThreads.at(ProcID).erase(Thread->GetThreadID());
-        
+
         if( AssignedThreads.at(ProcID).empty() ){
           Enabled[ProcID] = false;
         }

--- a/src/RevCoProc.cc
+++ b/src/RevCoProc.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevCoProc.h"
+#include "RevCoProc.h"
 
 using namespace SST;
 using namespace RevCPU;

--- a/src/RevExt.cc
+++ b/src/RevExt.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevExt.h"
+#include "RevExt.h"
 using namespace SST::RevCPU;
 
 /// Change the FP environment

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevFeature.h"
+#include "RevFeature.h"
 #include <utility>
 #include <cstring>
 #include <string_view>

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevLoader.h"
+#include "RevLoader.h"
 #include "RevMem.h"
 
 using namespace SST::RevCPU;

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevMem.h"
-#include "../include/RevRand.h"
+#include "RevMem.h"
+#include "RevRand.h"
 #include <cstring>
 #include <cmath>
 #include <utility>

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevMemCtrl.h"
-#include "../include/RevInstTable.h"
+#include "RevMemCtrl.h"
+#include "RevInstTable.h"
 
 using namespace SST;
 using namespace SST::RevCPU;

--- a/src/RevNIC.cc
+++ b/src/RevNIC.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevNIC.h"
+#include "RevNIC.h"
 
 using namespace SST;
 using namespace RevCPU;

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevOpts.h"
+#include "RevOpts.h"
 using namespace SST::RevCPU;
 
 RevOpts::RevOpts( unsigned NumCores, unsigned NumHarts, const int Verbosity )

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevPrefetcher.h"
+#include "RevPrefetcher.h"
 using namespace SST::RevCPU;
 
 /*RevPrefetcher::~RevPrefetcher(){

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -8,7 +8,7 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "../include/RevProc.h"
+#include "RevProc.h"
 #include "RevSysCalls.cc"
 
 using namespace SST::RevCPU;

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1,6 +1,6 @@
-#include "../include/RevProc.h"
-#include "../include/RevSysCalls.h"
-#include "../../common/include/RevCommon.h"
+#include "RevProc.h"
+#include "RevSysCalls.h"
+#include "RevCommon.h"
 #include "RevMem.h"
 #include <bitset>
 #include <filesystem>

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -13,13 +13,13 @@
 #include <iomanip>
 #include <string>
 
-#include "../include/RevTracer.h"
+#include "RevTracer.h"
 #include "RevTracer.h"
 
 using namespace SST::RevCPU;
 
 RevTracer::RevTracer(std::string Name, SST::Output *o): name(Name), pOutput(o) {
-    
+
     enableQ.resize(MAX_ENABLE_Q);
     enableQ.assign(MAX_ENABLE_Q,0);
     enableQindex = 0;
@@ -109,7 +109,7 @@ void RevTracer::CheckUserControls(uint64_t cycle)
         }
         return;
     }
-    
+
     // Using a startCycle will override programmatic controls.
     if (startCycle>0) {
         bool enable = startCycle && cycle > startCycle;
@@ -180,7 +180,7 @@ void RevTracer::memWrite(uint64_t adr, size_t len,  const void *data)
 void RevTracer::memRead(uint64_t adr, size_t len, void *data)
 {
     uint64_t d = *((uint64_t*) data);
-    traceRecs.emplace_back(TraceRec_t(MemLoad,adr,len,d)); 
+    traceRecs.emplace_back(TraceRec_t(MemLoad,adr,len,d));
 }
 
 void RevTracer::pcWrite(uint32_t newpc)
@@ -207,14 +207,14 @@ void RevTracer::InstTrace(size_t cycle, unsigned id, unsigned hart, unsigned tid
 std::string RevTracer::RenderOneLiner(const std::string& fallbackMnemonic)
 {
     // Flow Control Events
-    std::stringstream ss_events; 
+    std::stringstream ss_events;
     if (events.v) {
         if (events.f.trc_ctl) {
             EVENT_SYMBOL e = outputEnabled ? EVENT_SYMBOL::TRACE_ON : EVENT_SYMBOL::TRACE_OFF;
             ss_events << event2char.at(e);
         }
     }
-    
+
     // Disassembly
     std::stringstream ss_disasm;
     #ifdef REV_USE_SPIKE
@@ -243,7 +243,7 @@ std::string RevTracer::RenderOneLiner(const std::string& fallbackMnemonic)
     os << " " << std::setfill(' ') << std::setw(2) << ss_events.str() << " " << ss_disasm.str();
 
     // register and memory read/write events preserving code ordering
-    if (traceRecs.empty()) 
+    if (traceRecs.empty())
         return os.str();
 
     // We got something, count it and render it
@@ -280,7 +280,7 @@ std::string RevTracer::RenderOneLiner(const std::string& fallbackMnemonic)
             case PcWrite:
                 // a:pc
                 uint64_t pc = r.a;
-                if ( lastPC+4 != pc ) { 
+                if ( lastPC+4 != pc ) {
                     // only render if non-sequential instruction
                     ss_rw << "pc<-0x" << std::hex << pc;
                     if (traceSymbols and (traceSymbols->find(pc) != traceSymbols->end()))
@@ -310,7 +310,7 @@ void RevTracer::fmt_reg(uint8_t r, std::stringstream& s)
 {
     #ifdef REV_USE_SPIKE
     if (r<32) {
-        s<<xpr_name[r]; // defined in disasm.h 
+        s<<xpr_name[r]; // defined in disasm.h
         return;
     }
     s << "?" << (unsigned)r;

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -14,7 +14,6 @@
 #include <string>
 
 #include "RevTracer.h"
-#include "RevTracer.h"
 
 using namespace SST::RevCPU;
 

--- a/src/librevcpu.cc
+++ b/src/librevcpu.cc
@@ -9,12 +9,12 @@
 //
 
 #include "SST.h"
-#include "../include/RevCPU.h"
+#include "RevCPU.h"
 
 namespace SST::RevCPU{
 
 char pyrevcpu[] = {
-#include "../include/pyrevcpu.inc"
+#include "pyrevcpu.inc"
   0x00};
 
 class RevCPUPyModule : public SSTElementPythonModule {


### PR DESCRIPTION
This adds a `CMakeLists.txt` file to the `common` directory and removes the need for relative paths inside of the `src` directory. 

Idk if this is the typical way to do this but it's working. 

