### PR TITLE
Fixing the off-by-one bug in mmap

### DIFF
--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -2244,7 +2244,7 @@ EcallStatus RevProc::ECALL_mmap(RevInst& inst){
 
   if( !addr ){
     // If address is NULL... We add it to MemSegs.end()->getTopAddr()+1
-    addr = mem->AllocMem(size+1);
+    addr = mem->AllocMem(size);
     // addr = mem->AddMemSeg(Size);
   } else {
     // We were passed an address... try to put a segment there.


### PR DESCRIPTION
I was an idiot when making the mmap code. there was an unnecessary `+1` in the call to `AllocMem`. This should fix it. 