### PR TITLE
Fix Formatted Output of MemOp enum class

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <ostream>
 #include <type_traits>
 
 #ifndef _REV_NUM_REGS_
@@ -80,6 +81,8 @@ enum class MemOp : uint8_t {
   MemOpFENCE       = 8,
   MemOpAMO         = 9,
 };
+
+std::ostream& operator<<(std::ostream& os, MemOp op);
 
 inline uint64_t make_lsq_hash(uint16_t destReg, RevRegClass regType, unsigned HartID){
   return static_cast<uint64_t>(regType) << (16 + 8) | static_cast<uint64_t>(destReg) << 16 | HartID;

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -11,11 +11,25 @@
 #include "RevMemCtrl.h"
 #include "RevInstTable.h"
 
-using namespace SST;
-using namespace SST::RevCPU;
-using namespace SST::Interfaces;
+namespace SST::RevCPU{
 
 #define IS_ATOMIC 0x3FE00000
+
+std::ostream& operator<<(std::ostream& os, MemOp op){
+  switch(op){
+    case MemOp::MemOpREAD:        return os << "MemOpREAD";
+    case MemOp::MemOpWRITE:       return os << "MemOpWRITE";
+    case MemOp::MemOpFLUSH:       return os << "MemOpFLUSH";
+    case MemOp::MemOpREADLOCK:    return os << "MemOpREADLOCK";
+    case MemOp::MemOpWRITEUNLOCK: return os << "MemOpWRITEUNLOCK";
+    case MemOp::MemOpLOADLINK:    return os << "MemOpLOADLINK";
+    case MemOp::MemOpSTORECOND:   return os << "MemOpSTORECOND";
+    case MemOp::MemOpCUSTOM:      return os << "MemOpCUSTOM";
+    case MemOp::MemOpFENCE:       return os << "MemOpFENCE";
+    case MemOp::MemOpAMO:         return os << "MemOpAMO";
+  }
+  return os;
+}
 
 // ---------------------------------------------------------------
 // RevMemOp
@@ -1652,4 +1666,5 @@ void RevBasicMemCtrl::RevStdMemHandlers::handle(StandardMem::InvNotify* ev){
   Ctrl->handleInvResp(ev);
 }
 
+} // namespace SST::RevCPU
 // EOF


### PR DESCRIPTION
When `_REV_DEBUG_` is defined, some `MemOp` values are outputted. There was no method defined for streaming `MemOp`, which is a `enum class`. In the past it was probably an unscoped enum (`enum` non-`class`) which could be implicit converted to integer and printed as such.

I've added an `operator<<` to output `MemOp` by the tag names.

Unfortunately argument-dependent lookup will not work if the function is defined in a namespace higher in scope than the argument type's definition (`MemOp`). 

`RevMemCtrl.cc` was `using namespace SST::RevCPU;` but was defining everything in global namespace. I have switched it to defining inside `namespace SST:RevCPU { }`, so that it can see argument-dependent lookup from types defined in `SST::RevCPU`. There were a couple of `using namespace SST;` declarations which are redundant now that we define inside of `SST::RevCPU`, which already has other `SST` namespaces imported or searched automatically as parent namespaces.