### PR TITLE
Do not check Git hooks for builduser

### DIFF
--- a/scripts/test_git_hooks.sh
+++ b/scripts/test_git_hooks.sh
@@ -10,6 +10,10 @@ else
   END=
 fi
 
+if [ "$(id -nu)" = builduser ]; then
+    exit 0
+fi
+
 hooks=$(git config core.hooksPath)
 if [ "${hooks}" != .githooks ]; then
     printf "${RED}\n"


### PR DESCRIPTION
This avoids the Git hooks checks for `builduser` during CI runs.