### PR TITLE
Refine how EcallState is cleared

### DIFF
--- a/include/RevSysCalls.h
+++ b/include/RevSysCalls.h
@@ -41,11 +41,9 @@ struct EcallState {
     string.clear();
     path_string.clear();
     bytesRead = 0;
-    buf[0] = '\0';
   }
-  EcallState() {
-    buf[0] = '\0';
-  }
-};
-}
+
+  explicit EcallState() = default;
+}; // struct EcallState
+}  // namespace SST::RevCPU
 #endif

--- a/src/RevProc.cc
+++ b/src/RevProc.cc
@@ -2348,8 +2348,10 @@ void RevProc::ExecEcall(RevInst& inst){
 
     // For now, rewind the PC and keep executing the ECALL until we
     // have completed
-    if(EcallStatus::SUCCESS != status){
+    if( status != EcallStatus::SUCCESS ){
       RegFile->SetPC( RegFile->GetPC() - inst.instSize );
+    } else {
+      Harts[HartToDecodeID]->GetEcallState().clear();
     }
   } else {
     output->fatal(CALL_INFO, -1, "Ecall Code = %" PRIu64 " not found", EcallCode);

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -35,10 +35,6 @@ EcallStatus RevProc::EcallLoadAndParseString(RevInst& inst,
       // action is usually passed in as a lambda with local code and captures
       // from the caller, such as performing a syscall using EcallState.string.
       action();
-
-      EcallState.string.clear();   //reset the ECALL buffers
-      EcallState.bytesRead = 0;
-
       DependencyClear(HartToExecID, RevReg::a0, RevRegClass::RegGPR);
       rtval = EcallStatus::SUCCESS;
     }else{
@@ -120,6 +116,7 @@ EcallStatus RevProc::ECALL_setxattr(RevInst& inst){
     // will move the ECALL.string to ECALL.path_string and continue below
     auto action = [&]{
       ECALL.path_string = std::move(ECALL.string);
+      ECALL.string.clear();
     };
     auto rtv = EcallLoadAndParseString(inst, path, action);
 
@@ -750,7 +747,6 @@ EcallStatus RevProc::ECALL_write(RevInst& inst){
   if(nleft == 0 && LSQueue->count(lsq_hash) == 0){
     int rc = write(fd, EcallState.string.data(), EcallState.string.size());
     RegFile->SetX(RevReg::a0, rc);
-    EcallState.clear();
     DependencyClear(HartToExecID, RevReg::a0, RevRegClass::RegGPR);
     return EcallStatus::SUCCESS;
   }
@@ -2216,7 +2212,6 @@ EcallStatus RevProc::ECALL_clone(RevInst& inst){
 
  //    // clean up ecall state
  //    rtval = EcallStatus::SUCCESS;
- //    ECALL.bytesRead = 0;
 
  //  } //else
   return rtval;
@@ -3072,7 +3067,6 @@ EcallStatus RevProc::ECALL_clone3(RevInst& inst){
 
  //    // clean up ecall state
  //    rtval = EcallStatus::SUCCESS;
- //    ECALL.bytesRead = 0;
 
  //  } //else
   return rtval;


### PR DESCRIPTION
This is a refinement of https://github.com/tactcomplabs/rev/pull/247

- Make Ecalls clear `EcallState` when `EcallStatus::SUCCESS` is returned
- Remove redundant clears of `EcallState` when `EcallStatus::SUCCESS` is returned
- Fix potential bug when `EcallState.string` is moved to `EcallState.path_string` (guarantee `string` is empty after it is moved from, which `std::move` does not guarantee)
- Do not zero out `EcallState.buf` because `EcallState.bytesRead` indicates the number of bytes in `buf` which are valid, and `buf` does not need to be zeroed, just `bytesRead`