### PR TITLE
Fix mmap test

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -2876,7 +2876,7 @@ int rev_execve(const char  *filename, const char  *const  *argv, const char  *co
   return rc;
 }
 
-int rev_mmap(uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset){
+uint64_t rev_mmap(uint64_t addr, size_t length, int prot, int flags, int fd, off_t offset){
   int rc;
   asm volatile (
     "li a7, 222 \n\t"

--- a/test/syscalls/munmap/munmap.c
+++ b/test/syscalls/munmap/munmap.c
@@ -10,17 +10,17 @@ int main() {
 
   // Create an anonymous memory mapping
   addr = (uint64_t*)rev_mmap(0,                 // Let rev choose the address
-              N * sizeof(uint32_t),
+              N * sizeof(uint64_t),
               PROT_READ | PROT_WRITE | PROT_EXEC, // RWX permissions
               MAP_PRIVATE | MAP_ANONYMOUS, // Not shared, anonymous
               -1,                   // No file descriptor because it's an anonymous mapping
               0);                   // No offset, irrelevant for anonymous mappings
 
 
-  for( uint32_t i=0; i< N; i++ ){
+  for( uint64_t i=0; i< N; i++ ){
     addr[i] = i;
   }
-  for (uint32_t i = 0; i < N ; i++){
+  for (uint64_t i = 0; i < N ; i++){
         assert(addr[i] == i);
   }
 


### PR DESCRIPTION
Size parameter in mmap test was smaller than it should be. Change rev_mmap declaration to return 64bit value, so allocating memory above 2GB is possible.