### PR TITLE
Fix fmv.d.x instruction implementation.

### DIFF
--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -48,7 +48,7 @@ class RV64D : public RevExt {
     uint64_t u64 = R->GetX<uint64_t>(Inst.rs1);
     double fp;
     memcpy(&fp, &u64, sizeof(fp));
-    R->SetFP(Inst.rs1, fp);
+    R->SetFP(Inst.rd, fp);
     R->AdvancePC(Inst);
     return true;
   }


### PR DESCRIPTION
Instruction was incorrectly loading rs1 GPR value back to rs1 GPR register.
Now it is correctly loading rs1 GPR value into rd FPR register.