### PR TITLE
Clean up RevFlag

### DIFF
--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -45,8 +45,6 @@
 #define _REVMEM_BASE_ 0x00000000
 #endif
 
-#define REVMEM_FLAGS(x) (static_cast<StandardMem::Request::flags_t>(x))
-
 #define _STACK_SIZE_ (size_t{1024*1024})
 
 namespace SST::RevCPU{
@@ -150,12 +148,12 @@ public:
 
   /// RevMem: write to the target memory location with the target flags
   bool WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void *Data,
-                 StandardMem::Request::flags_t flags );
+                 RevFlag flags );
 
   /// RevMem: read data from the target memory location
   bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void *Target,
                 const MemReq& req,
-                StandardMem::Request::flags_t flags);
+                RevFlag flags);
 
   /// RevMem: DEPRECATED: read data from the target memory location
   [[deprecated("Simple RevMem interfaces have been deprecated")]]
@@ -176,7 +174,7 @@ public:
   template <typename T>
   bool ReadVal( unsigned Hart, uint64_t Addr, T *Target,
                 const MemReq& req,
-                StandardMem::Request::flags_t flags){
+                RevFlag flags){
     return ReadMem(Hart, Addr, sizeof(T), Target, req, flags);
   }
 
@@ -184,7 +182,7 @@ public:
   template <typename T>
   bool LR( unsigned Hart, uint64_t Addr, T *Target,
            uint8_t aq, uint8_t rl, const MemReq& req,
-           StandardMem::Request::flags_t flags){
+           RevFlag flags){
     return LRBase(Hart, Addr, sizeof(T), Target, aq, rl, req, flags);
   }
 
@@ -192,7 +190,7 @@ public:
   template <typename T>
   bool SC( unsigned Hart, uint64_t Addr, T *Data, T *Target,
            uint8_t aq, uint8_t rl,
-           StandardMem::Request::flags_t flags){
+           RevFlag flags){
     return SCBase(Hart, Addr, sizeof(T), Data, Target, aq, rl, flags);
   }
 
@@ -200,7 +198,7 @@ public:
   template <typename T>
   bool AMOVal( unsigned Hart, uint64_t Addr, T *Data, T *Target,
                const MemReq& req,
-               StandardMem::Request::flags_t flags){
+               RevFlag flags){
     return AMOMem(Hart, Addr, sizeof(T), Data, Target, req, flags);
   }
 
@@ -230,17 +228,17 @@ public:
   /// RevMem: Add a memory reservation for the target address
   bool LRBase(unsigned Hart, uint64_t Addr, size_t Len,
               void *Data, uint8_t aq, uint8_t rl, const MemReq& req,
-              StandardMem::Request::flags_t flags);
+              RevFlag flags);
 
   /// RevMem: Clear a memory reservation for the target address
   bool SCBase(unsigned Hart, uint64_t Addr, size_t Len,
               void *Data, void *Target, uint8_t aq, uint8_t rl,
-              StandardMem::Request::flags_t flags);
+              RevFlag flags);
 
   /// RevMem: Initiated an AMO request
   bool AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
               void *Data, void *Target, const MemReq& req,
-              StandardMem::Request::flags_t flags);
+              RevFlag flags);
 
   /// RevMem: Initiates a future operation [RV64P only]
   bool SetFuture( uint64_t Addr );

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -28,14 +28,14 @@ class RV32A : public RevExt {
       M->LR(F->GetHartToExecID(), uint64_t(R->RV32[Inst.rs1]),
             &R->RV32[Inst.rd],
             Inst.aq, Inst.rl, req,
-            REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
+            RevFlag::F_SEXT32);
     }else{
       req.Set(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExecID(), MemOp::MemOpAMO, true, R->GetMarkLoadComplete());
       R->LSQueue->insert({make_lsq_hash(req.DestReg, req.RegType, req.Hart), req});
       M->LR(F->GetHartToExecID(), R->RV64[Inst.rs1],
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rd]),
             Inst.aq, Inst.rl, req,
-            REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
+            RevFlag::F_SEXT64);
     }
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
     R->AdvancePC(Inst);
@@ -48,28 +48,28 @@ class RV32A : public RevExt {
             &R->RV32[Inst.rs2],
             &R->RV32[Inst.rd],
             Inst.aq, Inst.rl,
-            REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT32));
+            RevFlag::F_SEXT32);
     }else{
       M->SC(F->GetHartToExecID(), R->RV64[Inst.rs1],
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rs2]),
             reinterpret_cast<uint32_t*>(&R->RV64[Inst.rd]),
             Inst.aq, Inst.rl,
-            REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
+            RevFlag::F_SEXT64);
     }
     R->AdvancePC(Inst);
     return true;
   }
 
-  template<RevCPU::RevFlag F_AMO>
+  template<RevFlag F_AMO>
   static bool amooper(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     uint32_t flags = static_cast<uint32_t>(F_AMO);
 
     if( Inst.aq && Inst.rl){
-      flags |= uint32_t(RevCPU::RevFlag::F_AQ) | uint32_t(RevCPU::RevFlag::F_RL);
+      flags |= uint32_t(RevFlag::F_AQ) | uint32_t(RevFlag::F_RL);
     }else if( Inst.aq ){
-      flags |= uint32_t(RevCPU::RevFlag::F_AQ);
+      flags |= uint32_t(RevFlag::F_AQ);
     }else if( Inst.rl ){
-      flags |= uint32_t(RevCPU::RevFlag::F_RL);
+      flags |= uint32_t(RevFlag::F_RL);
     }
 
     MemReq req;
@@ -89,9 +89,9 @@ class RV32A : public RevExt {
                 &R->RV32[Inst.rs2],
                 &R->RV32[Inst.rd],
                 req,
-                flags);
+                RevFlag{flags});
     }else{
-      flags |= uint32_t(RevCPU::RevFlag::F_SEXT64);
+      flags |= uint32_t(RevFlag::F_SEXT64);
       req.Set(R->RV64[Inst.rs1],
               Inst.rd,
               RevRegClass::RegGPR,
@@ -107,7 +107,7 @@ class RV32A : public RevExt {
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rs2]),
                 reinterpret_cast<int32_t*>(&R->RV64[Inst.rd]),
                 req,
-                flags);
+                RevFlag{flags});
     }
     // update the cost
     R->cost += M->RandCost(F->GetMinCost(), F->GetMaxCost());
@@ -115,15 +115,15 @@ class RV32A : public RevExt {
     return true;
   }
 
-  static constexpr auto& amoswapw = amooper<RevCPU::RevFlag::F_AMOSWAP>;
-  static constexpr auto& amoaddw  = amooper<RevCPU::RevFlag::F_AMOADD>;
-  static constexpr auto& amoxorw  = amooper<RevCPU::RevFlag::F_AMOXOR>;
-  static constexpr auto& amoandw  = amooper<RevCPU::RevFlag::F_AMOAND>;
-  static constexpr auto& amoorw   = amooper<RevCPU::RevFlag::F_AMOOR>;
-  static constexpr auto& amominw  = amooper<RevCPU::RevFlag::F_AMOMIN>;
-  static constexpr auto& amomaxw  = amooper<RevCPU::RevFlag::F_AMOMAX>;
-  static constexpr auto& amominuw = amooper<RevCPU::RevFlag::F_AMOMINU>;
-  static constexpr auto& amomaxuw = amooper<RevCPU::RevFlag::F_AMOMAXU>;
+  static constexpr auto& amoswapw = amooper<RevFlag::F_AMOSWAP>;
+  static constexpr auto& amoaddw  = amooper<RevFlag::F_AMOADD>;
+  static constexpr auto& amoxorw  = amooper<RevFlag::F_AMOXOR>;
+  static constexpr auto& amoandw  = amooper<RevFlag::F_AMOAND>;
+  static constexpr auto& amoorw   = amooper<RevFlag::F_AMOOR>;
+  static constexpr auto& amominw  = amooper<RevFlag::F_AMOMIN>;
+  static constexpr auto& amomaxw  = amooper<RevFlag::F_AMOMAX>;
+  static constexpr auto& amominuw = amooper<RevFlag::F_AMOMINU>;
+  static constexpr auto& amomaxuw = amooper<RevFlag::F_AMOMAXU>;
 
   // ----------------------------------------------------------------------
   //

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -27,7 +27,7 @@ class RV64A : public RevExt {
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rd],
           Inst.aq, Inst.rl, req,
-          REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
+          RevFlag::F_SEXT64);
     R->AdvancePC(Inst);
     return true;
   }
@@ -38,22 +38,22 @@ class RV64A : public RevExt {
           &R->RV64[Inst.rs2],
           &R->RV64[Inst.rd],
           Inst.aq, Inst.rl,
-          REVMEM_FLAGS(RevCPU::RevFlag::F_SEXT64));
+          RevFlag::F_SEXT64);
     R->AdvancePC(Inst);
     return true;
   }
 
   /// Atomic Memory Operations
-  template<RevCPU::RevFlag F_AMO>
+  template<RevFlag F_AMO>
   static bool amooperd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
     uint32_t flags = static_cast<uint32_t>(F_AMO);
 
     if( Inst.aq && Inst.rl ){
-      flags |= uint32_t(RevCPU::RevFlag::F_AQ) | uint32_t(RevCPU::RevFlag::F_RL);
+      flags |= uint32_t(RevFlag::F_AQ) | uint32_t(RevFlag::F_RL);
     }else if( Inst.aq ){
-      flags |= uint32_t(RevCPU::RevFlag::F_AQ);
+      flags |= uint32_t(RevFlag::F_AQ);
     }else if( Inst.rl ){
-      flags |= uint32_t(RevCPU::RevFlag::F_RL);
+      flags |= uint32_t(RevFlag::F_RL);
     }
 
     MemReq req(R->RV64[Inst.rs1],
@@ -71,7 +71,7 @@ class RV64A : public RevExt {
               &R->RV64[Inst.rs2],
               &R->RV64[Inst.rd],
               req,
-              flags);
+              RevFlag{flags});
 
     R->AdvancePC(Inst);
 
@@ -80,15 +80,15 @@ class RV64A : public RevExt {
     return true;
   }
 
-  static constexpr auto& amoaddd  = amooperd<RevCPU::RevFlag::F_AMOADD>;
-  static constexpr auto& amoswapd = amooperd<RevCPU::RevFlag::F_AMOSWAP>;
-  static constexpr auto& amoxord  = amooperd<RevCPU::RevFlag::F_AMOXOR>;
-  static constexpr auto& amoandd  = amooperd<RevCPU::RevFlag::F_AMOAND>;
-  static constexpr auto& amoord   = amooperd<RevCPU::RevFlag::F_AMOOR>;
-  static constexpr auto& amomind  = amooperd<RevCPU::RevFlag::F_AMOMIN>;
-  static constexpr auto& amomaxd  = amooperd<RevCPU::RevFlag::F_AMOMAX>;
-  static constexpr auto& amominud = amooperd<RevCPU::RevFlag::F_AMOMINU>;
-  static constexpr auto& amomaxud = amooperd<RevCPU::RevFlag::F_AMOMAXU>;
+  static constexpr auto& amoaddd  = amooperd<RevFlag::F_AMOADD>;
+  static constexpr auto& amoswapd = amooperd<RevFlag::F_AMOSWAP>;
+  static constexpr auto& amoxord  = amooperd<RevFlag::F_AMOXOR>;
+  static constexpr auto& amoandd  = amooperd<RevFlag::F_AMOAND>;
+  static constexpr auto& amoord   = amooperd<RevFlag::F_AMOOR>;
+  static constexpr auto& amomind  = amooperd<RevFlag::F_AMOMIN>;
+  static constexpr auto& amomaxd  = amooperd<RevFlag::F_AMOMAX>;
+  static constexpr auto& amominud = amooperd<RevFlag::F_AMOMINU>;
+  static constexpr auto& amomaxud = amooperd<RevFlag::F_AMOMAXU>;
 
   // ----------------------------------------------------------------------
   //

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -109,7 +109,7 @@ bool RevMem::StatusFuture(uint64_t Addr){
 bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Target, uint8_t aq, uint8_t rl,
                     const MemReq& req,
-                    StandardMem::Request::flags_t flags){
+                    RevFlag flags){
   for( auto it = LRSC.begin(); it != LRSC.end(); ++it ){
     if( (Hart == std::get<LRSC_HART>(*it)) &&
         (Addr == std::get<LRSC_ADDR>(*it)) ){
@@ -155,7 +155,7 @@ bool RevMem::LRBase(unsigned Hart, uint64_t Addr, size_t Len,
 
 bool RevMem::SCBase(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Data, void *Target, uint8_t aq, uint8_t rl,
-                    StandardMem::Request::flags_t flags){
+                    RevFlag flags){
   std::vector<std::tuple<unsigned, uint64_t, unsigned, uint64_t*>>::iterator it;
 
   for( it = LRSC.begin(); it != LRSC.end(); ++it ){
@@ -543,7 +543,7 @@ bool RevMem::FenceMem(unsigned Hart){
 bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
                     void *Data, void *Target,
                     const MemReq& req,
-                    StandardMem::Request::flags_t flags){
+                    RevFlag flags){
 #ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -591,7 +591,7 @@ bool RevMem::AMOMem(unsigned Hart, uint64_t Addr, size_t Len,
 }
 
 bool RevMem::WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void *Data,
-                       StandardMem::Request::flags_t flags){
+                       RevFlag flags){
 #ifdef _REV_DEBUG_
   std::cout << "Writing " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -710,7 +710,7 @@ bool RevMem::WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void *Dat
                              (uint64_t)(BaseMem),
                              Len,
                              DataMem,
-                             0x00);
+                             RevFlag::F_NONE);
     }else{
       for( unsigned i=0; i< (Len-span); i++ ){
         BaseMem[i] = DataMem[i];
@@ -724,7 +724,7 @@ bool RevMem::WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void *Dat
                              (uint64_t)(BaseMem),
                              Len,
                              &(DataMem[Cur]),
-                             0x00);
+                             RevFlag::F_NONE);
     }else{
       // write the memory using the internal RevMem model
       unsigned Cur = (Len-span);
@@ -746,7 +746,7 @@ bool RevMem::WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void *Dat
                              (uint64_t)(BaseMem),
                              Len,
                              DataMem,
-                             0x00);
+                             RevFlag::F_NONE);
     }else{
       // write the memory using the internal RevMem model
       for( unsigned i=0; i<Len; i++ ){
@@ -797,7 +797,7 @@ bool RevMem::ReadMem( uint64_t Addr, size_t Len, void *Data ){
 }
 
 bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
-                     const MemReq& req, StandardMem::Request::flags_t flags){
+                     const MemReq& req, RevFlag flags){
 #ifdef _REV_DEBUG_
   std::cout << "NEW READMEM: Reading " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -13,8 +13,7 @@
 
 namespace SST::RevCPU{
 
-#define IS_ATOMIC 0x3FE00000
-
+/// MemOp: Formatted Output
 std::ostream& operator<<(std::ostream& os, MemOp op){
   switch(op){
     case MemOp::MemOpREAD:        return os << "MemOpREAD";
@@ -35,7 +34,7 @@ std::ostream& operator<<(std::ostream& os, MemOp op){
 // RevMemOp
 // ---------------------------------------------------------------
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
-                   MemOp Op, StandardMem::Request::flags_t flags )
+                   MemOp Op, RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false),
     Op(Op), CustomOpc(0),
     SplitRqst(1), flags(flags), target(nullptr), procReq(){
@@ -43,7 +42,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                    uint32_t Size, void *target,
-                   MemOp Op, StandardMem::Request::flags_t flags )
+                   MemOp Op, RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false),
     Op(Op), CustomOpc(0),
     SplitRqst(1), flags(flags), target(target), procReq(){
@@ -51,7 +50,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    char *buffer, MemOp Op,
-                   StandardMem::Request::flags_t flags )
+                   RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
     SplitRqst(1), flags(flags), target(nullptr), procReq(){
@@ -62,7 +61,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    char *buffer, void *target, MemOp Op,
-                   StandardMem::Request::flags_t flags )
+                   RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
     SplitRqst(1), flags(flags), target(target), procReq(){
@@ -73,7 +72,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    std::vector<uint8_t> buffer, MemOp Op,
-                   StandardMem::Request::flags_t flags )
+                   RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size),
     Inv(false), Op(Op), CustomOpc(0),
     SplitRqst(1), membuf(buffer), flags(flags), target(nullptr), procReq(){
@@ -81,7 +80,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
                    void *target, unsigned CustomOpc, MemOp Op,
-                   StandardMem::Request::flags_t flags )
+                   RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false), Op(Op),
     CustomOpc(CustomOpc), SplitRqst(1), flags(flags),
     target(target), procReq(){
@@ -90,7 +89,7 @@ RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 RevMemOp::RevMemOp(unsigned Hart, uint64_t Addr, uint64_t PAddr,
                    uint32_t Size, char *buffer,
                    unsigned CustomOpc, MemOp Op,
-                   StandardMem::Request::flags_t flags )
+                   RevFlag flags )
   : Hart(Hart), Addr(Addr), PAddr(PAddr), Size(Size), Inv(false), Op(Op),
     CustomOpc(CustomOpc), SplitRqst(1), flags(flags), target(nullptr), procReq(){
   for(uint32_t i = 0; i< Size; i++){
@@ -229,7 +228,7 @@ bool RevBasicMemCtrl::sendFLUSHRequest(unsigned Hart,
                                        uint64_t PAddr,
                                        uint32_t Size,
                                        bool Inv,
-                                       StandardMem::Request::flags_t flags){
+                                       RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size,
@@ -246,7 +245,7 @@ bool RevBasicMemCtrl::sendREADRequest(unsigned Hart,
                                       uint32_t Size,
                                       void *target,
                                       const MemReq& req,
-                                      StandardMem::Request::flags_t flags){
+                                      RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, target,
@@ -262,7 +261,7 @@ bool RevBasicMemCtrl::sendWRITERequest(unsigned Hart,
                                        uint64_t PAddr,
                                        uint32_t Size,
                                        char *buffer,
-                                       StandardMem::Request::flags_t flags){
+                                       RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, buffer,
@@ -279,7 +278,7 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
                                      char *buffer,
                                      void *target,
                                      const MemReq& req,
-                                     StandardMem::Request::flags_t flags){
+                                     RevFlag flags){
 
   if( Size == 0 )
     return true;
@@ -287,7 +286,7 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
   // Check to see if our flags contain an atomic request
   // The flag hex value is a bitwise OR of all the RevFlag
   // AMO enums
-  if( (flags & IS_ATOMIC) == 0 ){
+  if( !RevFlagHas(flags, RevFlag::F_ATOMIC) ){
     // not an atomic request
     return true;
   }
@@ -311,20 +310,20 @@ bool RevBasicMemCtrl::sendAMORequest(unsigned Hart,
   rqstQ.push_back(Op);
 
   // now we record the stat for the particular AMO
-  static constexpr std::pair<RevCPU::RevFlag, RevBasicMemCtrl::MemCtrlStats> table[] = {
-    { RevCPU::RevFlag::F_AMOADD,  RevBasicMemCtrl::MemCtrlStats::AMOAddPending  },
-    { RevCPU::RevFlag::F_AMOXOR,  RevBasicMemCtrl::MemCtrlStats::AMOXorPending  },
-    { RevCPU::RevFlag::F_AMOAND,  RevBasicMemCtrl::MemCtrlStats::AMOAndPending  },
-    { RevCPU::RevFlag::F_AMOOR,   RevBasicMemCtrl::MemCtrlStats::AMOOrPending   },
-    { RevCPU::RevFlag::F_AMOMIN,  RevBasicMemCtrl::MemCtrlStats::AMOMinPending  },
-    { RevCPU::RevFlag::F_AMOMAX,  RevBasicMemCtrl::MemCtrlStats::AMOMaxPending  },
-    { RevCPU::RevFlag::F_AMOMIN,  RevBasicMemCtrl::MemCtrlStats::AMOMinuPending },
-    { RevCPU::RevFlag::F_AMOMAXU, RevBasicMemCtrl::MemCtrlStats::AMOMaxuPending },
-    { RevCPU::RevFlag::F_AMOSWAP, RevBasicMemCtrl::MemCtrlStats::AMOSwapPending },
+  static constexpr std::pair<RevFlag, RevBasicMemCtrl::MemCtrlStats> table[] = {
+    { RevFlag::F_AMOADD,  RevBasicMemCtrl::MemCtrlStats::AMOAddPending  },
+    { RevFlag::F_AMOXOR,  RevBasicMemCtrl::MemCtrlStats::AMOXorPending  },
+    { RevFlag::F_AMOAND,  RevBasicMemCtrl::MemCtrlStats::AMOAndPending  },
+    { RevFlag::F_AMOOR,   RevBasicMemCtrl::MemCtrlStats::AMOOrPending   },
+    { RevFlag::F_AMOMIN,  RevBasicMemCtrl::MemCtrlStats::AMOMinPending  },
+    { RevFlag::F_AMOMAX,  RevBasicMemCtrl::MemCtrlStats::AMOMaxPending  },
+    { RevFlag::F_AMOMIN,  RevBasicMemCtrl::MemCtrlStats::AMOMinuPending },
+    { RevFlag::F_AMOMAXU, RevBasicMemCtrl::MemCtrlStats::AMOMaxuPending },
+    { RevFlag::F_AMOSWAP, RevBasicMemCtrl::MemCtrlStats::AMOSwapPending },
   };
 
-  for(auto [flag, stat] : table){
-    if(flags & uint32_t(flag)){
+  for(auto& [flag, stat] : table){
+    if( RevFlagHas(flags, flag) ){
       recordStat(stat, 1);
       break;
     }
@@ -338,7 +337,7 @@ bool RevBasicMemCtrl::sendREADLOCKRequest(unsigned Hart,
                                           uint32_t Size,
                                           void *target,
                                           const MemReq& req,
-                                          StandardMem::Request::flags_t flags){
+                                          RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, target,
@@ -354,7 +353,7 @@ bool RevBasicMemCtrl::sendWRITELOCKRequest(unsigned Hart,
                                            uint64_t PAddr,
                                            uint32_t Size,
                                            char *buffer,
-                                           StandardMem::Request::flags_t flags){
+                                           RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, buffer,
@@ -368,7 +367,7 @@ bool RevBasicMemCtrl::sendLOADLINKRequest(unsigned Hart,
                                           uint64_t Addr,
                                           uint64_t PAddr,
                                           uint32_t Size,
-                                          StandardMem::Request::flags_t flags){
+                                          RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size,
@@ -383,7 +382,7 @@ bool RevBasicMemCtrl::sendSTORECONDRequest(unsigned Hart,
                                            uint64_t PAddr,
                                            uint32_t Size,
                                            char *buffer,
-                                           StandardMem::Request::flags_t flags){
+                                           RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, buffer,
@@ -399,7 +398,7 @@ bool RevBasicMemCtrl::sendCUSTOMREADRequest(unsigned Hart,
                                             uint32_t Size,
                                             void *target,
                                             unsigned Opc,
-                                            StandardMem::Request::flags_t flags){
+                                            RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, target, Opc,
@@ -415,7 +414,7 @@ bool RevBasicMemCtrl::sendCUSTOMWRITERequest(unsigned Hart,
                                              uint32_t Size,
                                              char *buffer,
                                              unsigned Opc,
-                                             StandardMem::Request::flags_t flags){
+                                             RevFlag flags){
   if( Size == 0 )
     return true;
   RevMemOp *Op = new RevMemOp(Hart, Addr, PAddr, Size, buffer, Opc,
@@ -427,7 +426,7 @@ bool RevBasicMemCtrl::sendCUSTOMWRITERequest(unsigned Hart,
 
 bool RevBasicMemCtrl::sendFENCE(unsigned Hart){
   RevMemOp *Op = new RevMemOp(Hart, 0x00ull, 0x00ull, 0x00,
-                              MemOp::MemOpFENCE, 0x00);
+                              MemOp::MemOpFENCE, RevFlag::F_NONE);
   rqstQ.push_back(Op);
   recordStat(RevBasicMemCtrl::MemCtrlStats::FencePending, 1);
   return true;
@@ -605,7 +604,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
   Interfaces::StandardMem::Request *rqst = nullptr;
   unsigned NumLines = getNumCacheLines(op->getAddr(),
                                        op->getSize());
-  StandardMem::Request::flags_t TmpFlags = op->getStdFlags();
+  RevFlag TmpFlags = op->getStdFlags();
 
 #ifdef _REV_DEBUG_
   std::cout << "building caching mem request for addr=0x"
@@ -704,7 +703,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
 #endif
     rqst = new Interfaces::StandardMem::Read(op->getAddr(),
                                              (uint64_t)(BaseCacheLineSize),
-                                             TmpFlags);
+                                             (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -722,7 +721,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     rqst = new Interfaces::StandardMem::Write(op->getAddr(),
                                               (uint64_t)(BaseCacheLineSize),
                                               newBuf,
-                                              TmpFlags);
+                                              (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -734,7 +733,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
                                                   (uint64_t)(BaseCacheLineSize),
                                                   op->getInv(),
                                                   (uint64_t)(BaseCacheLineSize),
-                                                  TmpFlags);
+                                                  (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -744,7 +743,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
   case MemOp::MemOpREADLOCK:
     rqst = new Interfaces::StandardMem::ReadLock(op->getAddr(),
                                                  (uint64_t)(BaseCacheLineSize),
-                                                 TmpFlags);
+                                                 (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -760,7 +759,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
                                                     (uint64_t)(BaseCacheLineSize),
                                                     newBuf,
                                                     false,
-                                                    TmpFlags);
+                                                    (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -770,7 +769,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
   case MemOp::MemOpLOADLINK:
     rqst = new Interfaces::StandardMem::LoadLink(op->getAddr(),
                                                  (uint64_t)(BaseCacheLineSize),
-                                                 TmpFlags);
+                                                 (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -785,7 +784,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     rqst = new Interfaces::StandardMem::StoreConditional(op->getAddr(),
                                                          (uint64_t)(BaseCacheLineSize),
                                                          newBuf,
-                                                         TmpFlags);
+                                                         (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -794,7 +793,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     break;
   case MemOp::MemOpCUSTOM:
     // TODO: need more support for custom memory ops
-    rqst = new Interfaces::StandardMem::CustomReq(nullptr, TmpFlags);
+    rqst = new Interfaces::StandardMem::CustomReq(nullptr, (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -830,7 +829,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     case MemOp::MemOpREAD:
       rqst = new Interfaces::StandardMem::Read(newBase,
                                                newSize,
-                                               TmpFlags);
+                                               (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -845,7 +844,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
       rqst = new Interfaces::StandardMem::Write(newBase,
                                                 newSize,
                                                 newBuf,
-                                                TmpFlags);
+                                                (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -857,7 +856,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
                                                     newSize,
                                                     op->getInv(),
                                                     newSize,
-                                                    TmpFlags);
+                                                    (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -867,7 +866,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     case MemOp::MemOpREADLOCK:
       rqst = new Interfaces::StandardMem::ReadLock(newBase,
                                                    newSize,
-                                                   TmpFlags);
+                                                   (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -883,7 +882,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
                                                       newSize,
                                                       newBuf,
                                                       false,
-                                                      TmpFlags);
+                                                      (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -893,7 +892,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
     case MemOp::MemOpLOADLINK:
       rqst = new Interfaces::StandardMem::LoadLink(newBase,
                                                    newSize,
-                                                   TmpFlags);
+                                                   (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -908,7 +907,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
       rqst = new Interfaces::StandardMem::StoreConditional(newBase,
                                                            newSize,
                                                            newBuf,
-                                                           TmpFlags);
+                                                           (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -917,7 +916,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
       break;
     case MemOp::MemOpCUSTOM:
       // TODO: need more support for custom memory ops
-      rqst = new Interfaces::StandardMem::CustomReq(nullptr, TmpFlags);
+      rqst = new Interfaces::StandardMem::CustomReq(nullptr, (StandardMem::Request::flags_t)TmpFlags);
       requests.push_back(rqst->getID());
       outstanding[rqst->getID()] = op;
       memIface->send(rqst);
@@ -938,20 +937,20 @@ bool RevBasicMemCtrl::buildCacheMemRqst(RevMemOp *op,
 }
 
 bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
-                                      StandardMem::Request::flags_t TmpFlags){
+                                      RevFlag TmpFlags){
   Interfaces::StandardMem::Request *rqst = nullptr;
 
 #ifdef _REV_DEBUG_
   std::cout << "building raw mem request for addr=0x"
             << std::hex << op->getAddr() << std::dec
-            << "; Flags = 0x" << std::hex << TmpFlags << std::dec << std::endl;
+            << "; Flags = 0x" << std::hex << (StandardMem::Request::flags_t)TmpFlags << std::dec << std::endl;
 #endif
 
   switch(op->getOp()){
   case MemOp::MemOpREAD:
     rqst = new Interfaces::StandardMem::Read(op->getAddr(),
                                              (uint64_t)(op->getSize()),
-                                             TmpFlags);
+                                             (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -962,7 +961,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
     rqst = new Interfaces::StandardMem::Write(op->getAddr(),
                                               (uint64_t)(op->getSize()),
                                               op->getBuf(),
-                                              TmpFlags);
+                                              (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -974,7 +973,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
                                                   (uint64_t)(op->getSize()),
                                                   op->getInv(),
                                                   (uint64_t)(op->getSize()),
-                                                  TmpFlags);
+                                                  (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -984,7 +983,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
   case MemOp::MemOpREADLOCK:
     rqst = new Interfaces::StandardMem::ReadLock(op->getAddr(),
                                                  (uint64_t)(op->getSize()),
-                                                 TmpFlags);
+                                                 (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -996,7 +995,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
                                                     (uint64_t)(op->getSize()),
                                                     op->getBuf(),
                                                     false,
-                                                    TmpFlags);
+                                                    (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -1006,7 +1005,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
   case MemOp::MemOpLOADLINK:
     rqst = new Interfaces::StandardMem::LoadLink(op->getAddr(),
                                                  (uint64_t)(op->getSize()),
-                                                 TmpFlags);
+                                                 (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -1017,7 +1016,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
     rqst = new Interfaces::StandardMem::StoreConditional(op->getAddr(),
                                                          (uint64_t)(op->getSize()),
                                                          op->getBuf(),
-                                                         TmpFlags);
+                                                         (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -1026,7 +1025,7 @@ bool RevBasicMemCtrl::buildRawMemRqst(RevMemOp *op,
     break;
   case MemOp::MemOpCUSTOM:
     // TODO: need more support for custom memory ops
-    rqst = new Interfaces::StandardMem::CustomReq(nullptr, TmpFlags);
+    rqst = new Interfaces::StandardMem::CustomReq(nullptr, (StandardMem::Request::flags_t)TmpFlags);
     requests.push_back(rqst->getID());
     outstanding[rqst->getID()] = op;
     memIface->send(rqst);
@@ -1052,8 +1051,10 @@ bool RevBasicMemCtrl::buildStandardMemRqst(RevMemOp *op,
 #ifdef _REV_DEBUG_
   std::cout << "building mem request for addr=0x"
             << std::hex << op->getAddr() << std::dec
-            << "; flags = 0x" << std::hex << op->getFlags() << std::dec << std::endl;
-  if( op->getAddr() % lineSize )
+            << "; flags = 0x" << std::hex << (StandardMem::Request::flags_t)op->getFlags() << std::dec << std::endl;
+  if( !lineSize )
+    std::cout << "WARNING: lineSize == 0!" << std::endl;
+  else if( op->getAddr() % lineSize )
     std::cout << "WARNING: address is not cache aligned!" << std::endl;
   if( !op->isCacheable() )
     std::cout << "WARNING: operation is not cache-able!" << std::endl;
@@ -1077,7 +1078,7 @@ bool RevBasicMemCtrl::buildStandardMemRqst(RevMemOp *op,
   // ALWAYS 1 and we dispatch a single memory requests per
   // RevMemOp
   // ---------------------------------------------------------
-  StandardMem::Request::flags_t TmpFlags;
+  RevFlag TmpFlags;
   if( (hasCache) &&
       (op->isCacheable()) ){
     // cache is enabled and we want to cache the request
@@ -1104,9 +1105,9 @@ bool RevBasicMemCtrl::isAQ(unsigned Slot, unsigned Hart){
 
   // search all preceding slots for an AMO from the same Hart
   for( unsigned i = 0; i < Slot; i++ ){
-    if( (rqstQ[i]->getFlags() & IS_ATOMIC) != 0 &&
+    if( RevFlagHas(rqstQ[i]->getFlags(), RevFlag::F_ATOMIC) &&
         rqstQ[i]->getHart() == rqstQ[Slot]->getHart() ){
-      if( (rqstQ[i]->getFlags() & uint32_t(RevCPU::RevFlag::F_AQ)) != 0 ){
+      if( RevFlagHas(rqstQ[i]->getFlags(), RevFlag::F_AQ) ){
         // this implies that we found a preceding request in the request queue
         // that was 1) an AMO and 2) came from the same HART as 'slot'
         // and 3) had the AQ flag set;
@@ -1126,8 +1127,8 @@ bool RevBasicMemCtrl::isRL(unsigned Slot, unsigned Hart){
     return false;
   }
 
-  if( (rqstQ[Slot]->getFlags() & IS_ATOMIC) != 0 &&
-      (rqstQ[Slot]->getFlags() & uint32_t(RevCPU::RevFlag::F_RL)) != 0 ){
+  if( RevFlagHas(rqstQ[Slot]->getFlags(), RevFlag::F_ATOMIC) &&
+      RevFlagHas(rqstQ[Slot]->getFlags(), RevFlag::F_RL) ){
     // this is an AMO, check to see if there are other ops from the same
     // HART in flight
     for( unsigned i = 0; i < Slot; i++ ){
@@ -1235,22 +1236,22 @@ bool RevBasicMemCtrl::processNextRqst(unsigned &t_max_loads,
 }
 
 void RevBasicMemCtrl::handleFlagResp(RevMemOp *op){
-  StandardMem::Request::flags_t flags = op->getFlags();
+  RevFlag flags = op->getFlags();
   unsigned bits = 8 * op->getSize();
 
-  if( flags & uint32_t(RevCPU::RevFlag::F_SEXT32) ){
+  if( RevFlagHas(flags, RevFlag::F_SEXT32) ){
     uint32_t *target = static_cast<uint32_t*>(op->getTarget());
     *target = SignExt(*target, bits);
-  }else if( flags & uint32_t(RevCPU::RevFlag::F_SEXT64) ){
+  }else if( RevFlagHas(flags, RevFlag::F_SEXT64) ){
     uint64_t *target = static_cast<uint64_t*>(op->getTarget());
     *target = SignExt(*target, bits);
-  }else if( flags & uint32_t(RevCPU::RevFlag::F_ZEXT32) ){
+  }else if( RevFlagHas(flags, RevFlag::F_ZEXT32) ){
     uint32_t *target = static_cast<uint32_t*>(op->getTarget());
     *target = ZeroExt(*target, bits);
-  }else if( flags & uint32_t(RevCPU::RevFlag::F_ZEXT64) ){
+  }else if( RevFlagHas(flags, RevFlag::F_ZEXT64) ){
     uint64_t *target = static_cast<uint64_t*>(op->getTarget());
     *target = ZeroExt(*target, bits);
-  }else if( flags & uint32_t(RevCPU::RevFlag::F_BOXNAN) ){
+  }else if( RevFlagHas(flags, RevFlag::F_BOXNAN) ){
     double *target = static_cast<double*>(op->getTarget());
     BoxNaN(target, target);
   }
@@ -1352,7 +1353,7 @@ void RevBasicMemCtrl::handleReadResp(StandardMem::ReadResp* ev){
 void RevBasicMemCtrl::performAMO(std::tuple<unsigned,
                                  char *,
                                  void *,
-                                 StandardMem::Request::flags_t,
+                                 RevFlag,
                                  RevMemOp *,
                                  bool> Entry){
   RevMemOp *Tmp = std::get<AMOTABLE_MEMOP>(Entry);
@@ -1361,7 +1362,7 @@ void RevBasicMemCtrl::performAMO(std::tuple<unsigned,
   }
   void *Target = Tmp->getTarget();
 
-  StandardMem::Request::flags_t flags = Tmp->getFlags();
+  RevFlag flags = Tmp->getFlags();
   std::vector<uint8_t> buffer = Tmp->getBuf();
   std::vector<uint8_t> tempT;
 

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -178,7 +178,7 @@ void RevPrefetcher::Fill(uint64_t Addr){
     mem->ReadVal( feature->GetHartToExecID(), Addr+(y*4),
                   &iStack[x][y],
                   req,
-                  REVMEM_FLAGS(0x00) );
+                  RevFlag::F_NONE );
   }
 }
 

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -51,7 +51,7 @@ EcallStatus RevProc::EcallLoadAndParseString(RevInst& inst,
                   straddr + EcallState.string.size(),
                   EcallState.buf.data(),
                   req,
-                  REVMEM_FLAGS(0));
+                   RevFlag::F_NONE);
       EcallState.bytesRead = 1;
       DependencySet(HartToExecID, 10, false);
       rtval = EcallStatus::CONTINUE;
@@ -763,22 +763,22 @@ EcallStatus RevProc::ECALL_write(RevInst& inst){
     if(nleft >= 8){
       mem->ReadVal(HartToExecID, addr+EcallState.string.size(),
                    reinterpret_cast<uint64_t*>(EcallState.buf.data()),
-                   req, REVMEM_FLAGS(0));
+                   req, RevFlag::F_NONE);
       EcallState.bytesRead = 8;
     } else if(nleft >= 4){
       mem->ReadVal(HartToExecID, addr+EcallState.string.size(),
                    reinterpret_cast<uint32_t*>(EcallState.buf.data()),
-                   req, REVMEM_FLAGS(0));
+                   req, RevFlag::F_NONE);
       EcallState.bytesRead = 4;
     } else if(nleft >= 2){
       mem->ReadVal(HartToExecID, addr+EcallState.string.size(),
                    reinterpret_cast<uint16_t*>(EcallState.buf.data()),
-                   req, REVMEM_FLAGS(0));
+                   req, RevFlag::F_NONE);
       EcallState.bytesRead = 2;
     } else{
       mem->ReadVal(HartToExecID, addr+EcallState.string.size(),
                    reinterpret_cast<uint8_t*>(EcallState.buf.data()),
-                   req, REVMEM_FLAGS(0));
+                   req, RevFlag::F_NONE);
       EcallState.bytesRead = 1;
     }
 
@@ -2085,7 +2085,7 @@ EcallStatus RevProc::ECALL_clone(RevInst& inst){
  //    // struct clone_args args;  // So while clone_args is a whole struct, we appear to be only
  //                                // using the 1st uint64, so that's all we're going to fetch
  //   uint64_t* args = reinterpret_cast<uint64_t*>(ECALL.buf.data());
- //   mem->ReadVal<uint64_t>(HartToExecID, CloneArgsAddr, args, inst.hazard, REVMEM_FLAGS(0x00));
+ //   mem->ReadVal<uint64_t>(HartToExecID, CloneArgsAddr, args, inst.hazard, RevFlag::F_NONE);
  //   ECALL.bytesRead = sizeof(*args);
  //   rtval = EcallStatus::CONTINUE;
  // }else{
@@ -2941,7 +2941,7 @@ EcallStatus RevProc::ECALL_clone3(RevInst& inst){
  //    // struct clone_args args;  // So while clone_args is a whole struct, we appear to be only
  //                                // using the 1st uint64, so that's all we're going to fetch
  //   uint64_t* args = reinterpret_cast<uint64_t*>(ECALL.buf.data());
- //   mem->ReadVal<uint64_t>(HartToExecID, CloneArgsAddr, args, inst.hazard, REVMEM_FLAGS(0x00));
+ //   mem->ReadVal<uint64_t>(HartToExecID, CloneArgsAddr, args, inst.hazard, RevFlag::F_NONE);
  //   ECALL.bytesRead = sizeof(*args);
  //   rtval = EcallStatus::CONTINUE;
  // }else{
@@ -3163,7 +3163,7 @@ EcallStatus RevProc::ECALL_pthread_create(RevInst& inst){
   CreateThread(NewTID,
                NewThreadPC, reinterpret_cast<void*>(ArgPtr));
 
-  mem->WriteMem(HartToExecID, tidAddr, sizeof(NewTID), &NewTID, REVMEM_FLAGS(0x00));
+  mem->WriteMem(HartToExecID, tidAddr, sizeof(NewTID), &NewTID, RevFlag::F_NONE);
   return EcallStatus::SUCCESS;
 }
 


### PR DESCRIPTION
Clean up the `enum class` `RevFlag`
- Add a `F_NONE` enum tag for no flags, and use it instead of `0`, `static_cast<RevFlag>(0)`, `REVMEM_FLAGS(0)`, etc.
- Ensure that `RevFlag` has the same underlying type as `StandardMem::Request::flags_t` since they are used interchangeably
- Add casts from `RevFlag` to `StandardMem::Request::flags_t`  when calling SST or outputting streaming IO
- Remove the `IS_ATOMIC` macro constant, replacing it with a `F_ATOMIC` `enum` tag which is computed from the `AMO` tags (except acquire and release)
- Add a `RevFlagHas()` function for testing for the existence of flags, such as `RevFlagHas(flag, RevFlag:F_AQ)`
- Remove the unused function `IsAMOOp()`, to be replaced with `RevFlagHas(flag, RevFlag::F_ATOMIC)` (this is more succinct and avoids the need to cast everywhere a test is made)
- Remove unnecessary `RevCPU::` and similar namespace specifiers such as in `RevCPU::RevFlag::F_AMOADD`, since we're already inside `SST::RevCPU` namespace
- Use `RevFlag` parameters and variables in all Rev functions, instead of `uint32_t` or `StandardMem::Request::flags_t`
- Remove the `REVMEM_FLAGS()` macro which is just a static cast to `RevFlag` -- use `RevFlag::_name_` instead of casting
- Guard against a division-by-zero error when `_REV_DEBUG_` is defined
- Simplify some loops which test flags, by using structured bindings instead of `std::pair::first` and `std::pair::second`