### PR TITLE
Allow files to reformat to be specified on the command line

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,28 +31,43 @@ set_colors() {
 
 usage() {
     cat<<EOF
-Usage: pre-commit [ --reformat] [ --nostage ]
+Usage: pre-commit [ --reformat] [ --nostage ] [ file1 ] [ file2 ] [ file3 ] ...
 
 Format files prior to commit so that they match style guidelines
 
+Normally called before commit, but if files are explicitly specified, reformats
+them in-place without respect to commits.
+
 Options:
-    --reformat   Reformat all files in the source tree, rather than staged files
-    --nostage    Do not add files modified by pre-commit to the staging area
+   --reformat   Reformat all files in the source tree, rather than staged files
+   --nostage    Do not add files modified by pre-commit to the staging area
 EOF
     exit 1
 }
 
 # Parse command-line options
 parse_options() {
+    FILES=()
     REFORMAT=
     NOSTAGE=
+    EXPLICIT_FILES=
+    local endopts=
     for opt in "$@"; do
-        case $opt in
-            --reformat) REFORMAT=1 ;;
-            --nostage)  NOSTAGE=1  ;;
-            *) usage
-        esac
+        if [[ -n $endopts ]]; then
+            FILES+=("$opt")
+        else
+            case $opt in
+                --)         endopts=1  ;;
+                --reformat) REFORMAT=1 ;;
+                --nostage)  NOSTAGE=1  ;;
+                -*)         usage      ;;
+                *)          FILES+=("$opt")
+            esac
+        fi
     done
+    if [[ ${#FILES[@]} -ne 0 ]]; then
+        EXPLICIT_FILES=1
+    fi
 }
 
 # Check for existence of clang-format or print error message on how to install
@@ -89,7 +104,7 @@ detect_change() {
     if ! cmp -s "$1" "$2"; then
         printf "${YELLOW}$3${END}\n" "$1"
         cp -f "$2" "$1"
-        if [[ -z $NOSTAGE ]]; then
+        if [[ -z $EXPLICIT_FILES && -z $NOSTAGE ]]; then
             git add -u "$1"
         fi
     fi
@@ -98,23 +113,29 @@ detect_change() {
 # Generate list of modified files
 # If --reformat is used, all files are reformatted
 get_files() {
-    if [[ -n $REFORMAT ]]; then
-        git ls-files --exclude-standard
-    else
-        if git rev-parse --verify HEAD >/dev/null 2>&1; then
-            against=HEAD
+    if [[ -z $EXPLICIT_FILES ]]; then
+        # Do everything from top level
+        top=$(git rev-parse --show-toplevel)
+        cd "$top"
+        if [[ -n $REFORMAT ]]; then
+            git ls-files -z --exclude-standard | readarray -d '' FILES
         else
-            # Initial commit: diff against initial commit
-            against=$(git log --reverse --pretty=format:%H | head -1)
+            if git rev-parse --verify HEAD >/dev/null 2>&1; then
+                against=HEAD
+            else
+                # Initial commit: diff against initial commit
+                against=$(git log --reverse --pretty=format:%H | head -1)
+            fi
+            git diff-index -z --cached --name-only "$against" | readarray -d '' FILES
         fi
-        git diff-index --cached --name-only "$against"
     fi
 }
 
 # Test if argument is a text regular file
 # git grep tests whether Git considers it a text file
+# If files were explicitly specified, they are assumed to be text files
 is_text_file() {
-    [[ -f $1 ]] && git grep -Iqe . -- "$1"
+    [[ -n $EXPLICIT_FILES ]] || git grep -Iqe . -- "$1"
 }
 
 # Test if argument is a C/C++ file
@@ -130,13 +151,12 @@ reformat_files() {
     temp=$(mktemp)
     trap 'rm -f "$temp"' EXIT
 
-    # Do everything from top level
-    top=$(git rev-parse --show-toplevel)
-    cd "$top"
+    # Get the list of files into FILES
+    get_files
 
     # Fix formatting on text files
-    for file in $(get_files); do
-        if is_text_file "$file"; then
+    for file in "${FILES[@]}"; do
+        if [[ -f $file ]] && is_text_file "$file"; then
             # Replace non-ASCII characters with ASCII equivalents
             iconv -s -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"
             detect_change "$file" "$temp" "%s: Converting non-ASCII characters to ASCII equivalents"
@@ -149,7 +169,7 @@ reformat_files() {
             # Run clang-format on C/C++ files
             if is_cxx_file "$file"; then
                 check_clang_format
-                clang-format -- "$file" > "$temp"
+                clang-format --assume-filename="$0" -- "$file" > "$temp"
                 detect_change "$file" "$temp" "%s: Reformatting with clang-format according to coding guidelines"
             fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@
 
 set_shell_options() {
     set -eEu -o pipefail
-    shopt -s nocasematch
+    shopt -s nocasematch lastpipe
     export PATH=$PATH:/usr/bin:/bin
     exec >&2
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,11 +5,11 @@
 # Based on https://github.com/rocm/rocBLAS
 #
 # shellcheck enable=all
-# shellcheck disable=2034,2059,2250,2310
+# shellcheck disable=2034,2059,2250,2310,2312
 
 set_shell_options() {
     set -eEu -o pipefail
-    shopt -s nocasematch lastpipe
+    shopt -s nocasematch
     export PATH=$PATH:/usr/bin:/bin
     exec >&2
 }
@@ -67,6 +67,7 @@ parse_options() {
     done
     if [[ ${#FILES[@]} -ne 0 ]]; then
         EXPLICIT_FILES=1
+        NOSTAGE=1
     fi
 }
 
@@ -113,12 +114,18 @@ detect_change() {
 # Generate list of modified files
 # If --reformat is used, all files are reformatted
 get_files() {
-    if [[ -z $EXPLICIT_FILES ]]; then
+    if [[ -n $EXPLICIT_FILES ]]; then
+        # cd to this script's directory before running clang-format
+        # so that the .clang-format from this script's repo is used
+        REPO=$(dirname "$0")
+    else
         # Do everything from top level
-        top=$(git rev-parse --show-toplevel)
-        cd "$top"
+        REPO=$(git rev-parse --show-toplevel)
+        cd "$REPO"
         if [[ -n $REFORMAT ]]; then
-            git ls-files -z --exclude-standard | readarray -d '' FILES
+            while IFS= read -r -d $'\0' FILE; do
+                FILES+=("$FILE")
+            done < <(git ls-files -z --exclude-standard)
         else
             if git rev-parse --verify HEAD >/dev/null 2>&1; then
                 against=HEAD
@@ -126,12 +133,14 @@ get_files() {
                 # Initial commit: diff against initial commit
                 against=$(git log --reverse --pretty=format:%H | head -1)
             fi
-            git diff-index -z --cached --name-only "$against" | readarray -d '' FILES
+            while IFS= read -r -d $'\0' FILE; do
+                FILES+=("$FILE")
+            done < <(git diff-index -z --cached --name-only "$against")
         fi
     fi
 }
 
-# Test if argument is a text regular file
+# Test if argument is a text file
 # git grep tests whether Git considers it a text file
 # If files were explicitly specified, they are assumed to be text files
 is_text_file() {
@@ -169,7 +178,7 @@ reformat_files() {
             # Run clang-format on C/C++ files
             if is_cxx_file "$file"; then
                 check_clang_format
-                clang-format --assume-filename="$0" -- "$file" > "$temp"
+                (cd "$REPO" && clang-format) < "$file" > "$temp"
                 detect_change "$file" "$temp" "%s: Reformatting with clang-format according to coding guidelines"
             fi
 

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -8,8 +8,8 @@
 // See LICENSE in the top level directory for licensing details
 //
 
-#include "RevMemCtrl.h"
 #include "RevInstTable.h"
+#include "RevMemCtrl.h"
 
 namespace SST::RevCPU {
 

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1,7 +1,7 @@
-#include "RevSysCalls.h"
 #include "RevCommon.h"
 #include "RevCore.h"
 #include "RevMem.h"
+#include "RevSysCalls.h"
 #include <bitset>
 #include <filesystem>
 #include <sys/xattr.h>

--- a/test/syscalls/printf/printf.c
+++ b/test/syscalls/printf/printf.c
@@ -1,5 +1,5 @@
-#include "printf.h"
 #include "../../../common/syscalls/syscalls.h"
+#include "printf.h"
 #include <unistd.h>
 
 int main() {


### PR DESCRIPTION
This allows specifying filenames on the `pre-commit` script command-line, to reformat files which might exist outside of a Git repository.

Note that the `pre-commit` script should still exist in a Rev Git repository clone, because the script uses its own path to set the directory where the `.clang-format` file should be found, which is at the top of the Rev source tree.

`clang-format` [does not have a very good way](https://bugs.llvm.org/show_bug.cgi?id=20753) of explicitly specifying a `.clang-format` file. You can only specify it indirectly by using `--assume-filename`, where that refers to some file in a source tree where `.clang-format` exists up the directory tree. In this case, `pre-commit` uses `--assume-filename="$0"` (specifying itself) to point to somewhere in the tree where `.clang-format` can be found up the directory hierarchy.

So for example,
```
cd ~/mydir
~/rev/.githooks/pre-commit mysourcefile1.cpp mysourcefile2.cpp
```
Right now it does not support  recursively reformatting directories, unless it's called from inside a Git repo without explicit filenames (such as using the `--reformat` option to reformat an entire repo), because that would be too dangerous.

I have tested this on Linux but not on MacOS.


