### PR TITLE
Simplify code; use std::vector instead of std::queue because it's faster

### DIFF
--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -131,11 +131,14 @@ public:
   RevMem& GetMem() const { return *mem; }
 
   ///< RevProc: Called by RevCPU to handle the state changes threads may have happened during this Proc's ClockTick
-  std::queue<std::unique_ptr<RevThread>> TransferThreadsThatChangedState() {
-    auto temp = std::move(ThreadsThatChangedState);
-    ThreadsThatChangedState = {}; // reset to an empty queue
-    return temp;
-}
+  auto TransferThreadsThatChangedState() {
+    return std::move(ThreadsThatChangedState);
+  }
+
+  ///< RevProc: Add
+  void AddThreadsThatChangedState(std::unique_ptr<RevThread>&& thread){
+    ThreadsThatChangedState.push_back(std::move(thread));
+  }
 
   ///< RevProc: SpawnThread creates a new thread and returns its ThreadID
   void CreateThread(uint32_t NewTid, uint64_t fn, void* arg);
@@ -233,7 +236,7 @@ private:
   std::function<uint32_t()> GetNewThreadID;
 
   // If a given assigned thread experiences a change of state, it sets the corresponding bit
-  std::queue<std::unique_ptr<RevThread>> ThreadsThatChangedState; ///< RevProc: used to signal to RevCPU that the thread assigned to HART has changed state
+  std::vector<std::unique_ptr<RevThread>> ThreadsThatChangedState; ///< RevProc: used to signal to RevCPU that the thread assigned to HART has changed state
 
   SST::Output *output;                   ///< RevProc: output handler
   std::unique_ptr<RevFeature> featureUP; ///< RevProc: feature handler

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -772,9 +772,7 @@ void RevCPU::UpdateThreadAssignments(uint32_t ProcID){
 void RevCPU::HandleThreadStateChangesForProc(uint32_t ProcID){
   // Handle any thread state changes for this core
   // NOTE: At this point we handle EVERY thread that changed state every cycle
-  auto ThreadsThatChangedState = Procs[ProcID]->TransferThreadsThatChangedState();
-  while( !ThreadsThatChangedState.empty() ){
-    std::unique_ptr<RevThread> Thread = std::move(ThreadsThatChangedState.front());
+  for( auto& Thread : Procs[ProcID]->TransferThreadsThatChangedState()){
     uint32_t ThreadID = Thread->GetID();
     // Handle the thread that changed state based on the new state
     switch ( Thread->GetState() ) {
@@ -824,10 +822,7 @@ void RevCPU::HandleThreadStateChangesForProc(uint32_t ProcID){
     if( Procs[ProcID]->HasNoWork() ){
       Enabled[ProcID] = false;
     }
-    // Remove the pointer to the thread as it was handled
-    ThreadsThatChangedState.pop();
   }
-  return;
 }
 
 void RevCPU::InitMainThread(uint32_t MainThreadID, const uint64_t StartAddr){

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1907,7 +1907,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       HartsClearToExecute[HartToDecodeID] = false;
       HartsClearToDecode[HartToDecodeID] = false;
       IdleHarts.set(HartToDecodeID);
-      ThreadsThatChangedState.emplace(std::move(ActiveThread));
+      AddThreadsThatChangedState(std::move(ActiveThread));
     }
 
     if( HartToExecID != _REV_INVALID_HART_ID_ && !IdleHarts[HartToExecID]
@@ -1919,7 +1919,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
       HartsClearToExecute[HartToExecID] = false;
       HartsClearToDecode[HartToExecID] = false;
       IdleHarts[HartToExecID] = true;
-      ThreadsThatChangedState.emplace(std::move(ActiveThread));
+      AddThreadsThatChangedState(std::move(ActiveThread));
     }
   }
 
@@ -2000,7 +2000,7 @@ void RevProc::CreateThread(uint32_t NewTID, uint64_t firstPC, void* arg){
                                 std::move(NewThreadRegFile));
 
   // Add new thread to this vector so the RevCPU will add and schedule it
-  ThreadsThatChangedState.emplace(std::move(NewThread));
+  AddThreadsThatChangedState(std::move(NewThread));
 
   return;
 }

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -3170,7 +3170,7 @@ EcallStatus RevProc::ECALL_pthread_join(RevInst& inst){
     BlockedThread->SetWaitingToJoinTID(RegFile->GetX<uint64_t>(RevReg::a0));
 
     // Signal to RevCPU this thread is has changed state
-    ThreadsThatChangedState.emplace(std::move(BlockedThread));
+    AddThreadsThatChangedState(std::move(BlockedThread));
 
     // Output the ecall buf
 


### PR DESCRIPTION
This uses `std::vector` instead of `std::queue` because it's marginally faster for `big_loop` (I tested `std::deque`, `std::queue`, `std::list`, `std:forward_list`, and `std::vector`). `std::vector` has amortized `O(1)` insertions, and for this project, we just need fast insertions and fast traversal over the entire list when we're ready.

A function was added, to add members to the `ThreadsThatChangedState`. That was originally to facilitate trying out different containers, which need slightly different insertion methods. But it looks better to have a single function to do it rather than to make assumptions about the container and manipulate it in several places.

When using `ThreadsThatChangedState` list, we transfer the `std::vector<std::unique_ptr<...>>` by using `std::move` in `TransferThreadsThatChangedState()`. Moves like this automatically `empty()` the original data, so after calling that function, the `ThreadsThatChangedState` vector is empty.

We iterate over the transferred list using range-based `for (auto& Thread : ...)`, and might use `std::move` to transfer some of the `std::unique_ptr` `Thread` items to somewhere else.

Any `std::unique_ptr` in the list which were not transferred out, and the `std::vector` list itself, are automatically destroyed at the end of the function, so we don't have to manually delete them or destroy the list. We already transferred ownership when we called `TransferThreadsThatChangedState()`.

VTune says that 16% of `big_loop` time is being spent in `RevCPU::HandleThreadStateChangesForProc`, but even after these changes, I don't see a big speedup. This makes me suspect that debug builds, or builds with verbose logging, are causing the slowdown. I'll try the VTune run again with verbose logging, and see if there are any logging hotspots.