### PR TITLE
Clear Ecall state every time we successfully execute an ecall

### DIFF
--- a/include/RevSysCalls.h
+++ b/include/RevSysCalls.h
@@ -41,7 +41,7 @@ struct EcallState {
     string.clear();
     path_string.clear();
     bytesRead = 0;
-    buf[0] = '\0';
+    buf.fill('\0');
   }
   EcallState() {
     buf[0] = '\0';

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2372,8 +2372,10 @@ void RevProc::ExecEcall(RevInst& inst){
 
     // For now, rewind the PC and keep executing the ECALL until we
     // have completed
-    if(EcallStatus::SUCCESS != status){
+    if( status != EcallStatus::SUCCESS ){
       RegFile->SetPC( RegFile->GetPC() - inst.instSize );
+    } else {
+      Harts[HartToDecodeID]->GetEcallState().clear();
     }
   } else {
     output->fatal(CALL_INFO, -1, "Ecall Code = %" PRIu64 " not found", EcallCode);


### PR DESCRIPTION
This clears the ecall state object every time we successfully return from an Ecall instruction. We weren't doing this before and it would lead to some odd behavior for system calls that relied on information contained in this object (ie. `if(EcallState.bytesRead .... ` 