### PR TITLE
Memoize instruction decoding

### DIFF
--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -118,6 +118,7 @@ struct RevInst {
   uint32_t cost       = 0; ///< RevInst: the cost to execute this instruction, in clock cycles
   unsigned entry      = 0; ///< RevInst: Where to find this instruction in the InstTables
   uint16_t hart       = 0; ///< RevInst: What hart is this inst being executed on
+  bool isCoProcInst   = 0; ///< RevInst: whether instruction is coprocessor instruction
 
   explicit RevInst() = default; // prevent aggregate initialization
 

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -651,7 +651,7 @@ private:
   bool PrefetchInst();
 
   /// RevProc: decode the instruction at the current PC
-  RevInst DecodeInst();
+  RevInst FetchAndDecodeInst();
 
   /// RevProc: decode a particular instruction opcode
   RevInst DecodeInst(uint32_t Inst) const;

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -653,6 +653,9 @@ private:
   /// RevProc: decode the instruction at the current PC
   RevInst DecodeInst();
 
+  /// RevProc: decode a particular instruction opcode
+  RevInst DecodeInst(uint32_t Inst) const;
+
   /// RevProc: decode a compressed instruction
   RevInst DecodeCompressed(uint32_t Inst) const;
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1258,7 +1258,7 @@ bool RevProc::PrefetchInst(){
   return sfetch->IsAvail(PC);
 }
 
-RevInst RevProc::DecodeInst(){
+RevInst RevProc::FetchAndDecodeInst(){
   uint32_t Inst = 0x00ul;
   uint64_t PC   = GetPC();
   bool Fetched  = false;
@@ -1657,7 +1657,7 @@ bool RevProc::ClockTick( SST::Cycle_t currentCycle ){
     }
 
     if( !Stalled && !CoProcStallReq[HartToDecodeID]){
-      Inst = DecodeInst();
+      Inst = FetchAndDecodeInst();
       Inst.entry = RegFile->GetEntry();
     }
 


### PR DESCRIPTION
I ran experiments, and while there is a slight improvement in `big_loop` when `std::unordered_map` is used to memoize decodings, it's not big enough to justify the complication of adding memoization at this time.

`CMAKE_BUILD_TYPE=Release`

|  Memoization off    |            |
|------------|------------------|
| big_loop  |       6.1 seconds |
| full test suite | 96.6 seconds |
| Extreme NOP test case (25M unique NOP instructions) | 20.1 seconds |
| 1,000 iterations of 10,000 unique NOP instructions |  10.7 seconds |

| Memoization on, `std::map`, `std::map::try_emplace` | |
|------------|------------------|
| big_loop |         5.4 seconds |
| full test suite |  95.9 seconds |
| Extreme NOP test case (25M unique instructions) |  37.3 seconds |
| 1,000 iterations of 10,000 unique NOP instructions |  11.9 seconds |

| Memoization on, `std::unordered_map`, `std::unordered_map::try_emplace` |  |
|------------|------------------|
| big_loop |         5.5 seconds |
| full test suite | 95.3 seconds |
| Extreme NOP test case (25M unique NOP instructions) | 25.5 seconds |
| 1,000 iterations of 10,000 unique NOP instructions | 10.6 seconds |

This change makes the decoding of instructions a _pure_ function which can be memoized in the future if decoding becomes a hotspot. This change:
- Splits `RevProc::DecodeInst()` into `RevProc::DecodeInst()` and `RevProc::DecodeInst(uint32_t)`.
 -- `RevProc::DecodeInst()` performs what it does already, calling `RevProc::DecodeInst(uint32_t)` for the pure instruction decoding part, which can be memoized if necessary
 -- `RevProc::DecodeInst(uint32_t)` is a _pure_ function which decodes a `uint32_t` instruction, compressed or not, into a `RevInst` payload struct. It returns the existing `RevProc::DecodeCompressed(uint32_t)` for compressed instructions.
- Avoids writing to `RevRegFile` inside decoding functions, leaving it until the end of `RevProc::DecodeInst()`.
- Sets a `isCoProcInst` field inside `RevInst` so that memoization or other functions know that the instruction was decoded as a coprocessor instruction, so that if it is cached and occurs again, the coprocessor instruction can be re-issued.

-----

This is a small change to memoize instruction decoding, which profiling shows is taking up a significant amount of time. Which makes sense, because if you're going through all of the mechanics of decoding instructions during every simulated clock, that adds up.

Also it separates the mechanics of decoding a particular instruction, from the rest of the work (prefetching, tracing, fault injection, setting up the `RevRegFile`, etc.). IMO the decoding of an instruction should be functionally separated from the preparation of executing an instruction.

It needs A/B performance testing and possibly more tuning, before it's justified to be merged.

Right now it makes SST go into an infinite loop because of an unknown issue I can't get my head around. It's probably a simple mistake. It seems to happen when switching between compressed and uncompressed instructions, although nothing should have been changed regarding the decoding of either. All this change does, is to add memoization to decoding, and delays the setting of `RevRegFile` until _after_ the possibly-memoized-decoding.

One thing which has changed, is that `cost` is set in `RevInst` instead of `RevRegFile`, and is only set in `RevRegFile` at the very end of decoding (copying `cost` from `RevInst` to `RevRegFile`). I don't think the decoder should be changing `RevRegFile` while it's in the middle of decoding an instruction. It should be _pure_, having no side effects and not depending on outside variables which can change during a run, so that a decoding can be memoized.

(I don't understand why the decoder did not already set the `cost` field in `RevInst` -- that field already existed -- and set the `cost` field in `RevRegFile` instead.)

As an experiment, I tried adding a `reg_cost` field to `RevInst` and setting that instead of `RevInst::cost`, and then copying it to `RevRegFile::cost` at the end of the decoding, but that did not fix it.

This change also delays the clearing of  `RevRegFile::trigger` until at the end of decoding, but I would not expect that change to affect anything.

The `Entry` field is somewhat confusing to me -- is it purely for debugging purposes? This change preserves it.

I don't know exactly how coprocessor instructions are handled, and as coprocessor instructions are not bound by the RISC-V spec, they can be expected to do anything -- even **HCF** -- so I am very conservative; if a coprocessor instruction is suspected/verified during decoding, a new `isCoProcInst` field in `RevInst` is set to `true`. If memoization finds a previously decoded instruction is a coprocessor instruction, it reruns the "coprocessor instruction issuer" just like it did when it first decoded it, while running the memoized `NOP` on the host.

Even if performance testing determines that memoizing is not a net gain, I think we should reorganize decoding so that it does not modify `RevRegFile` except at the highest level, and we should try to pack everything obtained during decoding into `RevInst`, so that decoding becomes a _pure_ function which can _potentially_ be memoized.

Right now there is an `if(1)` statement in the code, which currently turns off memoization. I need to figure out why the code, even without memoization enabled, causes SST to go into an infinite loop, before I can test it with memoization turned on. Eventually I plan to make memoization a Python variable setting, so that one can turn off decoding memoization if, for example, they are debugging decoding.
