### PR TITLE
Change functions to pass RevInst by reference instead of by value

### DIFF
--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -211,7 +211,7 @@ struct RevInstEntry{
   RevInstF format;      ///< RevInstEntry: instruction format
 
   /// RevInstEntry: Instruction implementation function
-  bool (*func)(RevFeature *, RevRegFile *, RevMem *, RevInst);
+  bool (*func)(RevFeature *, RevRegFile *, RevMem *, const RevInst&);
 
   bool compressed;      ///< RevInstEntry: compressed instruction
 
@@ -267,7 +267,7 @@ struct RevInstEntryBuilder : RevInstDefaultsPolicy{
   auto& SetCompressed(bool c)        { InstEntry.compressed = c; return *this;}
   auto& SetfpcvtOp(uint8_t op)       { InstEntry.fpcvtOp = op;   return *this;}
 
-  auto& SetImplFunc(bool func(RevFeature *, RevRegFile *, RevMem *, RevInst)){
+  auto& SetImplFunc(bool func(RevFeature *, RevRegFile *, RevMem *, const RevInst&)){
     InstEntry.func = func;
     return *this;
   }

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -327,25 +327,25 @@ public:
 
   // Friend functions and classes to access internal register state
   template<typename FP, typename INT>
-  friend bool CvtFpToInt(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool CvtFpToInt(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T>
-  friend bool load(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool load(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T>
-  friend bool store(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool store(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T>
-  friend bool fload(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool fload(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T>
-  friend bool fstore(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool fstore(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T, template<class> class OP>
-  friend bool foper(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool foper(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   template<typename T, template<class> class OP>
-  friend bool fcondop(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst);
+  friend bool fcondop(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst);
 
   friend std::ostream& operator<<(std::ostream& os, const RevRegFile& regFile);
 

--- a/include/insns/RV32A.h
+++ b/include/insns/RV32A.h
@@ -20,7 +20,7 @@ namespace SST::RevCPU{
 
 class RV32A : public RevExt {
 
-  static bool lrw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool lrw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     if( R->IsRV32 ){
       MemReq req(uint64_t(R->RV32[Inst.rs1]), Inst.rd, RevRegClass::RegGPR, F->GetHartToExecID(), MemOp::MemOpAMO, true, R->GetMarkLoadComplete());
       R->LSQueue->insert( req.LSQHashPair() );
@@ -41,7 +41,7 @@ class RV32A : public RevExt {
     return true;
   }
 
-  static bool scw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool scw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     if( R->IsRV32 ){
       M->SC(F->GetHartToExecID(), R->RV32[Inst.rs1],
             &R->RV32[Inst.rs2],
@@ -60,7 +60,7 @@ class RV32A : public RevExt {
   }
 
   template<RevFlag F_AMO>
-  static bool amooper(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool amooper(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     uint32_t flags = static_cast<uint32_t>(F_AMO);
 
     if( Inst.aq && Inst.rl){

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -23,25 +23,25 @@ class RV32D : public RevExt{
 
   // Compressed instructions
   static bool cfldsp(RevFeature *F, RevRegFile *R,
-                     RevMem *M, RevInst Inst) {
+                     RevMem *M, const RevInst& Inst) {
     // c.flwsp rd, $imm = lw rd, x2, $imm
     return fld(F, R, M, Inst);
   }
 
   static bool cfsdsp(RevFeature *F, RevRegFile *R,
-                     RevMem *M, RevInst Inst) {
+                     RevMem *M, const RevInst& Inst) {
     // c.fsdsp rs2, $imm = fsd rs2, x2, $imm
     return fsd(F, R, M, Inst);
   }
 
   static bool cfld(RevFeature *F, RevRegFile *R,
-                   RevMem *M, RevInst Inst) {
+                   RevMem *M, const RevInst& Inst) {
     // c.fld %rd, %rs1, $imm = flw %rd, %rs1, $imm
     return fld(F, R, M, Inst);
   }
 
   static bool cfsd(RevFeature *F, RevRegFile *R,
-                   RevMem *M, RevInst Inst) {
+                   RevMem *M, const RevInst& Inst) {
     // c.fsd rs2, rs1, $imm = fsd rs2, $imm(rs1)
     return fsd(F, R, M, Inst);
   }
@@ -73,44 +73,44 @@ class RV32D : public RevExt{
   static constexpr auto& fcvtwd  = CvtFpToInt<double, int32_t>;
   static constexpr auto& fcvtwud = CvtFpToInt<double, uint32_t>;
 
-  static bool fsqrtd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsqrtd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, std::sqrt(R->GetFP<double>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, std::copysign(R->GetFP<double>(Inst.rs1), R->GetFP<double>(Inst.rs2)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjnd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjnd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, std::copysign(R->GetFP<double>(Inst.rs1), -R->GetFP<double>(Inst.rs2)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjxd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjxd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     double rs1 = R->GetFP<double>(Inst.rs1), rs2 = R->GetFP<double>(Inst.rs2);
     R->SetFP(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtsd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtsd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<float>(R->GetFP<double>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtds(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtds(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<double>(R->GetFP<float>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fclassd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fclassd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     double fp64 = R->GetFP<double>(Inst.rs1);
     uint64_t i64;
     memcpy(&i64, &fp64, sizeof(i64));
@@ -120,13 +120,13 @@ class RV32D : public RevExt{
     return true;
   }
 
-  static bool fcvtdw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtdw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<double>(R->GetX<int32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtdwu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtdwu(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<double>(R->GetX<uint32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -22,22 +22,22 @@ namespace SST::RevCPU{
 class RV32F : public RevExt{
 
   // Compressed instructions
-  static bool cflwsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cflwsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     // c.flwsp rd, $imm = lw rd, x2, $imm
     return flw(F, R, M, Inst);
   }
 
-  static bool cfswsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cfswsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     // c.swsp rs2, $imm = sw rs2, x2, $imm
     return fsw(F, R, M, Inst);
   }
 
-  static bool cflw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cflw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     // c.flw %rd, %rs1, $imm = flw %rd, %rs1, $imm
     return flw(F, R, M, Inst);
   }
 
-  static bool cfsw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cfsw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     // c.fsw rs2, rs1, $imm = fsw rs2, $imm(rs1)
     return fsw(F, R, M, Inst);
   }
@@ -69,32 +69,32 @@ class RV32F : public RevExt{
   static constexpr auto& fcvtws  = CvtFpToInt<float,  int32_t>;
   static constexpr auto& fcvtwus = CvtFpToInt<float, uint32_t>;
 
-  static bool fsqrts(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsqrts(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, sqrtf( R->GetFP<float>(Inst.rs1) ));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjs(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, std::copysign( R->GetFP<float>(Inst.rs1), R->GetFP<float>(Inst.rs2) ));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjns(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjns(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, std::copysign( R->GetFP<float>(Inst.rs1), -R->GetFP<float>(Inst.rs2) ));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fsgnjxs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fsgnjxs(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     float rs1 = R->GetFP<float>(Inst.rs1), rs2 = R->GetFP<float>(Inst.rs2);
     R->SetFP(Inst.rd, std::copysign(rs1, std::signbit(rs1) ? -rs2 : rs2));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fmvxw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fmvxw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     int32_t i32;
     float fp32 = R->GetFP<float, true>(Inst.rs1); // The FP32 value
     memcpy(&i32, &fp32, sizeof(i32));       // Reinterpreted as int32_t
@@ -103,7 +103,7 @@ class RV32F : public RevExt{
     return true;
   }
 
-  static bool fmvwx(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fmvwx(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     float fp32;
     auto i32 = R->GetX<int32_t>(Inst.rs1);  // The X register as a 32-bit value
     memcpy(&fp32, &i32, sizeof(fp32));      // Reinterpreted as float
@@ -112,7 +112,7 @@ class RV32F : public RevExt{
     return true;
   }
 
-  static bool fclasss(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fclasss(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     float fp32 = R->GetFP<float>(Inst.rs1);
     uint32_t i32;
     memcpy(&i32, &fp32, sizeof(i32));
@@ -122,13 +122,13 @@ class RV32F : public RevExt{
     return true;
   }
 
-  static bool fcvtsw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtsw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<float>(R->GetX<int32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtswu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtswu(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<float>(R->GetX<uint32_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -23,7 +23,9 @@ namespace SST::RevCPU{
 class RV32I : public RevExt {
 
   // Compressed instructions
-  static bool caddi4spn(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool caddi4spn(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.addi4spn rd, $imm == addi rd, x2, $imm
     //Inst.rs1  = 2;  //Removed - Set in Decode
     //Inst.rd   = CRegIdx(Inst.rd);  //Set in Decode
@@ -39,7 +41,9 @@ class RV32I : public RevExt {
     return addi(F, R, M, Inst);
   }
 
-  static bool clwsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool clwsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.lwsp rd, $imm = lw rd, x2, $imm
     //Inst.rs1  = 2; //Removed - set in decode
     //Inst.imm = ((Inst.imm & 0b111111)*4);
@@ -48,7 +52,9 @@ class RV32I : public RevExt {
     return lw(F, R, M, Inst);
   }
 
-  static bool cswsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cswsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.swsp rs2, $imm = sw rs2, x2, $imm
     //Inst.rs1  = 2;  //Removed - set in decode
     //Inst.imm = ((Inst.imm & 0b111111)*4);
@@ -57,7 +63,9 @@ class RV32I : public RevExt {
     return sw(F, R, M, Inst);
   }
 
-  static bool clw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool clw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.lw rd, rs1, $imm = lw rd, $imm(rs1)
     //Inst.rd  = CRegIdx(Inst.rd);    //Removed - Scaled in decode
     //Inst.rs1 = CRegIdx(Inst.rs1);   //Removed - Scaled in decode
@@ -67,7 +75,9 @@ class RV32I : public RevExt {
     return lw(F, R, M, Inst);
   }
 
-  static bool csw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.sw rs2, rs1, $imm = sw rs2, $imm(rs1)
     //Inst.rs2 = CRegIdx(Inst.rd);  //Removed - Scaled in Decode
     //Inst.rs1 = CRegIdx(Inst.rs1); //Removed - Scaled in Decode
@@ -77,7 +87,9 @@ class RV32I : public RevExt {
     return sw(F, R, M, Inst);
   }
 
-  static bool cj(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cj(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.j $imm = jal x0, $imm
     Inst.rd = 0; // x0
 
@@ -86,7 +98,9 @@ class RV32I : public RevExt {
     return jal(F, R, M, Inst);
   }
 
-  static bool cjal(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cjal(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.jal $imm = jal x0, $imm
     //Inst.rd = 1; // x1 //Removed - set in decode
     Inst.imm = Inst.jumpTarget;
@@ -94,14 +108,16 @@ class RV32I : public RevExt {
     return jal(F, R, M, Inst);
   }
 
-  static bool CRFUNC_1000(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst){
+  static bool CRFUNC_1000(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst){
     if( Inst.rs2 != 0 ){
       return cmv(F, R, M, Inst);
     }
     return cjr(F, R, M, Inst);
   }
 
-  static bool CRFUNC_1001(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst){
+  static bool CRFUNC_1001(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst){
+    RevInst Inst = CInst;
+
     if( (Inst.rs1 == 0) && (Inst.rd == 0) ){
       return ebreak(F, R, M, Inst);
     }else if( (Inst.rs2 == 0) && (Inst.rd != 0) ){
@@ -112,29 +128,37 @@ class RV32I : public RevExt {
     }
   }
 
-  static bool cjr(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cjr(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.jr %rs1 = jalr x0, 0(%rs1)
     Inst.rs2 = 0;
     return jalr(F, R, M, Inst);
   }
 
-  static bool cmv(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cmv(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     //Inst.rs1 = 0;  //Removed - performed in decode // expands to add rd, x0, rs2, so force rs1 to zero
     return add(F, R, M, Inst);
   }
 
-  static bool cadd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cadd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     Inst.rs1 = Inst.rd;
     return add(F, R, M, Inst);
   }
 
-  static bool cjalr(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cjalr(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.jalr %rs1 = jalr x1, 0(%rs1)
     Inst.rs2 = 1;
     return jalr(F, R, M, Inst);
   }
 
-  static bool cbeqz(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cbeqz(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.beqz %rs1, $imm = beq %rs1, x0, $imm
     Inst.rs2 = 0;
    // Inst.rs1 = CRegIdx(Inst.rs1); // removed - scaled in decode
@@ -147,7 +171,9 @@ class RV32I : public RevExt {
     return beq(F, R, M, Inst);
   }
 
-  static bool cbnez(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cbnez(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.bnez %rs1, $imm = bne %rs1, x0, $imm
     //Inst.rs2 = 0; //removed - set in decode
    // Inst.rs1 = CRegIdx(Inst.rs1); //removed - scaled in decode
@@ -160,7 +186,9 @@ class RV32I : public RevExt {
     return bne(F, R, M, Inst);
   }
 
-  static bool cli(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cli(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.li %rd, $imm = addi %rd, x0, $imm
     //Inst.rs1 = 0; //removed - set in decode
     // SEXT(Inst.imm, (Inst.imm & 0b111111), 6);
@@ -168,7 +196,9 @@ class RV32I : public RevExt {
     return addi(F, R, M, Inst);
   }
 
-  static bool CIFUNC(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool CIFUNC(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     if( Inst.rd == 2 ){
       // c.addi16sp
       //SEXT(Inst.imm, (Inst.imm & 0b011111111)*16, 32);
@@ -183,7 +213,9 @@ class RV32I : public RevExt {
     }
   }
 
-  static bool caddi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool caddi(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.addi %rd, $imm = addi %rd, %rd, $imm
     // uint32_t tmp = Inst.imm & 0b111111;
     Inst.imm = Inst.ImmSignExt(6);
@@ -191,27 +223,35 @@ class RV32I : public RevExt {
     return addi(F, R, M, Inst);
   }
 
-  static bool cslli(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cslli(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.slli %rd, $imm = slli %rd, %rd, $imm
    // Inst.rs1 = Inst.rd;  //removed - set in decode
     return slli(F, R, M, Inst);
   }
 
-  static bool csrli(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrli(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.srli %rd, $imm = srli %rd, %rd, $imm
     //Inst.rd  = CRegIdx(Inst.rd); //removed - set in decode
     Inst.rs1 = Inst.rd;
     return srli(F, R, M, Inst);
   }
 
-  static bool csrai(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrai(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.srai %rd, $imm = srai %rd, %rd, $imm
    // Inst.rd  = CRegIdx(Inst.rd); //removed - set in decode
    // Inst.rs1 = Inst.rd; //Removed - set in decode
     return srai(F, R, M, Inst);
   }
 
-  static bool candi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool candi(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.andi %rd, $imm = sandi %rd, %rd, $imm
     // Inst.rd  = CRegIdx(Inst.rd); //removed - scaled in decode
     // Inst.rs1 = Inst.rd;          //removed - set in decode
@@ -219,7 +259,9 @@ class RV32I : public RevExt {
     return andi(F, R, M, Inst);
   }
 
-  static bool cand(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cand(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.and %rd, %rs2 = and %rd, %rd, %rs2
    // Inst.rd  = CRegIdx(Inst.rd);//removed - scaled in decode
    // Inst.rs1 = Inst.rd;//removed - scaled in decode
@@ -227,7 +269,9 @@ class RV32I : public RevExt {
     return f_and(F, R, M, Inst);
   }
 
-  static bool cor(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cor(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.or %rd, %rs2 = or %rd, %rd, %rs2
     //Inst.rd  = CRegIdx(Inst.rd);//removed - scaled in decode
     //Inst.rs1 = Inst.rd;//removed - scaled in decode
@@ -235,7 +279,9 @@ class RV32I : public RevExt {
     return f_or(F, R, M, Inst);
   }
 
-  static bool cxor(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cxor(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.xor %rd, %rs2 = xor %rd, %rd, %rs2
     //Inst.rd  = CRegIdx(Inst.rd);//removed - scaled in decode
     //Inst.rs1 = Inst.rd;//removed - scaled in decode
@@ -243,7 +289,9 @@ class RV32I : public RevExt {
     return f_xor(F, R, M, Inst);
   }
 
-  static bool csub(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csub(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.sub %rd, %rs2 = sub %rd, %rd, %rs2
     //Inst.rd  = CRegIdx(Inst.rd);//removed - scaled in decode
     //Inst.rs1 = Inst.rd;//removed - scaled in decode
@@ -252,26 +300,26 @@ class RV32I : public RevExt {
   }
 
   // Standard instructions
-  static bool lui(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool lui(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetX(Inst.rd, static_cast<int32_t>(Inst.imm << 12));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool auipc(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool auipc(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     auto ui = static_cast<int32_t>(Inst.imm << 12);
     R->SetX(Inst.rd, ui + R->GetPC());
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool jal(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool jal(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetX(Inst.rd, R->GetPC() + Inst.instSize);
     R->SetPC(R->GetPC() + Inst.ImmSignExt(21));
     return true;
   }
 
-  static bool jalr(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool jalr(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     auto ret = R->GetPC() + Inst.instSize;
     R->SetPC((R->GetX<uint64_t>(Inst.rs1) + Inst.ImmSignExt(12)) & -2);
     R->SetX(Inst.rd, ret);
@@ -323,19 +371,19 @@ class RV32I : public RevExt {
   static constexpr auto& srl  = oper<ShiftRight,    OpKind::Reg, std::make_unsigned_t>;
   static constexpr auto& sra  = oper<ShiftRight,    OpKind::Reg>;
 
-  static bool fence(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fence(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     M->FenceMem(F->GetHartToExecID());
     R->AdvancePC(Inst);
     return true;  // temporarily disabled
   }
 
-  static bool fencei(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fencei(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     M->FenceMem(F->GetHartToExecID());
     R->AdvancePC(Inst);
     return true;  // temporarily disabled
   }
 
-  static bool ecall(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst){
+  static bool ecall(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst){
     /*
      * In reality this should be getting/setting a LOT of bits inside the
      * CSRs however because we are only concerned with ecall right now it's
@@ -358,37 +406,37 @@ class RV32I : public RevExt {
     return true;
   }
 
-  static bool ebreak(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool ebreak(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrs(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrs(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrc(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrc(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrwi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrwi(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrsi(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrsi(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool csrrci(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csrrci(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->AdvancePC(Inst);
     return true;
   }

--- a/include/insns/RV64A.h
+++ b/include/insns/RV64A.h
@@ -20,7 +20,7 @@ namespace SST::RevCPU{
 
 class RV64A : public RevExt {
 
-  static bool lrd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool lrd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     MemReq req(R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExecID(), MemOp::MemOpAMO, true, R->GetMarkLoadComplete() );
     R->LSQueue->insert( req.LSQHashPair() );
     M->LR(F->GetHartToExecID(),
@@ -32,7 +32,7 @@ class RV64A : public RevExt {
     return true;
   }
 
-  static bool scd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool scd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     M->SC(F->GetHartToExecID(),
           R->RV64[Inst.rs1],
           &R->RV64[Inst.rs2],
@@ -45,7 +45,7 @@ class RV64A : public RevExt {
 
   /// Atomic Memory Operations
   template<RevFlag F_AMO>
-  static bool amooperd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool amooperd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     uint32_t flags = static_cast<uint32_t>(F_AMO);
 
     if( Inst.aq && Inst.rl ){

--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -23,19 +23,19 @@ class RV64D : public RevExt {
   static constexpr auto& fcvtld  = CvtFpToInt<double,  int64_t>;
   static constexpr auto& fcvtlud = CvtFpToInt<double, uint64_t>;
 
-  static bool fcvtdl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtdl(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<double>(R->GetX<int64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtdlu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtdlu(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<double>(R->GetX<uint64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fmvxd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fmvxd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     uint64_t u64;
     double fp = R->GetFP<double, true>(Inst.rs1);
     memcpy(&u64, &fp, sizeof(u64));
@@ -44,7 +44,7 @@ class RV64D : public RevExt {
     return true;
   }
 
-  static bool fmvdx(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fmvdx(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     uint64_t u64 = R->GetX<uint64_t>(Inst.rs1);
     double fp;
     memcpy(&fp, &u64, sizeof(fp));

--- a/include/insns/RV64F.h
+++ b/include/insns/RV64F.h
@@ -23,13 +23,13 @@ class RV64F : public RevExt {
   static constexpr auto& fcvtls  = CvtFpToInt<float,  int64_t>;
   static constexpr auto& fcvtlus = CvtFpToInt<float, uint64_t>;
 
-  static bool fcvtsl(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtsl(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<float>(R->GetX<int64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;
   }
 
-  static bool fcvtslu(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool fcvtslu(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetFP(Inst.rd, static_cast<float>(R->GetX<uint64_t>(Inst.rs1)));
     R->AdvancePC(Inst);
     return true;

--- a/include/insns/RV64I.h
+++ b/include/insns/RV64I.h
@@ -20,7 +20,9 @@ namespace SST::RevCPU{
 class RV64I : public RevExt{
 
   // Compressed instructions
-  static bool cldsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cldsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.ldsp rd, $imm = lw rd, x2, $imm
     // Inst.rs1  = 2;  //Removed - set in decode
     //ZEXT(Inst.imm, ((Inst.imm&0b111111))*8, 32);
@@ -29,7 +31,9 @@ class RV64I : public RevExt{
     return ld(F, R, M, Inst);
   }
 
-  static bool csdsp(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csdsp(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.swsp rs2, $imm = sw rs2, x2, $imm
     // Inst.rs1  = 2; //Removed - set in decode
     //ZEXT(Inst.imm, ((Inst.imm&0b111111))*8, 32);
@@ -38,7 +42,9 @@ class RV64I : public RevExt{
     return sd(F, R, M, Inst);
   }
 
-  static bool cld(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cld(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.ld %rd, %rs1, $imm = ld %rd, %rs1, $imm
     //Inst.rd  = CRegIdx(Inst.rd);  //Removed - scaled in decode
     //Inst.rs1 = CRegIdx(Inst.rs1); //Removed - scaled in decode
@@ -47,7 +53,9 @@ class RV64I : public RevExt{
     return ld(F, R, M, Inst);
   }
 
-  static bool csd(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csd(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.sd rs2, rs1, $imm = sd rs2, $imm(rs1)
     //Inst.rs2 = CRegIdx(Inst.rs2);  //Removed - scaled in decode
     //Inst.rs1 = CRegIdx(Inst.rs1); // Removed  - scaled in decode
@@ -55,7 +63,9 @@ class RV64I : public RevExt{
     return sd(F, R, M, Inst);
   }
 
-  static bool caddiw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool caddiw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.addiw %rd, $imm = addiw %rd, %rd, $imm
     // Inst.rs1 = Inst.rd; //Removed - set in decode
     // uint64_t tmp = Inst.imm & 0b111111;
@@ -64,7 +74,9 @@ class RV64I : public RevExt{
     return addiw(F, R, M, Inst);
   }
 
-  static bool caddw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool caddw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.addw %rd, %rs2 = addw %rd, %rd, %rs2
     //Inst.rd  = CRegIdx(Inst.rd);  //Removed - set in decode
     //Inst.rs1 = Inst.rd;  //Removed - set in decode
@@ -72,7 +84,9 @@ class RV64I : public RevExt{
     return addw(F, R, M, Inst);
   }
 
-  static bool csubw(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool csubw(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& CInst) {
+    RevInst Inst = CInst;
+
     // c.subw %rd, %rs2 = subw %rd, %rd, %rs2
     //Inst.rd  = CRegIdx(Inst.rd);  //Removed - set in decode
     //Inst.rs1 = Inst.rd;  //Removed - set in decode

--- a/include/insns/RV64P.h
+++ b/include/insns/RV64P.h
@@ -19,17 +19,17 @@ namespace SST::RevCPU{
 
 class RV64P : public RevExt{
 
-  static bool future(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool future(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetX(Inst.rd, !!M->SetFuture(R->GetX<uint64_t>(Inst.rs1) + Inst.ImmSignExt(12)));
     return true;
   }
 
-  static bool rfuture(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool rfuture(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetX(Inst.rd, !!M->RevokeFuture(R->GetX<uint64_t>(Inst.rs1) + Inst.ImmSignExt(12)));
     return true;
   }
 
-  static bool sfuture(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool sfuture(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     R->SetX(Inst.rd, !!M->StatusFuture(R->GetX<uint64_t>(Inst.rs1) + Inst.ImmSignExt(12)));
     return true;
   }

--- a/include/insns/Zicbom.h
+++ b/include/insns/Zicbom.h
@@ -23,7 +23,7 @@ namespace SST::RevCPU{
 #define CBO_CLEAN_IMM 0b000000000010
 class Zicbom : public RevExt{
 
-  static bool cmo(RevFeature *F, RevRegFile *R, RevMem *M, RevInst Inst) {
+  static bool cmo(RevFeature *F, RevRegFile *R, RevMem *M, const RevInst& Inst) {
     switch(Inst.imm){
     case CBO_INVAL_IMM:
       // CBO.INVAL

--- a/src/RevExt.cc
+++ b/src/RevExt.cc
@@ -47,7 +47,7 @@ bool RevExt::Execute(unsigned Inst, const RevInst& payload, uint16_t HartID, Rev
   bool (*func)(RevFeature *,
                RevRegFile *,
                RevMem *,
-               RevInst);
+               const RevInst&);
 
   if( payload.compressed ){
     // this is a compressed instruction, grab the compressed trampoline function


### PR DESCRIPTION
As `RevInst` has grown in size, it has become more expensive to pass by value. Running `big_loop` after this change shows negligible improvement but no slowdown.
