### PR TITLE
Added the same environment check for RVOBJDUMP that we do for RVCXX & RVCC

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ else()
   message(FATAL_ERROR "RVCXX environment varible is not set.")
 endif()
 
+set(RVOBJDUMP "$ENV{RVOBJDUMP}")
 if(NOT RVOBJDUMP)
   file(GLOB RVOBJDUMP_FILES "${RISCV_BIN_PATH}/*objdump")
   list(GET RVOBJDUMP_FILES 0 RVOBJDUMP)


### PR DESCRIPTION
We don't check to see if `RVOBJDUMP` is set in the environment first but we do for RVCC and RVCXX... The logic to assign it automatically based on `RISCV` makes some assumptions that won't hold up for all environments. 

This just adds a check to see if there is already a value set for RVOBJDUMP set as a environment variable. 