### PR TITLE
Removing superfluous  ReadRequest when hitting page boundary

### DIFF
--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -825,7 +825,8 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
     BaseMem = &physMem[adjPhysAddr];
     if( ctrl ){
       unsigned Cur = (Len-span);
-      ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, req, flags);
+      //If we are using memH, this paging scheme is not relevant, we already issued the ReadReq above
+      //ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, req, flags);
     }else{
       unsigned Cur = (Len-span);
       for( unsigned i=0; i< span; i++ ){

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -823,20 +823,16 @@ bool RevMem::ReadMem(unsigned Hart, uint64_t Addr, size_t Len, void *Target,
       }
     }
     BaseMem = &physMem[adjPhysAddr];
-    if( ctrl ){
-      unsigned Cur = (Len-span);
-      //If we are using memH, this paging scheme is not relevant, we already issued the ReadReq above
-      //ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, req, flags);
-    }else{
-      unsigned Cur = (Len-span);
-      for( unsigned i=0; i< span; i++ ){
-        DataMem[Cur] = BaseMem[i];
-        Cur++;
-      }
-      // clear the hazard - if this was an AMO operation then we will clear outside of this function in AMOMem()
-      if(MemOp::MemOpAMO != req.ReqType){
-        req.MarkLoadComplete();
-      }
+    //If we are using memH, this paging scheme is not relevant, we already issued the ReadReq above
+    //ctrl->sendREADRequest(Hart, Addr, (uint64_t)(BaseMem), Len, ((char*)Target)+Cur, req, flags);
+    unsigned Cur = (Len-span);
+    for( unsigned i=0; i< span; i++ ){
+      DataMem[Cur] = BaseMem[i];
+      Cur++;
+    }
+    // clear the hazard - if this was an AMO operation then we will clear outside of this function in AMOMem()
+    if(MemOp::MemOpAMO != req.ReqType){
+      req.MarkLoadComplete();
     }
 #ifdef _REV_DEBUG_
     std::cout << "Warning: Reading off end of page... " << std::endl;


### PR DESCRIPTION
When operating Rev with MemH enabled if we hit a page boundary (like we are operating with `RevMem`) we generate two ReadRequests. This will cause two read responses to the same address / register causing an exception to be thrown in the `MarkLoadComplete() `function upon return of the 2nd read response.  This change so regardless of where we are in terms pf page boundaries we generate a single read request. 

There is still some dead code in there... wanted to make it _very_ clear what changed.