### PR TITLE
Simplify initialization of options at startup

### DIFF
--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -41,22 +41,22 @@ public:
   int GetVerbosity() { return verbosity; }
 
   /// RevOpts: initialize the set of starting addresses
-  bool InitStartAddrs( std::vector<std::string> StartAddrs );
+  bool InitStartAddrs( const std::vector<std::string>& StartAddrs );
 
   /// RevOpts: initialize the set of potential starting symbols
-  bool InitStartSymbols( std::vector<std::string> StartSymbols );
+  bool InitStartSymbols( const std::vector<std::string>& StartSymbols );
 
   /// RevOpts: initialize the set of machine models
-  bool InitMachineModels( std::vector<std::string> Machines );
+  bool InitMachineModels( const std::vector<std::string>& Machines );
 
   /// RevOpts: initalize the set of instruction tables
-  bool InitInstTables( std::vector<std::string> InstTables );
+  bool InitInstTables( const std::vector<std::string>& InstTables );
 
   /// RevOpts: initialize the memory latency cost tables
-  bool InitMemCosts( std::vector<std::string> MemCosts );
+  bool InitMemCosts( const std::vector<std::string>& MemCosts );
 
   /// RevOpts: initialize the prefetch depths
-  bool InitPrefetchDepth( std::vector<std::string> Depths );
+  bool InitPrefetchDepth( const std::vector<std::string>& Depths );
 
   /// RevOpts: retrieve the start address for the target core
   bool GetStartAddr( unsigned Core, uint64_t &StartAddr );

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -58,7 +58,7 @@ void RevOpts::splitStr(const std::string& s,
   }
 }
 
-bool RevOpts::InitPrefetchDepth( std::vector<std::string> Depths ){
+bool RevOpts::InitPrefetchDepth( const std::vector<std::string>& Depths ){
   std::vector<std::string> vstr;
   for(unsigned i=0; i<Depths.size(); i++ ){
     std::string s = Depths[i];
@@ -79,7 +79,7 @@ bool RevOpts::InitPrefetchDepth( std::vector<std::string> Depths ){
   return true;
 }
 
-bool RevOpts::InitStartAddrs( std::vector<std::string> StartAddrs ){
+bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ){
   std::vector<std::string> vstr;
 
   // check to see if we expand into multiple cores
@@ -119,7 +119,7 @@ bool RevOpts::InitStartAddrs( std::vector<std::string> StartAddrs ){
   return true;
 }
 
-bool RevOpts::InitStartSymbols( std::vector<std::string> StartSymbols ){
+bool RevOpts::InitStartSymbols( const std::vector<std::string>& StartSymbols ){
   std::vector<std::string> vstr;
   for(unsigned i=0; i<StartSymbols.size(); i++ ){
     std::string s = StartSymbols[i];
@@ -137,7 +137,7 @@ bool RevOpts::InitStartSymbols( std::vector<std::string> StartSymbols ){
   return true;
 }
 
-bool RevOpts::InitMachineModels( std::vector<std::string> Machines ){
+bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ){
   std::vector<std::string> vstr;
 
   // check to see if we expand into multiple cores
@@ -173,7 +173,7 @@ bool RevOpts::InitMachineModels( std::vector<std::string> Machines ){
   return true;
 }
 
-bool RevOpts::InitInstTables( std::vector<std::string> InstTables ){
+bool RevOpts::InitInstTables( const std::vector<std::string>& InstTables ){
   std::vector<std::string> vstr;
   for( unsigned i=0; i<InstTables.size(); i++ ){
     std::string s = InstTables[i];
@@ -191,7 +191,7 @@ bool RevOpts::InitInstTables( std::vector<std::string> InstTables ){
   return true;
 }
 
-bool RevOpts::InitMemCosts( std::vector<std::string> MemCosts ){
+bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ){
   std::vector<std::string> vstr;
 
   for( unsigned i=0; i<MemCosts.size(); i++ ){


### PR DESCRIPTION
This is a low-priority PR, which can wait until after releases. It:
1. Makes the handling of options more data-driven with less code duplication
2. Passes option vectors by reference instead of by value, to reduce function call overhead
3. Uses `std::nothrow` as indicated by a previous comment of mine