### PR TITLE
Load/Store Queue Update - allowing multiple loads per register target

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -126,7 +126,6 @@ struct MemReq{
     return std::make_pair( LSQHash(), *this );
   }
 
-private:
   uint64_t    Addr          = _INVALID_ADDR_;
   uint16_t    DestReg       = 0;
   RevRegClass RegType       = RevRegClass::RegUNKNOWN;
@@ -136,9 +135,6 @@ private:
 
   std::function<void(const MemReq&)> MarkLoadCompleteFunc = nullptr;
 
-  friend class RevTracer;
-  friend class RevMem;
-  friend class RevProc;
 };//struct MemReq
 
 // Enum for tracking the state of a RevThread.

--- a/include/RevHart.h
+++ b/include/RevHart.h
@@ -26,7 +26,7 @@ class RevHart{
   EcallState Ecall{};
 
   ///< RevHart: Pointer to the Proc's LSQueue
-  const std::shared_ptr<std::unordered_map<uint64_t, MemReq>>& LSQueue;
+  const std::shared_ptr<std::multimap<uint64_t, MemReq>>& LSQueue;
 
   ///< RevHart: Pointer to the Proc's MarkLoadCompleteFunc
   std::function<void(const MemReq&)> MarkLoadCompleteFunc;
@@ -40,7 +40,7 @@ class RevHart{
 
 public:
   ///< RevHart: Constructor
-  RevHart(unsigned ID, const std::shared_ptr<std::unordered_map<uint64_t, MemReq>>& LSQueue,
+  RevHart(unsigned ID, const std::shared_ptr<std::multimap<uint64_t, MemReq>>& LSQueue,
           std::function<void(const MemReq&)> MarkLoadCompleteFunc)
     : ID(ID), LSQueue(LSQueue), MarkLoadCompleteFunc(std::move(MarkLoadCompleteFunc)) {}
 

--- a/include/RevHart.h
+++ b/include/RevHart.h
@@ -26,7 +26,7 @@ class RevHart{
   EcallState Ecall{};
 
   ///< RevHart: Pointer to the Proc's LSQueue
-  const std::shared_ptr<std::multimap<uint64_t, MemReq>>& LSQueue;
+  const std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>>& LSQueue;
 
   ///< RevHart: Pointer to the Proc's MarkLoadCompleteFunc
   std::function<void(const MemReq&)> MarkLoadCompleteFunc;
@@ -40,7 +40,7 @@ class RevHart{
 
 public:
   ///< RevHart: Constructor
-  RevHart(unsigned ID, const std::shared_ptr<std::multimap<uint64_t, MemReq>>& LSQueue,
+  RevHart(unsigned ID, const std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>>& LSQueue,
           std::function<void(const MemReq&)> MarkLoadCompleteFunc)
     : ID(ID), LSQueue(LSQueue), MarkLoadCompleteFunc(std::move(MarkLoadCompleteFunc)) {}
 

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -43,7 +43,7 @@ public:
   bool IsAvail(uint64_t Addr);
 
   /// RevPrefetcher: Mark Instruction fill as complete
-  void MarkInstructionLoadComplete(MemReq& req);
+  void MarkInstructionLoadComplete(const MemReq& req);
 
 private:
   RevMem *mem;                                ///< RevMem object

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -31,7 +31,7 @@ public:
   RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth,
                 std::shared_ptr<std::multimap<uint64_t, MemReq>> lsq,
                 std::function<void(const MemReq&)> func)
-    : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func){}
+    : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func), OutstandingFetchQ(){}
 
   /// RevPrefetcher: destructor
   ~RevPrefetcher() = default;
@@ -42,6 +42,9 @@ public:
   /// RevPrefetcher: determines in the target instruction is already cached in a stream
   bool IsAvail(uint64_t Addr);
 
+  /// RevPrefetcher: Mark Instruction fill as complete
+  void MarkInstructionLoadComplete(MemReq& req);
+
 private:
   RevMem *mem;                                ///< RevMem object
   RevFeature *feature;                        ///< RevFeature object
@@ -50,6 +53,7 @@ private:
   std::vector<std::vector<uint32_t>> iStack; ///< Vector of instruction vectors
   std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue;
   std::function<void(const MemReq&)> MarkLoadAsComplete;
+  std::vector<MemReq> OutstandingFetchQ;
 
   /// fills a missed stream cache instruction
   void Fill(uint64_t Addr);

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -29,7 +29,7 @@ class RevPrefetcher{
 public:
   /// RevPrefetcher: constructor
   RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth,
-                std::shared_ptr<std::multimap<uint64_t, MemReq>> lsq,
+                std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> lsq,
                 std::function<void(const MemReq&)> func)
     : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func), OutstandingFetchQ(){}
 
@@ -51,7 +51,7 @@ private:
   unsigned depth;                             ///< Depth of each prefetcher stream
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<std::vector<uint32_t>> iStack; ///< Vector of instruction vectors
-  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue;
+  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> LSQueue;
   std::function<void(const MemReq&)> MarkLoadAsComplete;
   std::vector<MemReq> OutstandingFetchQ;
 

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -29,7 +29,7 @@ class RevPrefetcher{
 public:
   /// RevPrefetcher: constructor
   RevPrefetcher(RevMem *Mem, RevFeature *Feature, unsigned Depth,
-                std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq,
+                std::shared_ptr<std::multimap<uint64_t, MemReq>> lsq,
                 std::function<void(const MemReq&)> func)
     : mem(Mem), feature(Feature), depth(Depth), LSQueue(lsq), MarkLoadAsComplete(func){}
 
@@ -48,7 +48,7 @@ private:
   unsigned depth;                             ///< Depth of each prefetcher stream
   std::vector<uint64_t> baseAddr;             ///< Vector of base addresses for each stream
   std::vector<std::vector<uint32_t>> iStack; ///< Vector of instruction vectors
-  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue;
+  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue;
   std::function<void(const MemReq&)> MarkLoadAsComplete;
 
   /// fills a missed stream cache instruction

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -169,7 +169,7 @@ public:
   void MarkLoadComplete(const MemReq& req);
 
   ///< RevProc: Get pointer to Load / Store queue used to track memory operations
-  std::shared_ptr<std::multimap<uint64_t, MemReq>> GetLSQueue() const { return LSQueue; }
+  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> GetLSQueue() const { return LSQueue; }
 
   ///< RevProc: Add a co-processor to the RevProc
   void SetCoProc(RevCoProc* coproc);
@@ -268,7 +268,7 @@ private:
   RevProcStats StatsTotal{};             ///< RevProc: collection of total performance stats
   std::unique_ptr<RevPrefetcher> sfetch; ///< RevProc: stream instruction prefetcher
 
-  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
+  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
   TimeConverter* timeConverter;          ///< RevProc: Time converter for RTC
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecodeID RegFile

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -26,13 +26,14 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <queue>
 #include <string>
 #include <sys/xattr.h>
 #include <time.h>
 #include <tuple>
-#include <unordered_map>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -169,7 +170,7 @@ public:
   void MarkLoadComplete(const MemReq& req);
 
   ///< RevProc: Get pointer to Load / Store queue used to track memory operations
-  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> GetLSQueue() const { return LSQueue; }
+  std::shared_ptr<std::multimap<uint64_t, MemReq>> GetLSQueue() const { return LSQueue; }
 
   ///< RevProc: Add a co-processor to the RevProc
   void SetCoProc(RevCoProc* coproc);
@@ -268,7 +269,7 @@ private:
   RevProcStats StatsTotal{};             ///< RevProc: collection of total performance stats
   std::unique_ptr<RevPrefetcher> sfetch; ///< RevProc: stream instruction prefetcher
 
-  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
+  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue; ///< RevProc: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
   TimeConverter* timeConverter;          ///< RevProc: Time converter for RTC
 
   RevRegFile* RegFile = nullptr; ///< RevProc: Initial pointer to HartToDecodeID RegFile

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -26,13 +26,13 @@
 #include <iostream>
 #include <list>
 #include <map>
-#include <unordered_map>
 #include <memory>
 #include <queue>
 #include <string>
 #include <sys/xattr.h>
 #include <time.h>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/include/RevProc.h
+++ b/include/RevProc.h
@@ -33,7 +33,6 @@
 #include <sys/xattr.h>
 #include <time.h>
 #include <tuple>
-#include <map>
 #include <utility>
 #include <vector>
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -92,7 +92,7 @@ private:
 
   FCSR fcsr{}; ///< RevRegFile: FCSR
 
-  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue{};
+  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> LSQueue{};
   std::function<void(const MemReq&)> MarkLoadCompleteFunc{};
 
   union{  // Anonymous union. We zero-initialize the largest member
@@ -169,7 +169,7 @@ public:
   const auto& GetLSQueue() const { return LSQueue; }
 
   /// Set the Load/Store Queue
-  void SetLSQueue(std::shared_ptr<std::multimap<uint64_t, MemReq>> lsq){
+  void SetLSQueue(std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> lsq){
     LSQueue = std::move(lsq);
   }
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -92,7 +92,7 @@ private:
 
   FCSR fcsr{}; ///< RevRegFile: FCSR
 
-  std::shared_ptr<std::unordered_map<uint64_t, MemReq>> LSQueue{};
+  std::shared_ptr<std::multimap<uint64_t, MemReq>> LSQueue{};
   std::function<void(const MemReq&)> MarkLoadCompleteFunc{};
 
   union{  // Anonymous union. We zero-initialize the largest member
@@ -169,7 +169,7 @@ public:
   const auto& GetLSQueue() const { return LSQueue; }
 
   /// Set the Load/Store Queue
-  void SetLSQueue(std::shared_ptr<std::unordered_map<uint64_t, MemReq>> lsq){
+  void SetLSQueue(std::shared_ptr<std::multimap<uint64_t, MemReq>> lsq){
     LSQueue = std::move(lsq);
   }
 

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -78,13 +78,11 @@ void RevPrefetcher::MarkInstructionLoadComplete(const MemReq& req){
   auto it = OutstandingFetchQ.begin();
   while((it != OutstandingFetchQ.end())){
     if(it->Addr == req.Addr){
-      auto itToErase = it;
-      it++;
-      OutstandingFetchQ.erase(itToErase);
+      OutstandingFetchQ.erase(it++);
       break;
-    }else{
-      it++;
     }
+    it++;
+    
   }
 }
 

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -76,12 +76,15 @@ bool RevPrefetcher::IsAvail(uint64_t Addr){
 
 void RevPrefetcher::MarkInstructionLoadComplete(const MemReq& req){
   auto it = OutstandingFetchQ.begin();
-  while(!OutstandingFetchQ.empty() && (it != OutstandingFetchQ.end())){
+  while((it != OutstandingFetchQ.end())){
     if(it->Addr == req.Addr){
-      OutstandingFetchQ.erase(it);
+      auto itToErase = it;
+      it++;
+      OutstandingFetchQ.erase(itToErase);
       break;
+    }else{
+      it++;
     }
-    it++;
   }
 }
 

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -74,7 +74,7 @@ bool RevPrefetcher::IsAvail(uint64_t Addr){
   return false;
 }
 
-void RevPrefetcher::MarkInstructionLoadComplete(MemReq& req){
+void RevPrefetcher::MarkInstructionLoadComplete(const MemReq& req){
   auto it = OutstandingFetchQ.begin();
   while(!OutstandingFetchQ.empty() && (it != OutstandingFetchQ.end())){
     if(it->Addr == req.Addr){

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -75,7 +75,6 @@ bool RevPrefetcher::IsAvail(uint64_t Addr){
 }
 
 void RevPrefetcher::MarkInstructionLoadComplete(MemReq& req){
-  int i = 0;
   auto it = OutstandingFetchQ.begin();
   while(!OutstandingFetchQ.empty() && (it != OutstandingFetchQ.end())){
     if(it->Addr == req.Addr){

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1646,8 +1646,7 @@ void RevProc::MarkLoadComplete(const MemReq& req){
           if(LSQueue->count(req.LSQHash()) == 1){   // Only clear the dependency if this is the LAST outstanding load for this register
             DependencyClear(i->second.Hart, i->second.DestReg, (i->second.RegType == RevRegClass::RegFLOAT));
           }
-          MemReq temp = req;
-          sfetch->MarkInstructionLoadComplete(temp);
+          sfetch->MarkInstructionLoadComplete(req);
           LSQueue->erase(i);                        // Remove this load from the queue
           addrMatch = true;                         // Flag that there was a succesful match (if left false an error condition occurs)
           break;

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -41,7 +41,7 @@ RevProc::RevProc( unsigned Id,
   Opts->GetMemCost(Id, MinCost, MaxCost);
 
 
-  LSQueue = std::make_shared<std::unordered_map<uint64_t, MemReq>>();
+  LSQueue = std::make_shared<std::multimap<uint64_t, MemReq>>();
   LSQueue->clear();
 
   // Create the Hart Objects
@@ -1638,14 +1638,29 @@ unsigned RevProc::GetNextHartToDecodeID() const {
 
 void RevProc::MarkLoadComplete(const MemReq& req){
 
-  auto it = LSQueue->find(req.LSQHash());
-  if( it != LSQueue->end()){
-    DependencyClear(it->second.Hart, it->second.DestReg, (it->second.RegType == RevRegClass::RegFLOAT));
-    LSQueue->erase(it);
+  auto it = LSQueue->equal_range(req.LSQHash());      // Find all outstanding dependencies for this register
+  bool addrMatch = false;
+  if( it.first != LSQueue->end()){                  
+    for (auto i = it.first; i != it.second; ++i){    // Iterate over all outstanding loads for this reg (if any)
+        if(i->second.Addr == req.Addr){
+          if(LSQueue->count(req.LSQHash()) == 1){   // Only clear the dependency if this is the LAST outstanding load for this register
+            DependencyClear(i->second.Hart, i->second.DestReg, (i->second.RegType == RevRegClass::RegFLOAT));
+          }
+          LSQueue->erase(i);                        // Remove this load from the queue
+          addrMatch = true;                         // Flag that there was a succesful match (if left false an error condition occurs)
+          break;
+        }
+    }
   }else if(0 != req.DestReg){ //instruction pre-fetch fills target x0, we can ignore these
     output->fatal(CALL_INFO, -1,
                   "Core %" PRIu32 "; Hart %" PRIu32 "; Cannot find outstanding load for reg %" PRIu32 " from address %" PRIx64 "\n",
                   id, req.Hart, req.DestReg, req.Addr);
+  }
+  if(!addrMatch){
+    output->fatal(CALL_INFO, -1,
+                  "Core %" PRIu32 "; Hart %" PRIu32 "; Cannot find matching address for outstanding load for reg %" PRIu32 " from address %" PRIx64 "\n",
+                  id, req.Hart, req.DestReg, req.Addr);
+
   }
 }
 

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -1646,6 +1646,8 @@ void RevProc::MarkLoadComplete(const MemReq& req){
           if(LSQueue->count(req.LSQHash()) == 1){   // Only clear the dependency if this is the LAST outstanding load for this register
             DependencyClear(i->second.Hart, i->second.DestReg, (i->second.RegType == RevRegClass::RegFLOAT));
           }
+          MemReq temp = req;
+          sfetch->MarkInstructionLoadComplete(temp);
           LSQueue->erase(i);                        // Remove this load from the queue
           addrMatch = true;                         // Flag that there was a succesful match (if left false an error condition occurs)
           break;

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -41,7 +41,7 @@ RevProc::RevProc( unsigned Id,
   Opts->GetMemCost(Id, MinCost, MaxCost);
 
 
-  LSQueue = std::make_shared<std::multimap<uint64_t, MemReq>>();
+  LSQueue = std::make_shared<std::unordered_multimap<uint64_t, MemReq>>();
   LSQueue->clear();
 
   // Create the Hart Objects


### PR DESCRIPTION
This converts the `unordered_map` implementation of the `LSQueue` to a `multimap.` This allows multiple outstanding loads per register destination to be spawned. All load requests are now cleared based on the address read.  In addition, the pre-fetcher now tracks outstanding loads in an internal vector. On each pipeline clock the prefetcher checks the head of the vector against the outstanding loads and if there is a match this indicates that the instruction fill has not yet completed.  This scheme allows fill requests to complete in any order.

When the pre-fetcher makes a `Fill()` request all addresses are added to the internal vector. The `MarkLoadComplete` function in `RevProc` now will also call into the pre-fetcher if the destination address is `x0`.  (only load destinations spawned by the prefetcher should be targeting `x0`).  If the returned load matches an address in the vector then it is erased. 

For _all_ loads a dependency will only be cleared if _all_ outstanding loads for a given register have been returned.