### PR TITLE
Use do{ }while(0) idiom for function-style macros

### DIFF
--- a/include/RevTracer.h
+++ b/include/RevTracer.h
@@ -40,13 +40,13 @@
 
 // Tracing macros
 #ifndef NO_REV_TRACER
-#define TRACE_REG_READ(R,V)  { if (Tracer) Tracer->regRead( (R), (V) ); }
-#define TRACE_REG_WRITE(R,V) { if (Tracer) Tracer->regWrite( (R), (V) ); }
-#define TRACE_PC_WRITE(PC)   { if (Tracer) Tracer->pcWrite( (PC) ); }
-#define TRACE_MEM_WRITE(ADR, LEN, DATA)    { if (Tracer) Tracer->memWrite( (ADR), (LEN), (DATA) ); }
-#define TRACE_MEM_READ(ADR, LEN, DATA)     { if (Tracer) Tracer->memRead(  (ADR), (LEN), (DATA) ); }
-#define TRACE_MEMH_SENDREAD(ADR, LEN, REG) { if (Tracer) Tracer->memhSendRead( (ADR), (LEN), (REG) ); }
-#define TRACE_MEM_READ_RESPONSE(LEN, DATA, REQ) { if (Tracer) Tracer->memReadResponse( (LEN), (DATA), (REQ) ); }
+#define TRACE_REG_READ(R,V)  do{ if (Tracer) Tracer->regRead( (R), (V) ); }while(0)
+#define TRACE_REG_WRITE(R,V) do{ if (Tracer) Tracer->regWrite( (R), (V) ); }while(0)
+#define TRACE_PC_WRITE(PC)   do{ if (Tracer) Tracer->pcWrite( (PC) ); }while(0)
+#define TRACE_MEM_WRITE(ADR, LEN, DATA)    do{ if (Tracer) Tracer->memWrite( (ADR), (LEN), (DATA) ); }while(0)
+#define TRACE_MEM_READ(ADR, LEN, DATA)     do{ if (Tracer) Tracer->memRead(  (ADR), (LEN), (DATA) ); }while(0)
+#define TRACE_MEMH_SENDREAD(ADR, LEN, REG) do{ if (Tracer) Tracer->memhSendRead( (ADR), (LEN), (REG) ); }while(0)
+#define TRACE_MEM_READ_RESPONSE(LEN, DATA, REQ) do{ if (Tracer) Tracer->memReadResponse( (LEN), (DATA), (REQ) ); }while(0)
 #else
 #define TRACE_REG_READ(R,V)
 #define TRACE_REG_WRITE(R,V)


### PR DESCRIPTION
When macros can be called like functions, use `do{ }while(0)` [around the body of complex macros](https://stackoverflow.com/questions/257418/do-while-0-what-is-it-good-for/257425#257425) (more than single expressions) so that the macro can be called like a function and used anywhere inside an `if`-statement or elsewhere with normal syntax (ending statements with semicolons, etc.).

