### PR TITLE
Add perf_stats syscall

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -323,8 +323,13 @@ struct iocb {
 };
 
 struct rev_cpuinfo {
-	uint32_t cores;
-	uint32_t harts_per_core;
+   uint32_t cores;
+   uint32_t harts_per_core;
+};
+
+struct rev_stats {
+   uint64_t cycles;
+   uint64_t instructions;
 };
 
 #ifndef SYSCALL_TYPES_ONLY
@@ -3760,6 +3765,16 @@ int rev_cpuinfo(struct rev_cpuinfo *info) {
   int rc;
   asm volatile (
     "li a7, 500 \n\t"
+    "ecall \n\t"
+    "mv %0, a0" : "=r" (rc)
+    );
+  return rc;
+}
+
+int rev_perf_stats(struct rev_stats *stats) {
+  int rc;
+  asm volatile (
+    "li a7, 501 \n\t"
     "ecall \n\t"
     "mv %0, a0" : "=r" (rc)
     );

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -566,6 +566,7 @@ private:
 
   // =============== REV specific functions
   EcallStatus ECALL_cpuinfo(RevInst& inst);                // 500, rev_cpuinfo(struct rev_cpuinfo *info);
+  EcallStatus ECALL_perf_stats(RevInst& inst);             // 501, rev_perf_stats(struct rev_stats *stats);
 
   // =============== REV pthread functions
   EcallStatus ECALL_pthread_create(RevInst& inst);         // 1000, rev_pthread_create(pthread_t *thread, const pthread_attr_t  *attr, void  *(*start_routine)(void  *), void  *arg)

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2319,7 +2319,8 @@ void RevProc::InitEcallTable(){
     { 438, &RevProc::ECALL_pidfd_getfd},            //  rev_pidfd_getfd(int pidfd, int fd, unsigned int flags)
     { 439, &RevProc::ECALL_faccessat2},             //  rev_faccessat2(int dfd, const char  *filename, int mode, int flags)
     { 440, &RevProc::ECALL_process_madvise},        //  rev_process_madvise(int pidfd, const struct iovec  *vec, size_t vlen, int behavior, unsigned int flags)
-    { 500, &RevProc::ECALL_cpuinfo},                //  rev_cpuinfo(struct cpuinfo *info)
+    { 500, &RevProc::ECALL_cpuinfo},                //  rev_cpuinfo(struct rev_cpuinfo *info)
+    { 501, &RevProc::ECALL_perf_stats},             //  rev_cpuinfo(struct rev_perf_stats *stats)
     { 1000, &RevProc::ECALL_pthread_create},        //
     { 1001, &RevProc::ECALL_pthread_join},          //
   };

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -3136,6 +3136,19 @@ EcallStatus RevProc::ECALL_cpuinfo(RevInst& inst){
   return EcallStatus::SUCCESS;
 }
 
+// 501, rev_perf_stats(struct rev_perf_stats *stats)
+EcallStatus RevProc::ECALL_perf_stats(RevInst& inst){
+  output->verbose(CALL_INFO, 2, 0, "ECALL: perf_stats called by thread %" PRIu32 "\n", GetActiveThreadID());
+  struct rev_stats rs;
+  struct rev_stats *dest = (struct rev_stats*) RegFile->GetX<uint64_t>(RevReg::a0);
+
+  rs.cycles = Stats.totalCycles;
+  rs.instructions = Retired;
+  mem->WriteMem(HartToExec, (uint64_t)dest, sizeof(struct rev_stats), &rs);
+  RegFile->SetX(RevReg::a0 ,0);
+  return EcallStatus::SUCCESS;
+}
+
 // 1000, int pthread_create(pthread_t *restrict thread,
 //                          const pthread_attr_t *restrict attr,
 //                          void *(*start_routine)(void *),

--- a/test/syscalls/perf_stats/Makefile
+++ b/test/syscalls/perf_stats/Makefile
@@ -1,0 +1,22 @@
+#
+# Makefile
+#
+# makefile: perf_stats
+#
+## See LICENSE in the top level directory for licensing details
+#
+
+.PHONY: src
+
+EXAMPLE=perf_stats
+#CC=riscv64-unknown-elf-gcc
+CC="${RVCC}"
+#ARCH=rv64g
+ARCH=rv64imafdc
+
+all: $(EXAMPLE).exe
+$(EXAMPLE).exe: $(EXAMPLE).c
+	$(CC) -march=$(ARCH) -O0 -o $(EXAMPLE).exe $(EXAMPLE).c -static
+clean:
+	rm -Rf $(EXAMPLE).exe
+#-- EOF

--- a/test/syscalls/perf_stats/perf_stats.c
+++ b/test/syscalls/perf_stats/perf_stats.c
@@ -1,0 +1,22 @@
+#include "../../../common/syscalls/syscalls.h"
+#include <stdio.h>
+#include <string.h>
+
+void print(const char *prefix, unsigned long x) {
+  char buf[256];
+  sprintf(buf, "%s%lu\n", prefix, x);
+  rev_write(STDOUT_FILENO, buf, strlen(buf));
+}
+
+int main(int argc, char *argv[]) {
+  int ret = 0;
+  struct rev_stats rs1,rs2;
+  rev_perf_stats(&rs1);
+  for(int i = 0; i < 10 * argc; i++)
+	  ret++;
+  rev_perf_stats(&rs2);
+
+  print("instructions: ", rs2.instructions - rs1.instructions);
+  print("cycles: ", rs2.cycles - rs1.cycles);
+  return ret;
+}

--- a/test/syscalls/perf_stats/rev-test.py
+++ b/test/syscalls/perf_stats/rev-test.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test-ex1.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 1,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "numHarts" : 1,                               # Number of harts per core
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : os.getenv("REV_EXE", "perf_stats.exe"),  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF


### PR DESCRIPTION
Implement a new syscall to expose internal performance counters of REV core to the application. Add an example of usage where cycles and number of instructions executed of a simple loop is measured.

Fixed a comment in cpuinfo syscall.