### PR TITLE
Regression suite for stable C++ support methods on REV target

### DIFF
--- a/test/udruntime/include/debug.h
+++ b/test/udruntime/include/debug.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2021 University of Chicago and Argonne National Laboratory
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author - Jose M Monsalve Diaz
+ *
+ * Helper functions to add debug comments, error messages and others
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+//TODO set using compiler flags only
+#ifndef ASST
+#define ASST
+#endif
+
+#ifdef ASST
+#include "rev-macros.h"
+#include "syscalls.h"
+
+#undef assert
+#define assert TRACE_ASSERT
+#endif
+
+#ifndef DEBUG_MODE
+#define rev_udrt_print( ... )
+#endif
+
+#define __FILENAME__ \
+  ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
+
+// Macro for output of information, warning and error messages
+#ifdef DEBUG_MODE
+
+#ifndef ASST
+#define UPDOWN_ASSERT( assertion, message, ... )              \
+  {                                                           \
+    for( ; !( assertion );                                    \
+         printf( "[UPDOWN_ASSERT_FAIL: %s:%i] " message "\n", \
+                 __FILENAME__,                                \
+                 __LINE__,                                    \
+                 ##__VA_ARGS__ ),                             \
+         fflush( stderr ),                                    \
+         fflush( stdout ),                                    \
+         assert( 0 ) ) {                                      \
+    }                                                         \
+  }
+#else
+#define UPDOWN_ASSERT( assertion, message, ... ) \
+  { TRACE_ASSERT( assertion ); }
+#endif
+
+#ifndef ASST
+#define UPDOWN_WARNING( message, ... )               \
+  {                                                  \
+    printf( "[UPDOWN_WARNING: %s:%i] " message "\n", \
+            __FILENAME__,                            \
+            __LINE__,                                \
+            ##__VA_ARGS__ );                         \
+    fflush( stderr );                                \
+    fflush( stdout );                                \
+  }
+#else
+#define UPDOWN_WARNING( message, ... )        \
+  {                                           \
+    rev_udrt_print( "UPDOWN_WARNING: " );     \
+    rev_udrt_print( message, ##__VA_ARGS__ ); \
+  }
+#endif
+
+#ifndef ASST
+#define UPDOWN_WARNING_IF( condition, message, ... )   \
+  {                                                    \
+    if( condition ) {                                  \
+      printf( "[UPDOWN_WARNING: %s:%i] " message "\n", \
+              __FILENAME__,                            \
+              __LINE__,                                \
+              ##__VA_ARGS__ );                         \
+      fflush( stderr );                                \
+      fflush( stdout );                                \
+    }                                                  \
+  }
+#else
+#define UPDOWN_WARNING_IF( condition, message, ... ) \
+  {                                                  \
+    if( condition )                                  \
+      rev_udrt_print( "UPDOWN_WARNING: " );          \
+    rev_udrt_print( message, ##__VA_ARGS__ );        \
+  }
+#endif
+
+#ifndef ASST
+#define UPDOWN_ERROR( message, ... )                \
+  {                                                 \
+    fprintf( stderr,                                \
+             "[UPDOWN_ERROR: %s:%i] " message "\n", \
+             __FILENAME__,                          \
+             __LINE__,                              \
+             ##__VA_ARGS__ );                       \
+    fflush( stderr );                               \
+    fflush( stdout );                               \
+    assert( 0 && message );                         \
+  }
+#define UPDOWN_ERROR_IF( condition, message, ... )    \
+  {                                                   \
+    if( condition ) {                                 \
+      fprintf( stderr,                                \
+               "[UPDOWN_ERROR: %s:%i] " message "\n", \
+               __FILENAME__,                          \
+               __LINE__,                              \
+               ##__VA_ARGS__ );                       \
+      fflush( stderr );                               \
+      fflush( stdout );                               \
+      assert( 0 && message );                         \
+    }                                                 \
+  }
+#else
+#define UPDOWN_ERROR( message, ... ) \
+  { TRACE_ASSERT( 0 ); }
+#define UPDOWN_ERROR_IF( condition, message, ... ) \
+  {                                                \
+    if( condition ) {                              \
+      TRACE_ASSERT( 0 );                           \
+    }                                              \
+  }
+#endif
+
+#ifndef ASST
+#define UPDOWN_INFOMSG( message, ... )            \
+  {                                               \
+    printf( "[UPDOWN_INFO: %s:%i] " message "\n", \
+            __FILENAME__,                         \
+            __LINE__,                             \
+            ##__VA_ARGS__ );                      \
+    fflush( stderr );                             \
+    fflush( stdout );                             \
+  }
+#define UPDOWN_INFOMSG_IF( condition, message, ... ) \
+  {                                                  \
+    if( condition ) {                                \
+      printf( "[UPDOWN_INFO: %s:%i] " message "\n",  \
+              __FILENAME__,                          \
+              __LINE__,                              \
+              ##__VA_ARGS__ );                       \
+      fflush( stderr );                              \
+      fflush( stdout );                              \
+    }                                                \
+  }
+#else
+#define UPDOWN_INFOMSG( message, ... ) \
+  { rev_udrt_print( message, ##__VA_ARGS__ ); }
+#define UPDOWN_INFOMSG_IF( condition, message, ... ) \
+  {                                                  \
+    if( condition ) {                                \
+      rev_udrt_print( message, ##__VA_ARGS__ );      \
+    }                                                \
+  }
+#endif
+
+#else
+#define UPDOWN_ASSERT( assertion, message, ... ) \
+  {}
+#define UPDOWN_WARNING( message, ... ) \
+  {}
+#define UPDOWN_WARNING_IF( message, ... ) \
+  {}
+#define UPDOWN_ERROR( message, ... ) \
+  {}
+#define UPDOWN_ERROR_IF( message, ... ) \
+  {}
+#define UPDOWN_INFOMSG( message, ... ) \
+  {}
+#define UPDOWN_INFOMSG_IF( message, ... ) \
+  {}
+#endif  // END IF DEBUG_MODE

--- a/test/udruntime/include/event.h
+++ b/test/udruntime/include/event.h
@@ -1,0 +1,195 @@
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include "debug.h"
+
+#include "networkid.h"
+#include "operands.h"
+
+namespace UpDown {
+
+/**
+ * @brief Contains information of an )event in the UpDown
+ *
+ * This class constructs the information of the event word based on
+ * each of its parameters. It also contains a pointer to the operands
+ * that is used when sending the event
+ *
+ * @todo UpDown ID is not being used
+ * @todo, event_t considers a 4 byte word size
+ */
+class event_t {
+private:
+  word_t         EventWord = 0x0ffUL << 24;  // Fully encoded
+  networkid_t    NetworkId = networkid_t( 0 );
+  operands_t*    Operands  = nullptr;  // Operands to be sent with this event
+  static uint8_t save_tid;
+
+public:
+  word_t get_EventWord() {
+    return EventWord;
+  }
+
+  operands_t* get_Operands() {
+    return Operands;
+  }
+
+  void set_operands( operands_t* ops ) {
+    Operands = ops;
+  }
+
+  networkid_t get_NetworkId() {
+    return NetworkId;
+  }
+
+  uint8_t get_ThreadId() {
+    return ( EventWord >> 24 ) & 0xff;
+  }
+
+  uint32_t get_EventLabel() {
+    return EventWord & 0xfffff;
+  }
+
+  void set_EventLabel( uint32_t label ) {
+    EventWord = ( EventWord & 0xFFFFFFFFFFF00000 ) | ( label & 0xfffff );
+  }
+
+  uint8_t get_NumOperands() {
+    return ( Operands != nullptr ) ? Operands->get_NumOperands() : 0;
+  }
+
+  uint8_t get_EncodedNumOperands() {
+    return get_EventWord() >> 20 & 0x7;
+  }
+
+  ptr_t get_OperandsData() {
+    return ( Operands != nullptr ) ? Operands->get_Data() : nullptr;
+  }
+
+  /**
+   * @brief Construct a new empty event object
+   *
+   */
+
+  event_t() {
+    //UPDOWN_INFOMSG("event_t\n");
+    EventWord = ( ( ( ( 0xff << 24 ) & 0xff000000 ) |
+                    ( ( 0 << 20 ) & 0xf00000 ) | ( 0 & 0xfffff ) ) &
+                  0xffffffffffffffff );
+
+    UPDOWN_INFOMSG( "Creating a new event label = %d, "
+                    "thread_id = %d, num_operands = %d, ev_word = 0x%lX",
+                    get_EventLabel(),
+                    get_ThreadId(),
+                    0,
+                    get_EventWord() );
+  };
+
+  /**
+   * @brief Construct a new event_t object
+   *
+   * @param e_label Event label ID
+   * @param nwid Network ID representing Lane, Updown, Node, etc
+   * @param tid Thread ID
+   * @param operands Pointer to operands. Must be pre-initialized
+   */
+  event_t( uint32_t    e_label,
+           networkid_t nwid,
+           uint8_t     tid      = CREATE_THREAD,
+           operands_t* operands = nullptr ) {
+// UPDOWN_INFOMSG("event_t(%d, %d, %d, %lx)\n",
+//    e_label, nwid.get_NetworkId(), tid, reinterpret_cast<uint64_t>(operands));
+
+// uncomment next line to pass O2
+//#define O2_WORKAROUND
+// for some reason tid appears to be getting optimized out in O2.
+// printing it causes the test to pass.
+// Saving into static appears to have the same effect.
+#ifdef O2_WORKAROUND
+    save_tid = tid;
+#endif
+
+    NetworkId = nwid;
+    Operands  = operands;
+    if( operands ) {
+      assert( Operands->get_NumOperands() > 1 );
+    }
+    EventWord = ( NetworkId.get_NetworkId() & 0xffffffff );
+    EventWord =
+      ( ( EventWord << 32 ) & 0xffffffff00000000 ) |
+      ( ( tid << 24 ) & 0xff000000 ) | ( ( 0 << 23 ) & 0x800000 ) |
+      ( ( ( Operands != nullptr ? Operands->get_NumOperands() - 2 : 0 )
+          << 20 ) &
+        0xf00000 ) |
+      ( e_label & 0xfffff );
+    UPDOWN_INFOMSG( "Creating a new event label = %d, network_id = %d, "
+                    "thread_id = %d, num_operands = %d, ev_word = 0x%lx",
+                    get_EventLabel(),
+                    NetworkId.get_NetworkId(),
+                    get_ThreadId(),
+                    ( Operands != nullptr ) ? Operands->get_NumOperands() : 0,
+                    EventWord );
+  }
+
+  /**
+   * @brief Set the event word object with new values
+   *
+   * @param e_label the ID of the event in the updown
+   * @param noperands the number of operands
+   * @param lid Lane ID
+   * @param tid Thread ID
+   */
+  void set_event( uint32_t    e_label,
+                  networkid_t nwid,
+                  uint8_t     tid      = CREATE_THREAD,
+                  operands_t* operands = nullptr ) {
+    // UPDOWN_INFOMSG("set_event(%d, %d, %d, %lx\n",
+    // 	   e_label, nwid.get_NetworkId(), tid, reinterpret_cast<uint64_t>(operands));
+    NetworkId = nwid;
+    Operands  = operands;
+    if( Operands ) {
+      assert( Operands->get_NumOperands() > 1 );
+    }
+    EventWord =
+      ( ( ( static_cast< uint64_t >( nwid.get_NetworkId() ) << 32 ) &
+          0xffffffff00000000 ) |
+        ( ( tid << 24 ) & 0xff000000 ) | ( ( 0 << 23 ) & 0x0800000 ) |
+        ( ( ( Operands != nullptr ? Operands->get_NumOperands() - 2 : 0 )
+            << 20 ) &
+          0xf00000 ) |
+        ( e_label & 0xfffff ) );
+    UPDOWN_INFOMSG( "Setting the event word = %d, network_id = %d, "
+                    "thread_id = %d, num_operands = %d, ev_word = 0x%lX",
+                    get_EventLabel(),
+                    nwid.get_NetworkId(),
+                    tid,
+                    ( Operands != nullptr ) ? Operands->get_NumOperands() : 0,
+                    (unsigned long) EventWord );
+  }
+
+  // REV
+  event_t( event_t& rhs ) {
+    EventWord = rhs.get_EventWord();
+    NetworkId = rhs.get_NetworkId();
+    Operands  = rhs.get_Operands();
+  }
+
+  event_t( event_t&& ) = default;
+
+  event_t& operator=( event_t& rhs ) {
+    EventWord = rhs.get_EventWord();
+    NetworkId = rhs.get_NetworkId();
+    Operands  = rhs.get_Operands();
+    return *this;
+  }
+
+  event_t& operator=( event_t&& ) = default;
+};
+
+uint8_t event_t::save_tid = 0xff;
+}  // namespace UpDown

--- a/test/udruntime/include/networkid.h
+++ b/test/udruntime/include/networkid.h
@@ -1,0 +1,150 @@
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include "debug.h"
+
+namespace UpDown {
+
+/**
+ * @brief Contains encoding of hardware structures in UpDown System
+ *
+ * This class constructs the networkID description. The networkID are
+ * the MSB of the event word, and they describe a unique location in
+ * the system. There are two formats that can be enconded in the
+ * networkID. This is determined by the TopUd bit.
+ *
+ * # Top/UD = 0 (UD Network IDs):
+ * * Lane (6 bits)
+ * * UDs (2 bits)
+ * * Stack (3 bits)
+ * * Node (16 bits)
+ * * Send Policy (3 bits)
+ *
+ * # Top/UD = 1 (Top core or LLC Network IDs):
+ * * Core or LLC ID (5 bits)
+ * * Core Structures (3 bits): Cache/Prefetch buffer/Load-store queues
+ * * Operation (3 bits): Invalidate, write, etc...
+ * * Node (16 bits)
+ *
+ * @todo: Add encoding for top network elements
+ */
+class networkid_t {
+private:
+  uint32_t NetworkId;  // Complete networkID encoded
+public:
+  uint32_t get_NetworkId() {
+    return NetworkId;
+  }
+
+  uint32_t get_NetworkId_UdName() {
+    return NetworkId & ( ( 1 << ( 6 + 2 + 3 + 16 ) ) - 1 );
+  }
+
+  uint8_t get_LaneId() {
+    return ( NetworkId & 0x3f );
+  }
+
+  uint8_t get_UdId() {
+    return ( NetworkId & 0xc0 ) >> 6;
+  }
+
+  uint8_t get_StackId() {
+    return ( NetworkId & 0x700 ) >> 8;
+  }
+
+  uint16_t get_NodeId() {
+    return ( NetworkId & 0x7fff800 ) >> 11;
+  }
+
+  uint8_t get_SendPolicy() {
+    return ( NetworkId & 0x38000000 ) >> 27;
+  }
+
+  uint8_t get_TopUd() {
+    return ( NetworkId & 0x80000000 ) >> 31;
+  }
+
+  void set_SendPolicy( uint8_t SendPolicy ) {
+    NetworkId = NetworkId & 0xC7FFFFFF | ( ( SendPolicy << 27 ) & 0x38000000 );
+  }
+
+  /**
+   * @brief Construct a new network id
+   *
+   */
+  networkid_t() : NetworkId( 0 ) {
+    // rev_fast_print restricted to 6 words
+    assert( get_TopUd() == 0 );
+    UPDOWN_INFOMSG(
+      "(a) Creating a new network id TopUd = 0, SendPolicy = %d, NodeId = %d, "
+      "StackId=%d, UDId = 0x%X, lane_id=%d, network_id=0x%X",
+      //get_TopUd(),
+      get_SendPolicy(),
+      get_NodeId(),
+      get_StackId(),
+      get_UdId(),
+      get_LaneId(),
+      get_NetworkId() );
+  }
+
+  networkid_t( uint8_t  lane_id,
+               uint8_t  udid       = 0,
+               uint8_t  stack_id   = 0,
+               uint32_t nodeid     = 0,
+               uint8_t  topud      = 0,
+               uint8_t  sendpolicy = 0 ) {
+    NetworkId =
+      ( ( topud << 31 ) & 0x80000000 ) | ( ( sendpolicy << 27 ) & 0x38000000 ) |
+      ( ( nodeid << 11 ) & 0x7fff800 ) | ( ( stack_id << 8 ) & 0x700 ) |
+      ( ( udid << 6 ) & 0xC0 ) | ( ( lane_id & 0x3f ) );
+    assert( get_TopUd() == 0 );
+    UPDOWN_INFOMSG(
+      "(b) Creating a new network id TopUd = 0, SendPolicy = %d, NodeId = %d, "
+      "StackId=%d, UDId = 0x%X, lane_id=%d, network_id=0x%X",
+      //get_TopUd(),
+      get_SendPolicy(),
+      get_NodeId(),
+      get_StackId(),
+      get_UdId(),
+      get_LaneId(),
+      get_NetworkId() );
+  }
+
+  networkid_t( uint32_t ud_name, bool topud, uint8_t sendpolicy ) :
+    NetworkId( ( ( topud << 31 ) & 0x80000000 ) |
+               ( ( sendpolicy << 27 ) & 0x38000000 ) |
+               ( ( ud_name & 0x7FFFFFF ) ) ) {
+    assert( get_TopUd() == 0 );
+    UPDOWN_INFOMSG(
+      "(c) Creating a new network id TopUd = 0, SendPolicy = %d, NodeId = %d, "
+      "StackId=%d, UDId = 0x%X, lane_id=%d, network_id=0x%X",
+      //get_TopUd(),
+      get_SendPolicy(),
+      get_NodeId(),
+      get_StackId(),
+      get_UdId(),
+      get_LaneId(),
+      get_NetworkId() );
+  }
+
+  // REV
+  networkid_t( networkid_t& rhs ) {
+    NetworkId = rhs.get_NetworkId();
+  }
+
+  networkid_t( networkid_t&& ) = default;
+
+  networkid_t& operator=( networkid_t& rhs ) {
+    NetworkId = rhs.get_NetworkId();
+    return *this;
+  }
+
+  networkid_t& operator=( networkid_t&& ) = default;
+};
+
+}  // namespace UpDown

--- a/test/udruntime/include/operands.h
+++ b/test/udruntime/include/operands.h
@@ -1,0 +1,228 @@
+#pragma once
+#ifndef __UD_OPERANDS_H_
+#define __UD_OPERANDS_H_
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include "debug.h"
+
+//BEGIN A_SST
+#include "syscalls.h"
+
+//END A_SST
+
+namespace UpDown {
+
+template< typename T >
+class RevAllocPolicy {
+public:
+  RevAllocPolicy< T >()  = default;
+  ~RevAllocPolicy< T >() = default;
+
+  T* Create( size_t t ) {
+    T* p = reinterpret_cast< T* >( rev_mmap( 0,
+                                             t,
+                                             PROT_READ | PROT_WRITE | PROT_EXEC,
+                                             MAP_PRIVATE | MAP_ANONYMOUS,
+                                             -1,
+                                             0 ) );
+    return p;
+  }
+
+  void Destroy( T* p, uint8_t l ) {
+    std::size_t addr = reinterpret_cast< std::size_t >( p );
+    rev_munmap( addr, sizeof( T ) * l );
+  }
+};
+
+template< typename T >
+class StdAllocPolicy {
+public:
+  StdAllocPolicy< T >()  = default;
+  ~StdAllocPolicy< T >() = default;
+
+  T* Create( size_t t ) {
+    return reinterpret_cast< T* >( malloc( t ) );
+  }
+
+  void Destroy( T* p, uint8_t l ) {
+    free( p );
+  }
+};
+
+/**
+ * @brief Class that holds information about the operands.
+ *
+ * Contains a pointer to data and the number of operands.
+ * data is an array of ptr_t, representing each word in the
+ * operand buffer when copied.
+ *
+ *
+ */
+
+template< class AllocPolicy >
+class operandstemplate_t : public AllocPolicy {
+private:
+  // Number of operands 8 bits long. Up to 256 operands are allowed
+  uint8_t NumOperands;
+  // Pointer to the data to consider operands. Consecutive array of operands
+  ptr_t   Data;
+
+public:
+  /**
+   * @brief Construct a new empty operands_t object
+   *
+   * Set the Data pointer to null and NumOperands to 0
+   */
+  operandstemplate_t< AllocPolicy >() : NumOperands( 0 ) {
+    Data    = AllocPolicy::Create( sizeof( word_t ) );
+    Data[0] = 0;
+  }
+
+  /**
+   * @brief Copy Constructor
+   *
+   * @param o other object
+   */
+  operandstemplate_t< AllocPolicy >(
+    const operandstemplate_t< AllocPolicy >& o ) :
+    NumOperands( o.NumOperands ) {
+    Data = AllocPolicy::Create( sizeof( word_t ) * ( NumOperands + 1 ) );
+    // Copy the data
+    if( NumOperands != 0 )
+      std::memcpy( o.Data, Data, sizeof( word_t ) * ( NumOperands + 1 ) );
+  }
+
+  /**
+   * @brief Copy Constructor
+   *
+   * @param o other object
+   */
+  operandstemplate_t< AllocPolicy >( operandstemplate_t< AllocPolicy >&& o ) :
+    NumOperands( o.NumOperands ), Data( o.Data ) {
+    // Reset the other operand's pointer
+    if( o ) {
+      o.Data = nullptr;
+    }
+  }
+
+  /**
+   * @brief Construct a new operands_t opbejct, setting the operands
+   *
+   * @param num Number of operaqnds
+   * @param oper Operand value
+   * @param cont Continuation event
+   *
+   * @todo This should avoid using memcpy
+   */
+  operandstemplate_t< AllocPolicy >( uint8_t num,
+                                     ptr_t   oper,
+                                     word_t  cont = 0 ) :
+    NumOperands( num ) {
+
+    Data    = AllocPolicy::Create( sizeof( word_t ) * ( NumOperands + 1 ) );
+    Data[0] = cont;  // Fake continuation
+    std::memcpy( Data + 1, oper, get_NumOperands() * sizeof( word_t ) );
+  }
+
+  /**
+   * @brief Construct a new operands_t opbejct,
+   *
+   * @param num Number of operaqnds
+   * @param cont Continuation event
+   *
+   * @todo This should avoid using memcpy
+   */
+  operandstemplate_t< AllocPolicy >( uint8_t num, word_t cont = 0 ) :
+    NumOperands( num ) {  // TODO: Avoid this malloc
+    Data    = AllocPolicy::Create( sizeof( word_t ) * ( NumOperands + 1 ) );
+    Data[0] = cont;
+  }
+
+  /**
+   * @brief Get the pointer to Data
+   *
+   * @return ptr_t pointer to data
+   */
+  ptr_t get_Data() {
+    return Data;
+  }
+
+  /**
+   * @brief Set an operand
+   *
+   * @param op operand number
+   * @param val value for the operand
+   */
+  inline void set_operand( uint64_t op, word_t val ) {
+    Data[op + 1] = val;
+  }
+
+  /**
+   * @brief Set multiple operands at once
+   *
+   * Example:
+   *
+   * ```C
+   * // Mapping a struct to different operands
+   * // Assume no padding
+   *
+   * struct A {
+   *  word_t v1; // 4 bytes
+   *  word_t v2; // 4 bytes
+   *  int * ptr; // 8 bytes
+   * };
+   *
+   * // Assuming word_t is 4 bytes,
+   * // size of A should be 16 bytes, using
+   * // 4 elements in the operand buffer
+   * int anInt;
+   * A myStr = {1, 2, &anInt};
+   * rt.set_operands(0,4, &myStr);
+   *
+   * // the struct will be copied bit a bit, each
+   * // operand in a different location.
+   * ```
+   *
+   * @param op_begin Start operand inclusive
+   * @param op_end End operand inclusive
+   * @param val pointer to the value to be copied
+   *
+   *
+   */
+  inline void set_operands( uint64_t op_begin, uint64_t op_end, void* val ) {
+    std::memcpy(
+      Data + op_begin + 1, val, ( op_end - op_begin ) * sizeof( word_t ) );
+  }
+
+  /**
+   * @brief Set the Continuation
+   *
+   * @param cont
+   */
+  inline void set_cont( word_t cont ) {
+    Data[0] = cont;
+  }
+
+  /**
+   * @brief Get the NumOperands
+   *
+   * @return uint8_t number of operands
+   */
+  uint8_t get_NumOperands() {
+    return NumOperands;
+  }
+
+  ~operandstemplate_t() {
+    AllocPolicy::Destroy( Data, NumOperands );
+  }
+};
+
+typedef operandstemplate_t< RevAllocPolicy< word_t > > operands_t;
+}  // namespace UpDown
+
+#endif

--- a/test/udruntime/include/revalloc.hpp
+++ b/test/udruntime/include/revalloc.hpp
@@ -1,0 +1,193 @@
+#include "syscalls.h"
+#include "unistd.h"
+#include <limits>
+#include <memory>
+#include <stdlib.h>
+
+#ifndef __REV_REVALLOC__
+#define __REV_REVALLOC__
+
+/*void* operator new(std::size_t t){
+     void* p = reinterpret_cast<void*>(rev_mmap(0,
+              t,
+              PROT_READ | PROT_WRITE | PROT_EXEC,
+              MAP_PRIVATE | MAP_ANONYMOUS,
+              -1,
+              0));
+    return p;
+}*/
+
+void* mynew( std::size_t t ) {
+  void* p =
+    reinterpret_cast< void* >( rev_mmap( 0,
+                                         t,
+                                         PROT_READ | PROT_WRITE | PROT_EXEC,
+                                         MAP_PRIVATE | MAP_ANONYMOUS,
+                                         -1,
+                                         0 ) );
+  return p;
+}
+
+template< typename T >
+class StandardAllocPolicy {
+public:
+  //    typedefs
+  typedef T                 value_type;
+  typedef value_type*       pointer;
+  typedef const value_type* const_pointer;
+  typedef value_type&       reference;
+  typedef const value_type& const_reference;
+  typedef std::size_t       size_type;
+  typedef std::ptrdiff_t    difference_type;
+
+public:
+  //    convert an StandardAllocPolicy<T> to StandardAllocPolicy<U>
+  template< typename U >
+  struct rebind {
+    typedef StandardAllocPolicy< U > other;
+  };
+
+public:
+  inline explicit StandardAllocPolicy() {
+  }
+
+  inline ~StandardAllocPolicy() {
+  }
+
+  inline explicit StandardAllocPolicy( StandardAllocPolicy const& ) {
+  }
+
+  template< typename U >
+  inline explicit StandardAllocPolicy( StandardAllocPolicy< U > const& ) {
+  }
+
+  //    memory allocation
+  inline pointer
+    allocate( size_type cnt,
+              typename std::allocator< void >::const_pointer = 0 ) {
+    return reinterpret_cast< pointer >(
+      rev_mmap( 0,  // Let rev choose the address
+                cnt * sizeof( T ),
+                PROT_READ | PROT_WRITE | PROT_EXEC,  // RWX permissions
+                MAP_PRIVATE | MAP_ANONYMOUS,         // Not shared, anonymous
+                -1,     // No file descriptor because it's an anonymous mapping
+                0 ) );  // No offset, irrelevant for anonymous mappings
+  }
+
+  inline void deallocate( pointer p, size_type n ) {
+    // void* t = reinterpret_cast<void*> (p);
+    std::size_t addr = reinterpret_cast< std::size_t >( p );
+    rev_munmap( addr, n );
+  }
+
+  //    size
+  inline size_type max_size() const {
+    return std::numeric_limits< size_type >::max();
+  }
+
+  //    construction/destruction
+  //inline void construct(pointer p, const T& t) { pointer z = new(sizeof(T); new(z) T(t); p = z; }
+  template< class U, class... Args >
+  inline void construct( U* p, Args&&... args ) {
+    new( p ) U( std::forward< Args >( args )... );
+  };
+
+  //template<class U, class... Args>
+  //inline void construct(U* p, Args&&... args){ pointer z = reinterpret_cast<U*>(mynew(sizeof(U))); new(z) U(std::forward<Args>(args)...); p = z;}
+  inline void destroy( pointer p ) {
+    p->~T();
+  }
+};  //    end of class StandardAllocPolicy
+
+// determines if memory from another
+// allocator can be deallocated from this one
+template< typename T, typename T2 >
+inline bool operator==( StandardAllocPolicy< T > const&,
+                        StandardAllocPolicy< T2 > const& ) {
+  return true;
+}
+
+template< typename T, typename OtherAllocator >
+inline bool operator==( StandardAllocPolicy< T > const&,
+                        OtherAllocator const& ) {
+  return false;
+}
+
+template< typename T, typename Policy = StandardAllocPolicy< T > >
+class Allocator : public Policy {
+private:
+  typedef Policy AllocationPolicy;
+
+public:
+  typedef typename AllocationPolicy::size_type       size_type;
+  typedef typename AllocationPolicy::difference_type difference_type;
+  typedef typename AllocationPolicy::pointer         pointer;
+  typedef typename AllocationPolicy::const_pointer   const_pointer;
+  typedef typename AllocationPolicy::reference       reference;
+  typedef typename AllocationPolicy::const_reference const_reference;
+  typedef typename AllocationPolicy::value_type      value_type;
+
+public:
+  template< typename U >
+  struct rebind {
+    typedef Allocator< U, typename AllocationPolicy::rebind< U >::other > other;
+  };
+
+public:
+  inline explicit Allocator() {
+  }
+
+  inline ~Allocator() {
+  }
+
+  inline Allocator( Allocator const& rhs ) : Policy( rhs ) {
+  }
+
+  template< typename U >
+  inline Allocator( Allocator< U > const& ) {
+  }
+
+  template< typename U, typename P >
+  inline Allocator( Allocator< U, P > const& rhs ) : Policy( rhs ) {
+  }
+};  //    end of class Allocator
+
+// determines if memory from another
+// allocator can be deallocated from this one
+template< typename T, typename P >
+inline bool operator==( Allocator< T, P > const& lhs,
+                        Allocator< T, P > const& rhs ) {
+  return operator==( static_cast< P& >( lhs ), static_cast< P& >( rhs ) );
+}
+
+template< typename T, typename P, typename T2, typename P2 >
+inline bool operator==( Allocator< T, P > const&   lhs,
+                        Allocator< T2, P2 > const& rhs ) {
+  return operator==( static_cast< P& >( lhs ), static_cast< P2& >( rhs ) );
+}
+
+template< typename T, typename P, typename OtherAllocator >
+inline bool operator==( Allocator< T, P > const& lhs,
+                        OtherAllocator const&    rhs ) {
+  return operator==( static_cast< P& >( lhs ), rhs );
+}
+
+template< typename T, typename P >
+inline bool operator!=( Allocator< T, P > const& lhs,
+                        Allocator< T, P > const& rhs ) {
+  return !operator==( lhs, rhs );
+}
+
+template< typename T, typename P, typename T2, typename P2 >
+inline bool operator!=( Allocator< T, P > const&   lhs,
+                        Allocator< T2, P2 > const& rhs ) {
+  return !operator==( lhs, rhs );
+}
+
+template< typename T, typename P, typename OtherAllocator >
+inline bool operator!=( Allocator< T, P > const& lhs,
+                        OtherAllocator const&    rhs ) {
+  return !operator==( lhs, rhs );
+}
+
+#endif

--- a/test/udruntime/include/revupdown.h
+++ b/test/udruntime/include/revupdown.h
@@ -1,0 +1,163 @@
+/*
+ *  This wrapper will be removed once memory mapped based communication is in place.
+ *  That is, this is part of a planned transition to using updown.h natively.
+ */
+
+#ifndef _REVUPDOWN_H_
+#define _REVUPDOWN_H_
+
+// Use local Rev variant
+#include "updown.h"
+
+namespace UpDown {
+
+typedef UpDown::UDRuntime_t<
+  UpDown::RevRTAllocPolicy< UpDown::ud_mapped_memory_t > >
+  UDRuntimeA_t;
+
+class RevUDRuntime_t : public UDRuntimeA_t {
+
+public:
+  RevUDRuntime_t( UpDown::ud_machine_t m ) : UDRuntimeA_t( m ) {
+    // ECALL 4000: Initialize Rev UpDown CoProcessor
+    // TODO Eliminate by using shared simulator configuration data
+    int rc;
+    asm volatile( "add  a1, %1, x0 \n\t"
+                  "li a7, 4000     \n\t"
+                  "ecall           \n\t"
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( &m )
+                  : "a0", "a1", "a7" );
+    assert( rc == 0 );
+  };
+
+  virtual ~RevUDRuntime_t(){};
+
+  int rt_wait( unsigned timeout = 1024 ) {
+    // ECALL 4001: Wait for CoProcessor busy to clear
+    int rc;
+    asm volatile(
+      "move a1, %1              \n\t"  // init timeout
+      "li a7, 4001              \n\t"
+      "1:                       \n\t"  // rt_wait_loop
+      "ecall                    \n\t"
+      "beq a0, x0, 2f           \n\t"  // if equal branch to rt_wait_done
+      "addi a1,a1,-1            \n\t"  // timeout--
+      "bne a1, x0, 1b           \n\t"  // if not equal branch to rt_wait_loop
+      "2:                       \n\t"  // rt_wait_done
+      "move %0, a0              \n\t"
+      : "=r"( rc )
+      : "r"( timeout )
+      : "a0", "a1", "a7" );
+    return rc;
+  }
+
+  void t2ud_memcpy( void*       data,
+                    uint64_t    size,
+                    networkid_t nwid,
+                    uint32_t    offset ) override {
+    // ECALL 4010: Copy TOP data to UD scratchpad
+    if( rt_wait() != 0 )
+      assert( false );
+    int rc;
+    asm volatile( "add  a1, %1, x0 \n\t"  // data
+                  "add  a2, %2, x0 \n\t"  // size
+                  "add  a3, %3, x0 \n\t"  // &nwid
+                  "add  a4, %4, x0 \n\t"  // offset
+                  "li a7, 4010     \n\t"
+                  "ecall           \n\t"
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( data ), "r"( size ), "r"( &nwid ), "r"( offset )
+                  : "a0", "a1", "a2", "a3", "a4", "a7" );
+    assert( rc == 0 );
+  };
+
+  void ud2t_memcpy( void*       data,
+                    uint64_t    size,
+                    networkid_t nwid,
+                    uint32_t    offset ) override {
+    // ECALL 4011: Copy UD data to TOP
+    if( rt_wait() != 0 )
+      assert( false );
+    int rc;
+    asm volatile( "add  a1, %1, x0 \n\t"  // data
+                  "add  a2, %2, x0 \n\t"  // size
+                  "add  a3, %3, x0 \n\t"  // &nwid
+                  "add  a4, %4, x0 \n\t"  // offset
+                  "li a7, 4011     \n\t"
+                  "ecall           \n\t"
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( data ), "r"( size ), "r"( &nwid ), "r"( offset )
+                  : "a0", "a1", "a2", "a3", "a4", "a7" );
+    assert( rc == 0 );
+  };
+
+  void send_event( event_t ev ) override {
+    // ECALL 4020: Send an event to the UpDown event queues
+    if( rt_wait() != 0 )
+      assert( false );
+    int         rc;
+    operands_t* ops =
+      ev.get_Operands();  // Very confusing data type to work with
+    uint64_t* data         = ops->get_Data();
+    uint64_t  cont         = data[0];
+    uint64_t  num_operands = ops->get_NumOperands();
+    asm volatile( "add  a1, %1, x0 \n\t"  // event_t* ev
+                  "add  a2, %2, x0 \n\t"  // uint64_t cont
+                  "add  a3, %3, x0 \n\t"  // uint64_t* data
+                  "add  a4, %4, x0 \n\t"  // uint64_t num_operands
+                  "li a7, 4020     \n\t"  //
+                  "ecall           \n\t"
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( &ev ), "r"( cont ), "r"( data ), "r"( num_operands )
+                  : "a0", "a1", "a2", "a3", "a4", "a7" );
+    assert( rc == 0 );
+  };
+
+  void start_exec( networkid_t nwid ) override {
+    // ECALL 4021: Start a lane
+    if( rt_wait() != 0 )
+      assert( false );
+    int rc;
+    asm volatile( "add  a1, %1, x0 \n\t"  // nwid
+                  "li a7, 4021     \n\t"
+                  "ecall           \n\t"
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( &nwid )
+                  : "a0", "a1", "a7" );
+    assert( rc == 0 );
+  };
+
+  bool test_addr( networkid_t nwid, uint32_t offset, word_t expected = 1 ) {
+    // ECALL 4022: Test a memory location for a value
+    if( rt_wait() != 0 )
+      assert( false );
+    int          rc;
+    volatile int result = 0;
+    asm volatile( "add  a1, %1, x0 \n\t"  // nwid
+                  "add  a2, %2, x0 \n\t"  // offset
+                  "add  a3, %3, x0 \n\t"  // expected
+                  "add  a4, %4, x0 \n\t"  // &result
+                  "li   a7, 4022   \n\t"
+                  "ecall           \n\t"  // launches memory read request
+                  "add %0, a0, x0  \n\t"
+                  : "=r"( rc )
+                  : "r"( &nwid ), "r"( offset ), "r"( expected ), "r"( &result )
+                  : "a0", "a1", "a2", "a3", "a4", "a7" );
+    assert( rc == 0 );
+    rt_wait();  // wait for memory request to finish
+    //assert(result==1); // TODO remove this when accelerator working. Also change in RevSysCalls.cc which is forcing result to true
+    return result;
+  };
+
+
+};  // class RevUDRuntime_t
+
+}  // namespace UpDown
+
+#endif  //_REVUPDOWN_H_

--- a/test/udruntime/include/ud_machine.h
+++ b/test/udruntime/include/ud_machine.h
@@ -1,0 +1,66 @@
+#pragma once
+#ifndef __UD_MACHINE_H__
+#define __UD_MACHINE_H__
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include "debug.h"
+
+namespace UpDown {
+/**
+ * @brief Structure containing the machine configuration.
+ *
+ * This structure can be used to change the parameters of the runtime, during
+ * runtime construction.
+ */
+
+struct ud_machine_t {
+  // Offsets for addrs space
+  uint64_t MapMemBase = BASE_MAPPED_ADDR;  // Base address for memory map
+  uint64_t GMapMemBase =
+    BASE_MAPPED_GLOBAL_ADDR;                    // Base address for memory map
+  uint64_t UDbase           = BASE_SPMEM_ADDR;  // Base address for upstream
+  uint64_t SPMemBase        = BASE_SPMEM_ADDR;  // ScratchPad Base address
+  uint64_t ControlBase      = BASE_CTRL_ADDR;   // Base for control operands
+  uint64_t ProgBase         = BASE_PROG_ADDR;   // Base for control operands
+  uint64_t EventQueueOffset = EVENT_QUEUE_OFFSET;  // Offset for Event Queues
+  uint64_t OperandQueueOffset =
+    OPERAND_QUEUE_OFFSET;                        // Offset for Operands Queues
+  uint64_t StartExecOffset = START_EXEC_OFFSET;  // Offset for Start Exec signal
+  uint64_t LockOffset      = LOCK_OFFSET;        // Offset for Lock signal
+
+  // Machine config and capacities
+  uint64_t CapNumNodes     = NUM_NODES_CAPACITY;       // Max number of UpDowns
+  uint64_t CapNumStacks    = NUM_STACKS_CAPACITY;      // Max number of UpDowns
+  uint64_t CapNumUDs       = NUM_UDS_CAPACITY;         // Max number of UpDowns
+  uint64_t CapNumLanes     = NUM_LANES_CAPACITY;       // Max number of UpDowns
+  uint64_t CapSPmemPerLane = SPMEM_CAPACITY_PER_LANE;  // Max bank size per lane
+  uint64_t CapControlPerLane =
+    CONTROL_CAPACITY_PER_LANE;  // Max Control Sigs and regs per lane
+  uint64_t NumUDs           = DEF_NUM_UDS;     // Number of UpDowns
+  uint64_t NumLanes         = DEF_NUM_LANES;   // Number of lanes
+  uint32_t LocalMemAddrMode = 1;               // Local Memory Mode
+  uint64_t NumStacks        = DEF_NUM_STACKS;  // Number of lanes
+  uint64_t NumNodes         = DEF_NUM_NODES;   // Number of lanes
+
+  // Sizes for memories
+  uint64_t MapMemSize       = DEF_MAPPED_SIZE;   // Mapped Memory size
+  uint64_t GMapMemSize      = DEF_GMAPPED_SIZE;  // Mapped Memory size
+  uint64_t SPBankSize =
+    DEF_SPMEM_BANK_SIZE;  // Local Momory (scratchpad) Bank Size
+  uint64_t SPBankSizeWords =
+    DEF_SPMEM_BANK_SIZE * DEF_WORD_SIZE;  // LocalMemorySize in Words
+
+  // Scratchpad Memory Size
+  uint64_t SPSize() {
+    return this->CapNumNodes * this->CapNumStacks * this->CapNumUDs *
+           this->CapNumLanes * this->CapSPmemPerLane;
+  }
+};
+}  // namespace UpDown
+
+#endif

--- a/test/udruntime/include/updown.h
+++ b/test/udruntime/include/updown.h
@@ -1,0 +1,1784 @@
+/*
+ * Copyright (c) 2021 University of Chicago and Argonne National Laboratory
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Original Author - Jose M Monsalve Diaz
+ * Port To Rev - Dave Donofrio, Ken Griesser
+ *
+ */
+
+#ifndef UPDOWN_H
+#define UPDOWN_H
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <utility>
+
+#include "debug.h"
+#include "updown_config.h"
+
+#include "event.h"
+#include "ud_machine.h"
+
+#include "revalloc.hpp"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//TODO remove this. Only doing this since vscode intellisense isn't detecting it.
+#ifndef ASST
+#define ASST
+#endif
+
+namespace UpDown {
+
+template< typename T >
+class RevRTAllocPolicy {
+public:
+  RevRTAllocPolicy< T >()  = default;
+  ~RevRTAllocPolicy< T >() = default;
+
+  T* CreateMemMgr( ud_machine_t parms ) {
+    T* p = reinterpret_cast< T* >( rev_mmap( 0,
+                                             sizeof( T ),
+                                             PROT_READ | PROT_WRITE | PROT_EXEC,
+                                             MAP_PRIVATE | MAP_ANONYMOUS,
+                                             -1,
+                                             0 ) );
+    //p = new(p) T(std::forward<ud_machine_t>(parms));
+    p    = new( p ) T( parms );
+    return p;
+  }
+
+  void DestroyMemMgr( T* p ) {
+    std::size_t addr = reinterpret_cast< std::size_t >( p );
+    rev_munmap( addr, sizeof( T ) );
+  }
+};
+
+template< typename T >
+class StdRTAllocPolicy {
+public:
+  StdRTAllocPolicy< T >()  = default;
+  ~StdRTAllocPolicy< T >() = default;
+
+  T* CreateMemMgr( ud_machine_t parms ) {
+    return new T( parms );
+  }
+
+  void DestroyMemMgr( T* p ) {
+    delete( p );
+  }
+};
+
+/**
+ * @brief Class that defines local memory segments based on global segments
+ *
+ */
+
+
+/**
+ * @brief Class containing the UpDown Runtime
+ *
+ * This class is the entry point of the UpDown runtime, it manages all
+ * the necessary state, keeps track of pointers and memory allocation
+ * and coordinates execution of code.
+ *
+ */
+
+// Moved out some inner classes
+// class UDRuntime_t {
+// private:
+/**
+   * @brief Struct containing all the base addresses
+   *
+   * Base addresses are locations in memory where the
+   * top to updown communication happens.
+   *
+   * ## Current Memory Structure
+   * The memory is organized in two: Scratchpad memory and
+   * Control mapped registers and queues
+   *
+   * ### Scratchpad memory address space
+   * \verbatim
+   *        MEMORY                     SIZE
+   *   |--------------|  <-- Scratchpad Base Address
+   *   |              |
+   *   |   SPMEM UD0  |
+   *   |              |
+   *   |--------------|  <-- CapacityPerLane * CapacityNumLanes
+   *   |              |
+   *   |   SPMEM UD1  |
+   *   |              |
+   *   |--------------|  <-- 2 * CapacityPerLane * CapacityNumLanes
+   *   |      ...     |
+   *   |--------------|
+   *   |              |
+   *   |   SPMEM UDN  |
+   *   |              |
+   *   |--------------|  <-- NumUDs * CapacityPerLane * CapacityNumLanes
+   * \endverbatim
+   *
+   * ### Scratchpad memory for 1 UD
+   * \verbatim
+   *        MEMORY                     SIZE
+   *   |--------------|  <-- Scratchpad Base Address
+   *   |              |
+   *   |    Lane 0    |
+   *   |              |
+   *   |* * * * * * * |  <-- SPmem BankSize
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- CapacityPerLane
+   *   |              |
+   *   |    Lane 1    |
+   *   |              |
+   *   |* * * * * * * |  <-- CapacityPerLane + SPmem BankSize
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- 2 * CapacityPerLane
+   *   |      ...     |
+   *   |--------------|  <-- (NumLanes-1)*CapacityPerLane
+   *   |              |
+   *   |    Lane N    |
+   *   |              |
+   *   |* * * * * * * |  <-- (NumLanes-1)*CapacityPerLane + SPmem BankSize
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- (NumLanes) * CapacityPerLane
+   *   | * * * * * * *|
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|    | For expansion purposes
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|
+   *   |--------------|  <-- CapacityPerLane * CapacityNumLanes
+   * \endverbatim
+   *
+   * ### Control signals memory address space
+   * \verbatim
+   *        MEMORY                     SIZE
+   *   |--------------|  <-- Control Base Address
+   *   |              |
+   *   |  CONTROL UD0 |
+   *   |              |
+   *   |--------------|  <-- CapacityControlPerLane * CapacityNumLanes
+   *   |              |
+   *   |  CONTROL UD1 |
+   *   |              |
+   *   |--------------|  <-- 2 * CapacityControlPerLane * CapacityNumLanes
+   *   |      ...     |
+   *   |--------------|
+   *   |              |
+   *   |  CONTROL UD2 |
+   *   |              |
+   *   |--------------|  <-- NumUDs * CapacityControlPerLane * CapacityNumLanes
+   * \endverbatim
+   *
+   * ### Control signals memory address space for 1 UD
+   * \verbatim
+   *        MEMORY                     SIZE
+   *   |--------------|  <-- Control Base Address
+   *   |    Lane 0    |
+   *   |  Event Queue |
+   *   | Oprnds Queue |
+   *   |  Start Exec  |
+   *   |     Lock     |
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- CapacityControlPerLane
+   *   |    Lane 1    |
+   *   |  Event Queue |
+   *   | Oprnds Queue |
+   *   |  Start Exec  |
+   *   |     Lock     |
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- 2 * CapacityControlPerLane
+   *   |      ...     |
+   *   |--------------|  <-- (NumLanes-1) * CapacityControlPerLane
+   *   |    Lane N    |
+   *   |  Event Queue |
+   *   | Oprnds Queue |
+   *   |  Start Exec  |
+   *   |     Lock     |
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|    |
+   *   |* * * * * * * |    | For expansion purposes
+   *   | * * * * * * *|    |
+   *   |--------------|  <-- NumLanes * CapacityControlPerLane
+   *   | * * * * * * *|
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|    | For expansion purposes
+   *   |* * * * * * * |   -|
+   *   | * * * * * * *|
+   *   |--------------|  <-- CapacityControlPerLane * CapacityNumLanes
+   * \endverbatim
+   *
+   */
+// retained in class
+// struct base_addr_t {
+//   volatile ptr_t mmaddr;
+//   volatile ptr_t spaddr;
+//   volatile ptr_t ctrlAddr;
+//   volatile ptr_t progAddr;
+// };
+
+/**
+ * @brief This is a class to manage the mapped memory
+ *
+ * This class cosiders memory allocation and deallocation
+ * it contains all the information needed to do this.
+ */
+class ud_mapped_memory_t {
+private:
+  /**
+     * @brief A region in memory.
+     *
+     * This struct represents a region in memory, full or empty
+     *
+     */
+  struct mem_region_t {
+    uint64_t size;  // Size of the region
+    bool     free;  // Is the region free or being used
+  };
+
+  // Map to keep track of the free and used regions.
+  //std::map<void *, mem_region_t> regions_local;  // local segments
+  //std::map<void *, mem_region_t> regions_global; // global segments area
+  std::map< void*,
+            mem_region_t,
+            std::less< void* >,
+            Allocator< std::pair< const void*, mem_region_t > > >
+    regions_local;  // local segments
+  std::map< void*,
+            mem_region_t,
+            std::less< void* >,
+            Allocator< std::pair< const void*, mem_region_t > > >
+    regions_global;  // global segments area
+
+public:
+  /**
+     * @brief Construct a new ud_mapped_memory_t object
+     *
+     * Initializes the regions with a single region
+     * that is free and contains all the elements
+     *
+     * @param machine information from the description of the current machine
+     */
+  ud_mapped_memory_t( ud_machine_t& machine ) {
+    UPDOWN_INFOMSG( "Initializing Mapped Memory Manager for %lu at 0x%lX",
+                    machine.MapMemSize,
+                    machine.MapMemBase );
+    // Create the first segment
+    void* baseAddr           = reinterpret_cast< void* >( machine.MapMemBase );
+    regions_local[baseAddr]  = { machine.MapMemSize, true };
+    baseAddr                 = reinterpret_cast< void* >( machine.GMapMemBase );
+    regions_global[baseAddr] = { machine.GMapMemSize, true };
+  }
+
+  /**
+     * @brief Get a new region in memory
+     *
+     * This is equivalent to malloc, it finds a free region that
+     * can allocate the current size, and, if there is free space
+     * left, it creates a new region with the remaining free space.
+     *
+     * @param size size to be allocated in bytes.
+     * @return void* pointer to the allocated memory
+     */
+  void* get_region( uint64_t size, bool global ) {
+    UPDOWN_INFOMSG( "Allocating new region of size %lu bytes", size );
+    // Iterate over the regions finding one that fits
+
+    //std::map<void *, mem_region_t> *regions_to_use;
+    std::map< void*,
+              mem_region_t,
+              std::less< void* >,
+              Allocator< std::pair< const void*, mem_region_t > > >*
+      regions_to_use;
+    if( global )
+      regions_to_use = &regions_global;
+    else
+      regions_to_use = &regions_local;
+    auto  used_reg     = regions_to_use->end();
+    void* aligned_addr = nullptr;
+    for( auto it = regions_to_use->begin(); it != regions_to_use->end();
+         ++it ) {
+      // Check if region is free and have enough size
+      if( it->second.free && size <= it->second.size ) {
+        // Check alignment
+        aligned_addr = it->first;
+        if( reinterpret_cast< uint64_t >( aligned_addr ) % 8 != 0 ) {
+          uint64_t alignment_offset =
+            8 - ( reinterpret_cast< uint64_t >( aligned_addr ) % 8 );
+          if( it->second.size >= size + alignment_offset ) {
+            aligned_addr =
+              static_cast< char* >( aligned_addr ) + alignment_offset;
+          } else {
+            continue;
+          }
+        }
+
+        UPDOWN_INFOMSG( "Found a region at 0x%lX",
+                        reinterpret_cast< uint64_t >( it->first ) );
+        used_reg = it;
+        break;
+      }
+    }
+    // Check if we found space
+    if( used_reg == regions_to_use->end() ) {
+      UPDOWN_ERROR( "Allocator run out of memory. Cannot allocate %lu bytes",
+                    size );
+      return nullptr;
+    }
+
+    // Calculate alignment offset
+    uint64_t alignment_offset = reinterpret_cast< uint64_t >( aligned_addr ) -
+                                reinterpret_cast< uint64_t >( used_reg->first );
+    void* alloc_addr = nullptr;
+
+    // needs to be aligned
+    if( alignment_offset != 0 ) {
+      ( *regions_to_use )[aligned_addr] = { size, false };
+      UPDOWN_INFOMSG( "Creating a new region 0x%lX with the size %lu for new "
+                      "aligned allocation",
+                      reinterpret_cast< uint64_t >( aligned_addr ),
+                      size );
+      alloc_addr = aligned_addr;
+      if( used_reg->second.size - alignment_offset > size ) {
+        // Create a new empty region for unused space
+        void* new_region_addr = static_cast< char* >( aligned_addr ) + size;
+        ( *regions_to_use )[new_region_addr] = {
+          used_reg->second.size - alignment_offset - size, true };
+        UPDOWN_INFOMSG(
+          "Creating a new region 0x%lX with the remaining size %lu",
+          reinterpret_cast< uint64_t >( new_region_addr ),
+          used_reg->second.size - alignment_offset - size );
+      }
+      // Create a new empty region for alignment
+      used_reg->second.size = alignment_offset;
+      used_reg->second.free = true;
+    } else {
+      // no alignment needed
+      // split the new region
+      uint64_t new_size     = used_reg->second.size - size;
+      used_reg->second.size = size;
+      used_reg->second.free = false;
+      alloc_addr            = used_reg->first;
+      // Create a new empty region
+      if( new_size != 0 ) {
+        void* new_region_addr = static_cast< char* >( used_reg->first ) + size;
+        ( *regions_to_use )[new_region_addr] = { new_size, true };
+        UPDOWN_INFOMSG(
+          "Creating a new region 0x%lX with the remaining size %lu",
+          reinterpret_cast< uint64_t >( new_region_addr ),
+          new_size );
+      }
+    }
+
+    UPDOWN_INFOMSG( "Returning region 0x%lX = {%lu, Used}",
+                    reinterpret_cast< uint64_t >( alloc_addr ),
+                    size );
+    // Return the new pointer
+    return alloc_addr;
+  }
+
+  /**
+     * @brief Get a new region in memory at a specific address
+     *
+     * @param addr address to allocate the region
+     * @param size size to be allocated in bytes
+     * @param global if the region is global or local
+     * @return void* pointer to the allocated memory
+     */
+  void* get_region_at_addr( void* addr, uint64_t size, bool global ) {
+#ifndef ASST
+    UPDOWN_INFOMSG(
+      "Trying reserve region at %p of size %lu bytes", addr, size );
+#else
+    UPDOWN_INFOMSG( "Trying reserve region at 0x%lx of size %lu bytes",
+                    reinterpret_cast< uint64_t >( addr ),
+                    size );
+#endif
+    // Iterate over the regions finding one that fits
+    //std::map<void *, mem_region_t> *alloc_regions;
+    std::map< void*,
+              mem_region_t,
+              std::less< void* >,
+              Allocator< std::pair< const void*, mem_region_t > > >*
+      alloc_regions;
+    if( global )
+      alloc_regions = &regions_global;
+    else
+      alloc_regions = &regions_local;
+    auto sel_region = alloc_regions->end();
+    for( auto it = alloc_regions->begin(); it != alloc_regions->end(); ++it ) {
+      // Check if region is free and have enough size
+      if( it->first <= addr && it->second.free && size <= it->second.size ) {
+        UPDOWN_INFOMSG( "Found a region at 0x%lX",
+                        reinterpret_cast< uint64_t >( it->first ) );
+        sel_region = it;
+      } else if( it->first > addr ) {
+        break;
+      }
+    }
+    // Check if we found space
+    if( sel_region == alloc_regions->end() ) {
+      UPDOWN_ERROR( "Allocator cannot allocate %lu bytes at %p", size, addr );
+      return nullptr;
+    }
+    // split the new region
+    if( sel_region->first < addr ) {
+      // with leading free region
+      uint64_t sel_region_size = sel_region->second.size;
+      // change the size of the leading free region
+      sel_region->second.size =
+        reinterpret_cast< uint64_t >( addr ) -
+        reinterpret_cast< uint64_t >( sel_region->first );
+      // create new occupied region
+      ( *alloc_regions )[addr] = { size, false };
+      UPDOWN_INFOMSG( "Creating allocated region 0x%lX = {%lu, Used}",
+                      reinterpret_cast< uint64_t >( addr ),
+                      size );
+      // create new free region if there is space left
+      uint64_t new_size = sel_region_size - size - sel_region->second.size;
+      if( new_size != 0 ) {
+        void* new_reg               = static_cast< char* >( addr ) + size;
+        ( *alloc_regions )[new_reg] = { new_size, true };
+        UPDOWN_INFOMSG(
+          "Creating a new free region 0x%lX with the remaining size %lu",
+          reinterpret_cast< uint64_t >( new_reg ),
+          new_size );
+      }
+    } else {
+      // no leading free region
+      uint64_t sel_region_size = sel_region->second.size;
+      // change the size of the occupied region
+      sel_region->second.size  = size;
+      sel_region->second.free  = false;
+      // create new free region if there is space left
+      uint64_t new_size        = sel_region_size - size;
+      if( new_size != 0 ) {
+        void* new_reg = static_cast< char* >( sel_region->first ) + size;
+        ( *alloc_regions )[new_reg] = { new_size, true };
+        UPDOWN_INFOMSG(
+          "Creating a new free region 0x%lX with the remaining size %lu",
+          reinterpret_cast< uint64_t >( new_reg ),
+          new_size );
+      }
+    }
+    return addr;
+  }
+
+  /**
+     * @brief Remove a region
+     *
+     * This is equivalent to free. It removes a region from the map
+     * and extends the region before or after this one if they are free.
+     * Otherwise it creates a new free region
+     *
+     * @param ptr Pointer to be free. It must be a pointer in the regions map
+     *
+     */
+  void remove_region( void* ptr, bool global ) {
+    UPDOWN_INFOMSG( "Freeing the space at 0x%lX",
+                    reinterpret_cast< uint64_t >( ptr ) );
+    // Find location to free
+    //std::map<void *, mem_region_t> *regions_to_use;
+    std::map< void*,
+              mem_region_t,
+              std::less< void* >,
+              Allocator< std::pair< const void*, mem_region_t > > >*
+      regions_to_use;
+    if( global )
+      regions_to_use = &regions_global;
+    else
+      regions_to_use = &regions_local;
+    auto it = regions_to_use->find( ptr );
+    if( it == regions_to_use->end() || it->second.free ) {
+      UPDOWN_ERROR( "Trying to free pointer 0x%lX that is not in the regions"
+                    " or the region is free (double free?)",
+                    reinterpret_cast< uint64_t >( ptr ) );
+      return;
+    }
+    // merge left if free
+    if( it != regions_to_use->begin() && std::prev( it, 1 )->second.free ) {
+      uint64_t size = it->second.size;
+      it--;
+      it->second.size += size;
+      UPDOWN_INFOMSG( "Merging left 0x%lX to 0x%lX, adding %lu for a total of "
+                      "region with %lu",
+                      reinterpret_cast< uint64_t >( it->first ),
+                      reinterpret_cast< uint64_t >( std::next( it, 1 )->first ),
+                      size,
+                      it->second.size );
+      UPDOWN_INFOMSG( "Removing previous region at 0x%lX",
+                      reinterpret_cast< uint64_t >( it->first ) );
+      regions_to_use->erase( std::next( it, 1 ) );
+    }
+    // merge right if free
+    auto nextIt = std::next( it, 1 );
+    if( nextIt != regions_to_use->end() && nextIt->second.free ) {
+      uint64_t size = nextIt->second.size;
+      it->second.size += size;
+      UPDOWN_INFOMSG( "Merging right 0x%lX to 0x%lX, adding %lu for a total of "
+                      "region with %lu",
+                      reinterpret_cast< uint64_t >( it->first ),
+                      reinterpret_cast< uint64_t >( nextIt->first ),
+                      size,
+                      it->second.size );
+      UPDOWN_INFOMSG( "Removing previous region at 0x%lX",
+                      reinterpret_cast< uint64_t >( it->first ) );
+      regions_to_use->erase( nextIt );
+    }
+
+    // Check if there were no merges
+    if( it->first == ptr ) {
+#ifndef ASST
+      UPDOWN_INFOMSG( "No merges performed, just freeing 0x%lX = {%lu, %s}",
+                      reinterpret_cast< uint64_t >( it->first ),
+                      ( it->second.size ),
+                      ( it->second.free ) ? "Free" : "Used" );
+#else
+      if( it->second.free ) {
+        UPDOWN_INFOMSG( "No merges performed, just freeing 0x%lX = {%lu, Free}",
+                        reinterpret_cast< uint64_t >( it->first ),
+                        ( it->second.size ) );
+      } else {
+        UPDOWN_INFOMSG( "No merges performed, just freeing 0x%lX = {%lu, Used}",
+                        reinterpret_cast< uint64_t >( it->first ),
+                        ( it->second.size ) );
+      }
+#endif
+      it->second.free = true;
+    }
+  }
+};
+
+// moved from above to avoid inner classes
+template< class AllocationPolicy >
+class UDRuntime_t : public AllocationPolicy {
+private:
+  struct base_addr_t {
+    volatile ptr_t mmaddr;
+    volatile ptr_t spaddr;
+    volatile ptr_t ctrlAddr;
+    volatile ptr_t progAddr;
+  };
+
+  /**
+   * @brief This is a class to manage the mapped memory
+   *
+   * This class cosiders memory allocation and deallocation
+   * it contains all the information needed to do this.
+   */
+
+protected:
+  /**
+   * @brief container for all base addresses
+   *
+   */
+  base_addr_t         BaseAddrs;
+
+  /**
+   * @brief Contains configuration parameters of the machine abstraction
+   *
+   */
+  ud_machine_t        MachineConfig;
+
+  /**
+   * @brief
+   *
+   */
+  ud_mapped_memory_t* MappedMemoryManager;
+
+  /**
+   * @brief Initializes the base addresses for queues and states
+   *
+   * This function initializes BaseAddrs according to the configuration
+   * file for their use in the rest of the runtime
+   *
+   */
+  void                calc_addrmap();
+
+  /**
+   * @brief Get the aligned offset object
+   *
+   * @param ud_id UpDown ID
+   * @param lane_num Lane ID
+   * @param offset Offset in bytes
+   * @return uint64_t
+   */
+  uint64_t    get_lane_aligned_offset( networkid_t nwid, uint32_t offset = 0 );
+
+  /**
+   * @brief Get the global UD number based on the network_id
+   *
+   * @param nid Network ID
+   * @return uint32_t
+   */
+  uint32_t    get_globalUDNum( networkid_t& nid );
+
+  /**
+   * @brief Reset the Memory Manager when machine configuration is changed;
+   *
+   */
+
+  inline void reset_memory_manager() {
+    AllocationPolicy::DestroyMemMgr( MappedMemoryManager );
+    //delete MappedMemoryManager;
+    MappedMemoryManager = AllocationPolicy::CreateMemMgr( this->MachineConfig );
+  }
+
+public:
+  UDRuntime_t() {
+    UPDOWN_INFOMSG( "Initializing runtime" );
+    calc_addrmap();
+    MappedMemoryManager = AllocationPolicy::CreateMemMgr( this->MachineConfig );
+    //MappedMemoryManager = new ud_mapped_memory_t(this->MachineConfig);
+  }
+
+  UDRuntime_t( ud_machine_t machineConfig ) : MachineConfig( machineConfig ) {
+    UPDOWN_INFOMSG( "Initializing runtime with custom machineConfig" );
+    calc_addrmap();
+    MappedMemoryManager = AllocationPolicy::CreateMemMgr( this->MachineConfig );
+    //MappedMemoryManager = new ud_mapped_memory_t(this->MachineConfig);
+  }
+
+  ~UDRuntime_t() {
+    AllocationPolicy::DestroyMemMgr( MappedMemoryManager );
+  }
+
+  /**
+   * @brief Sends an event to the UpDown
+   *
+   * Sends a new event to the updown event queues. Information about the
+   * destination of the event is defined in the ev parameter, including
+   * destination UD_ID, lane_id, thread_id. The event_t also contains the
+   * operands
+   *
+   * @param ev the event to be sent
+   */
+  virtual void send_event( event_t ev );
+
+  /**
+   * @brief Signal lane to start execution
+   *
+   * @param ud_id UpDown ID
+   * @param lane_num lane to signal
+   */
+  virtual void start_exec( networkid_t nwid );
+
+  /**
+   * @brief Memory allocator for the mapped memory
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @todo: This should be thread safe?
+   *
+   * @param size size in bytes
+   * @return void * Pointer to the location.
+   */
+
+  void*        mm_malloc( uint64_t size );
+  void*        mm_malloc_at_addr( void* addr, uint64_t size );
+
+  /**
+   * @brief Free an already existing memory allocation
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @todo: This should be thread safe?
+   *
+   * @param ptr pointer to deallocate
+   */
+
+  void         mm_free( void* ptr );
+
+  /**
+   * @brief Memory allocator for the mapped memory
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @todo: This should be thread safe?
+   *
+   * @param size size in bytes
+   * @return void * Pointer to the location.
+   */
+
+  void*        mm_malloc_global( uint64_t size );
+  void*        mm_malloc_global_at_addr( void* addr, uint64_t size );
+
+  /**
+   * @brief Free an already existing memory allocation in global segments
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @todo: This should be thread safe?
+   *
+   * @param ptr pointer to deallocate
+   */
+
+  void         mm_free_global( void* ptr );
+
+  /**
+   * @brief Copy to mapped memory from top in global segments
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @param offset Destination offset within the memory mapped region
+   * @param src Source pointer
+   * @param size size in bytes
+   */
+
+  void         t2mm_memcpy( uint64_t offset, void* src, uint64_t size = 1 );
+
+  /**
+   * @brief Copy from mapped memory to top
+   *
+   * Mapped memory is a region in DRAM that can be accessed
+   * from updown. This is necessary due to the lack of support for
+   * virtual memories in the UpDown. The UpDown
+   * will be able to use pointers directly into this region
+   * without need for address translation.
+   *
+   * @param offset Destination offset within the memory mapped region
+   * @param dst Source pointer
+   * @param size size in bytes
+   */
+
+  void         mm2t_memcpy( uint64_t offset, void* dst, uint64_t size = 1 );
+
+  /**
+   * @brief Copy data from the top to the scratchpad memory
+   *
+   * This function sends data to the bank associated with the lane_num
+   * The address is calculated based on the offset.
+   *
+   * @param data pointer to the top data to be copied over to the lane
+   * @param size The number of bytes to be copied to the scratchpad
+   * memory
+   * @param ud_id UpDown number
+   * @param lane_num lane bank
+   * @param offset offset within bank in bytes
+   */
+  virtual void
+    t2ud_memcpy( void* data, uint64_t size, networkid_t nwid, uint32_t offset );
+
+  /**
+   * @brief Copy data from the scratchpad memory to the top
+   *
+   * @param data pointer to the top data to be contain values from the
+   * scratchpad memory
+   * @param size The number of bytes to be copied from the scratchpad
+   * memory
+   * @param ud_id UpDown number
+   * @param lane_num lane bank
+   * @param offset offset within bank in bytes
+   */
+  virtual void
+    ud2t_memcpy( void* data, uint64_t size, networkid_t nwid, uint32_t offset );
+
+  /**
+   * @brief Test a memory location in the updwon bank for the expected value
+   *
+   * Reads the updown scratchpad memory bank, and check if the value is equal to
+   * the expected value. Returns true if the values are equal
+   *
+   * @param ud_id UpDown number
+   * @param lane_num LaneID to check
+   * @param offset offset within the memory bank in bytes
+   * @param expected value that is expected in the memory bank
+   * @return word_t
+   */
+  virtual bool
+    test_addr( networkid_t nwid, uint32_t offset, word_t expected = 1 );
+
+  /**
+   * @brief Test a memory location in the updown bank for the expected value.
+   * Wait until it is the expected value
+   *
+   * Spinwaiting on a location of the updown scratchpad memory bank until the
+   * value read is the expected value. Uses lane_test_memory.
+   *
+   * @param lane_num LaneID to check
+   * @param offset offset within the memory bank in bytes
+   * @param expected value that is expected in the memory bank
+   */
+  virtual void
+    test_wait_addr( networkid_t nwid, uint32_t offset, word_t expected = 1 );
+
+  /**
+   * @brief Get offset in local memory
+   *
+   * This is a temporary solution to the absence of an appropriate virtual
+   * memory mapping. This functions assumes that physical memory side is
+   * contiguous and it does not have space for expansion. This is, instead
+   * of using the Scratchpad Capacity that is explained in
+   * UDRuntime_t::base_addr_t, it uses the actual size of the Scratchpad Memory.
+   *
+   * Currently, this function is used to allow pointers to be passed from top
+   * to updown.
+   *
+   * ### Scratchpad physical memory for 1 UD
+   * \verbatim
+   *        MEMORY                     SIZE
+   *   |--------------|  <-- Scratchpad Base Address
+   *   |              |
+   *   |    Lane 0    |
+   *   |              |
+   *   |--------------|  <-- SPmem BankSize
+   *   |              |
+   *   |    Lane 1    |
+   *   |              |
+   *   |--------------|  <-- 2 * SPmem BankSize
+   *   |      ...     |
+   *   |--------------|  <-- (NumLanes-1) * SPmem BankSize
+   *   |              |
+   *   |    Lane N    |
+   *   |              |
+   *   |--------------|  <-- (NumLanes) * SPmem BankSize
+   * \endverbatim
+   *
+   * @param ud_id UpDown ID
+   * @param lane_num Lane ID
+   * @param offset Offset in bytes
+   * @return uint64_t
+   */
+  uint64_t get_lane_physical_memory( networkid_t nwid, uint32_t offset = 0 );
+
+  /**
+   * @brief Get the ud physical memory object
+   *
+   * @param nwid
+   * @return uint64_t
+   */
+  uint64_t get_ud_physical_memory( networkid_t nwid );
+
+  /**
+   * @brief Helper function to dump current base addresses
+   *
+   * This function has no effect on runtime, but it is useful for debugging
+   *
+   */
+  void     dumpBaseAddrs() {
+#ifndef ASST
+    printf(
+#else
+    rev_udrt_print(
+#endif
+      "  mmaddr    = 0x%lX\n"
+      "  spaddr    = 0x%lX\n"
+      "  ctrlAddr  = 0x%lX\n"
+      "  progAddr  = 0x%lX\n",
+      reinterpret_cast< uint64_t >( BaseAddrs.mmaddr ),
+      reinterpret_cast< uint64_t >( BaseAddrs.spaddr ),
+      reinterpret_cast< uint64_t >( BaseAddrs.ctrlAddr ),
+      reinterpret_cast< uint64_t >( BaseAddrs.progAddr ) );
+  }
+
+  /**
+   * @brief Function to return the current Machine config
+   *
+   */
+  ud_machine_t getMachineConfig() {
+    return MachineConfig;
+  }
+
+  /**
+   * @brief Function to dump the memory into a file
+   * @param filename file to be dumped into
+   * @param vaddr Start vaddr
+   * @param size size of memory to be dumped
+  */
+  virtual void dumpMemory( const char* filename, void* vaddr, uint64_t size );
+
+  /**
+   * @brief Function to load memory from a file
+   * @param filename file to be dumped into
+   * @param vaddr Start vaddr
+   * @param size size of memory to be dumped
+   * @return std::pair<void *, uint64_t> pointer to the memory and size
+  */
+  virtual std::pair< void*, uint64_t > loadMemory( const char* filename,
+                                                   void*       vaddr = nullptr,
+                                                   uint64_t    size  = 0 );
+
+  /**
+   * @brief Function to dump the memory into a file
+   * @param vaddr Start vaddr
+   * @param size size of memory to be dumped
+   * @param filename file to be dumped into
+  */
+  virtual void                         dumpLocalMemory( const char* filename,
+                                                        networkid_t start_nwid = networkid_t(),
+                                                        uint64_t    num_lanes = 0 );
+
+  /**
+   * @brief Function to load memory from a file
+   * @param vaddr Start vaddr
+   * @param size size of memory to be dumped
+   * @param filename file to be dumped into
+   * @return std::pair<networkid_t, uint64_t> load networkid and number of lanes
+  */
+  virtual std::pair< networkid_t, uint64_t >
+       loadLocalMemory( const char* filename,
+                        networkid_t start_nwid = networkid_t(),
+                        uint64_t    num_lanes  = 0 );
+
+  /**
+   * @brief Helper function to dump current Machine Config
+   *
+   * This function has no effect on runtime, but it is useful for debugging
+   */
+  void dumpMachineConfig() {
+#ifndef ASST
+    printf( "  MapMemBase          = 0x%lX\n"
+            "  GMapMemBase         = 0x%lX\n"
+            "  UDbase              = 0x%lX\n"
+            "  SPMemBase           = 0x%lX\n"
+            "  ControlBase         = 0x%lX\n"
+            "  ProgBase            = 0x%lX\n"
+            "  EventQueueOffset    = (0x%lX)%lu\n"
+            "  OperandQueueOffset  = (0x%lX)%lu\n"
+            "  StartExecOffset     = (0x%lX)%lu\n"
+            "  LockOffset          = (0x%lX)%lu\n"
+            "  CapNumNodes         = (0x%lX)%lu\n"
+            "  CapNumStacks        = (0x%lX)%lu\n"
+            "  CapNumUDs           = (0x%lX)%lu\n"
+            "  CapNumLanes         = (0x%lX)%lu\n"
+            "  CapSPmemPerLane     = (0x%lX)%lu\n"
+            "  CapControlPerLane   = (0x%lX)%lu\n"
+            "  NumNodes            = (0x%lX)%lu\n"
+            "  NumStacks           = (0x%lX)%lu\n"
+            "  NumUDs              = (0x%lX)%lu\n"
+            "  NumLanes            = (0x%lX)%lu\n"
+            "  MapMemSize          = (0x%lX)%lu\n"
+            "  GMapMemSize         = (0x%lX)%lu\n"
+            "  SPBankSizse         = (0x%lX)%lu\n"
+            "  SPBankSizeWords     = (0x%lX)%lu\n",
+            MachineConfig.MapMemBase,
+            MachineConfig.GMapMemBase,
+            MachineConfig.UDbase,
+            MachineConfig.SPMemBase,
+            MachineConfig.ControlBase,
+            MachineConfig.ProgBase,
+            MachineConfig.EventQueueOffset,
+            MachineConfig.EventQueueOffset,
+            MachineConfig.OperandQueueOffset,
+            MachineConfig.OperandQueueOffset,
+            MachineConfig.StartExecOffset,
+            MachineConfig.StartExecOffset,
+            MachineConfig.LockOffset,
+            MachineConfig.LockOffset,
+            MachineConfig.CapNumNodes,
+            MachineConfig.CapNumNodes,
+            MachineConfig.CapNumStacks,
+            MachineConfig.CapNumStacks,
+            MachineConfig.CapNumUDs,
+            MachineConfig.CapNumUDs,
+            MachineConfig.CapNumLanes,
+            MachineConfig.CapNumLanes,
+            MachineConfig.CapSPmemPerLane,
+            MachineConfig.CapSPmemPerLane,
+            MachineConfig.CapControlPerLane,
+            MachineConfig.CapControlPerLane,
+            MachineConfig.NumNodes,
+            MachineConfig.NumNodes,
+            MachineConfig.NumStacks,
+            MachineConfig.NumStacks,
+            MachineConfig.NumUDs,
+            MachineConfig.NumUDs,
+            MachineConfig.NumLanes,
+            MachineConfig.NumLanes,
+            MachineConfig.MapMemSize,
+            MachineConfig.MapMemSize,
+            MachineConfig.GMapMemSize,
+            MachineConfig.GMapMemSize,
+            MachineConfig.SPBankSize,
+            MachineConfig.SPBankSize,
+            MachineConfig.SPBankSizeWords,
+            MachineConfig.SPBankSizeWords );
+#else
+    rev_udrt_print( "  MapMemBase          = 0x%lX\n"
+                    "  GMapMemBase         = 0x%lX\n"
+                    "  UDbase              = 0x%lX\n"
+                    "  SPMemBase           = 0x%lX\n"
+                    "  ControlBase         = 0x%lX\n"
+                    "  ProgramBase         = 0x%lX\n",
+                    MachineConfig.MapMemBase,
+                    MachineConfig.GMapMemBase,
+                    MachineConfig.UDbase,
+                    MachineConfig.SPMemBase,
+                    MachineConfig.ControlBase,
+                    MachineConfig.ProgBase );
+    rev_udrt_print( "  EventQueueOffset    = (0x%lX)%lu\n"
+                    "  OperandQueueOffset  = (0x%lX)%lu\n"
+                    "  StartExecOffset     = (0x%lX)%lu\n",
+                    MachineConfig.EventQueueOffset,
+                    MachineConfig.EventQueueOffset,
+                    MachineConfig.OperandQueueOffset,
+                    MachineConfig.OperandQueueOffset,
+                    MachineConfig.StartExecOffset,
+                    MachineConfig.StartExecOffset );
+    rev_udrt_print( "  LockOffset          = (0x%lX)%lu\n"
+                    "  CapNumNodes         = (0x%lX)%lu\n"
+                    "  CapNumStacks        = (0x%lX)%lu\n",
+                    MachineConfig.LockOffset,
+                    MachineConfig.LockOffset,
+                    MachineConfig.CapNumNodes,
+                    MachineConfig.CapNumNodes,
+                    MachineConfig.CapNumStacks,
+                    MachineConfig.CapNumStacks );
+    rev_udrt_print( "  CapNumUDs           = (0x%lX)%lu\n"
+                    "  CapNumLanes         = (0x%lX)%lu\n"
+                    "  CapSPmemPerLane     = (0x%lX)%lu\n",
+                    MachineConfig.CapNumUDs,
+                    MachineConfig.CapNumUDs,
+                    MachineConfig.CapNumLanes,
+                    MachineConfig.CapNumLanes,
+                    MachineConfig.CapSPmemPerLane,
+                    MachineConfig.CapSPmemPerLane );
+    rev_udrt_print( "  CapControlPerLane   = (0x%lX)%lu\n"
+                    "  NumNodes            = (0x%lX)%lu\n"
+                    "  NumStacks           = (0x%lX)%lu\n",
+                    MachineConfig.CapControlPerLane,
+                    MachineConfig.CapControlPerLane,
+                    MachineConfig.NumNodes,
+                    MachineConfig.NumNodes,
+                    MachineConfig.NumStacks,
+                    MachineConfig.NumStacks );
+    rev_udrt_print( "  NumUDs              = (0x%lX)%lu\n"
+                    "  NumLanes            = (0x%lX)%lu\n"
+                    "  MapMemSize          = (0x%lX)%lu\n",
+                    MachineConfig.NumUDs,
+                    MachineConfig.NumUDs,
+                    MachineConfig.NumLanes,
+                    MachineConfig.NumLanes,
+                    MachineConfig.MapMemSize,
+                    MachineConfig.MapMemSize );
+    rev_udrt_print( "  GMapMemSize         = (0x%lX)%lu\n"
+                    "  SPBankSize          = (0x%lX)%lu\n"
+                    "  SPBankSizeWords     = (0x%lX)%lu\n",
+                    MachineConfig.GMapMemSize,
+                    MachineConfig.GMapMemSize,
+                    MachineConfig.SPBankSize,
+                    MachineConfig.SPBankSize,
+                    MachineConfig.SPBankSizeWords,
+                    MachineConfig.SPBankSizeWords );
+#endif
+  }
+};  //class UDRuntime_t
+
+/*
+ * updown.cpp
+ */
+
+// TODO: This should not be offset with the number of elements. Best to
+// determine a fixed memory location for each section
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::calc_addrmap() {
+  BaseAddrs.mmaddr   = (ptr_t) MachineConfig.MapMemBase;
+  BaseAddrs.spaddr   = (ptr_t) MachineConfig.SPMemBase;
+  BaseAddrs.ctrlAddr = (ptr_t) MachineConfig.ControlBase;
+  BaseAddrs.progAddr = (ptr_t) MachineConfig.ProgBase;
+  UPDOWN_INFOMSG( "calc_addrmap: maddr: 0x%lX spaddr: 0x%lX ctrlAddr: 0x%lX",
+                  reinterpret_cast< uint64_t >( BaseAddrs.mmaddr ),
+                  reinterpret_cast< uint64_t >( BaseAddrs.spaddr ),
+                  reinterpret_cast< uint64_t >( BaseAddrs.ctrlAddr ),
+                  reinterpret_cast< uint64_t >( BaseAddrs.progAddr ) );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::send_event( event_t ev ) {
+  uint64_t offset =
+    ( ( ( ev.get_NetworkId() ).get_NodeId() * MachineConfig.CapNumStacks +
+        ( ev.get_NetworkId() ).get_StackId() ) *
+        MachineConfig.CapNumUDs +
+      ( ev.get_NetworkId() ).get_UdId() ) *
+      MachineConfig.CapNumLanes * MachineConfig.CapControlPerLane +
+    ( ev.get_NetworkId() ).get_LaneId() * MachineConfig.CapControlPerLane;
+  // Convert from bytes to words. the pointers are ptr_t
+  offset /= sizeof( word_t );
+  // Locking the lane's queues
+  auto lock = ( BaseAddrs.ctrlAddr + offset + MachineConfig.LockOffset );
+  UPDOWN_INFOMSG( "Locking 0x%lX", reinterpret_cast< uint64_t >( lock ) );
+  *lock = 1;
+  // Set the event Queue
+
+  // TODO: Num Operands should reflect the continuation, this should not be a +
+  // 1 in the for
+  auto OpsQ =
+    ( BaseAddrs.ctrlAddr + offset + MachineConfig.OperandQueueOffset );
+  UPDOWN_INFOMSG( "Using Operands Queue 0x%lX",
+                  reinterpret_cast< uint64_t >( OpsQ ) );
+  if( ev.get_NumOperands() != 0 )
+    for( uint8_t i = 0; i < ev.get_NumOperands() + 1; i++ ) {
+      *( OpsQ ) = ev.get_OperandsData()[i];
+      UPDOWN_INFOMSG( "OB[%u]: %lu (0x%lX)",
+                      i,
+                      ev.get_OperandsData()[i],
+                      ev.get_OperandsData()[i] );
+    }
+  UPDOWN_INFOMSG( "Unlocking 0x%lX", reinterpret_cast< uint64_t >( lock ) );
+  auto eventQ =
+    ( BaseAddrs.ctrlAddr + offset + MachineConfig.EventQueueOffset );
+#ifndef ASST
+  UPDOWN_INFOMSG( "Sending Event:%u to [%u, %u, %u, %u, %u] to queue at 0x%lX",
+                  ev.get_EventLabel(),
+                  ev.get_NetworkId().get_NodeId(),
+                  ev.get_NetworkId().get_StackId(),
+                  ev.get_NetworkId().get_UdId(),
+                  ev.get_NetworkId().get_LaneId(),
+                  ev.get_ThreadId(),
+                  reinterpret_cast< uint64_t >( eventQ ) );
+#else
+  UPDOWN_INFOMSG( "Sending Event:%u to [%u, %u, %u, %u] to queue at 0x%lX",
+                  ev.get_EventLabel(),
+                  ev.get_NetworkId().get_NodeId(),
+                  ev.get_NetworkId().get_StackId(),
+                  ev.get_NetworkId().get_UdId(),
+                  ev.get_NetworkId().get_LaneId(),
+                  reinterpret_cast< uint64_t >( eventQ ) );
+  UPDOWN_INFOMSG( "Sending Event to threadID %u\n", ev.get_ThreadId() );
+#endif
+  *eventQ   = ev.get_EventWord();
+  *( lock ) = 0;
+
+  // Set the Operand Queue
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::start_exec( networkid_t nwid ) {
+  uint8_t  ud_id    = nwid.get_UdId();
+  uint8_t  lane_id  = nwid.get_LaneId();
+  uint8_t  stack_id = nwid.get_StackId();
+  uint8_t  node_id  = nwid.get_NodeId();
+  uint64_t offset =
+    ( node_id * MachineConfig.CapNumStacks * MachineConfig.CapNumUDs +
+      stack_id * MachineConfig.CapNumUDs + ud_id ) *
+      MachineConfig.CapNumLanes * MachineConfig.CapControlPerLane +
+    lane_id * MachineConfig.CapControlPerLane;
+  // Convert from bytes to words. the pointers are ptr_t
+  offset /= sizeof( word_t );
+  auto startSig = BaseAddrs.ctrlAddr + offset + MachineConfig.StartExecOffset;
+  *( startSig ) = 1;
+  UPDOWN_INFOMSG( "Starting execution UD %u, Lane %u. Signal in  0x%lX",
+                  ud_id,
+                  lane_id,
+                  reinterpret_cast< uint64_t >( startSig ) );
+}
+
+template< class AllocationPolicy >
+uint32_t UDRuntime_t< AllocationPolicy >::get_globalUDNum( networkid_t& nid ) {
+  return nid.get_NodeId() *
+           ( this->MachineConfig.NumStacks * this->MachineConfig.NumUDs ) +
+         nid.get_StackId() * ( this->MachineConfig.NumUDs ) + nid.get_UdId();
+}
+
+template< class AllocationPolicy >
+uint64_t
+  UDRuntime_t< AllocationPolicy >::get_lane_aligned_offset( networkid_t nwid,
+                                                            uint32_t offset ) {
+  auto    alignment      = sizeof( word_t );
+  auto    aligned_offset = offset - offset % alignment;
+  uint8_t ud_id          = nwid.get_UdId();
+  uint8_t lane_id        = nwid.get_LaneId();
+  uint8_t stack_id       = nwid.get_StackId();
+  uint8_t node_id        = nwid.get_NodeId();
+  UPDOWN_WARNING_IF( offset % alignment != 0, "Unaligned offset %u", offset );
+  uint64_t returned_offset =
+    ( node_id * MachineConfig.CapNumStacks * MachineConfig.CapNumUDs +
+      stack_id * MachineConfig.CapNumUDs + ud_id ) *
+      MachineConfig.CapNumLanes * MachineConfig.CapSPmemPerLane +
+    MachineConfig.CapSPmemPerLane * lane_id +  // Lane offset
+    aligned_offset;
+  return returned_offset;
+}
+
+template< class AllocationPolicy >
+uint64_t
+  UDRuntime_t< AllocationPolicy >::get_lane_physical_memory( networkid_t nwid,
+                                                             uint32_t offset ) {
+  uint8_t ud_id          = nwid.get_UdId();
+  uint8_t lane_id        = nwid.get_LaneId();
+  uint8_t stack_id       = nwid.get_StackId();
+  uint8_t node_id        = nwid.get_NodeId();
+  auto    alignment      = sizeof( word_t );
+  auto    aligned_offset = offset - offset % alignment;
+  UPDOWN_WARNING_IF( offset % alignment != 0, "Unaligned offset %u", offset );
+  uint64_t returned_offset =
+    ( ( node_id * MachineConfig.NumStacks + stack_id ) * MachineConfig.NumUDs +
+      ud_id ) *
+      MachineConfig.NumLanes * MachineConfig.SPBankSize +
+    lane_id * MachineConfig.SPBankSize +  // Lane offset
+    aligned_offset + MachineConfig.SPMemBase;
+  return returned_offset;
+}
+
+template< class AllocationPolicy >
+uint64_t
+  UDRuntime_t< AllocationPolicy >::get_ud_physical_memory( networkid_t nwid ) {
+  uint8_t  ud_id    = nwid.get_UdId();
+  uint8_t  stack_id = nwid.get_StackId();
+  uint8_t  node_id  = nwid.get_NodeId();
+  uint64_t returned_offset =
+    ( ( node_id * MachineConfig.NumStacks + stack_id ) * MachineConfig.NumUDs +
+      ud_id ) *
+      MachineConfig.NumLanes * MachineConfig.SPBankSize +
+    MachineConfig.SPMemBase;
+  return returned_offset;
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::dumpMemory( const char* filename,
+                                                  void*       vaddr,
+                                                  uint64_t    size ) {
+#ifdef ASST
+  int fd = rev_openat( AT_FDCWD,
+                       filename,
+                       O_WRONLY | O_CREAT | O_TRUNC,
+                       S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH );
+  assert( fd != -1 );
+  // Follow gem5 format. G=gem5, D=DRAM
+  char byteHeader[2] = { 'G', 'D' };
+  rev_write( fd, (const char*) byteHeader, 2 );
+  // File offset, address, size
+  uint64_t wordHeader[3] = {
+    0x001aUL, reinterpret_cast< uint64_t >( vaddr ), size };
+  rev_write( fd, (const char*) wordHeader, 3 * sizeof( uint64_t ) );
+  // Now write the data
+  rev_write( fd, (const char*) vaddr, size );
+  rev_close( fd );
+#elif defined( GEM5_MODE )
+  m5_dump_mem( vaddr, size, filename );
+#endif
+}
+
+template< class AllocationPolicy >
+std::pair< void*, uint64_t > UDRuntime_t< AllocationPolicy >::loadMemory(
+  const char* filename, void* vaddr, uint64_t size ) {
+#ifdef ASST
+  int fd = rev_openat( AT_FDCWD, filename, 0, O_RDONLY );
+  assert( fd != -1 );
+  char byteHeader[2];
+  rev_read( fd, byteHeader, 2 );
+  assert( byteHeader[0] = 'G' );  // gem5
+  assert( byteHeader[1] = 'D' );  // dram
+  uint64_t wordHeader[3];
+  rev_read( fd, (char*) wordHeader, 3 * sizeof( uint64_t ) );
+  uint64_t dump_start_file_offset = wordHeader[0];
+  uint64_t dump_vaddr             = wordHeader[1];
+  uint64_t dump_size              = wordHeader[2];
+  assert( dump_start_file_offset = 0x1aUL );
+  if( vaddr == nullptr ) {
+    vaddr = reinterpret_cast< void* >( dump_vaddr );
+    UPDOWN_INFOMSG( "DRAM Dump vaddr (from dump file): 0x%lx", dump_vaddr );
+  } else {
+    UPDOWN_INFOMSG( "DRAM Dump vaddr (user specified): 0x%lx",
+                    reinterpret_cast< uint64_t >( vaddr ) );
+  }
+  if( vaddr == nullptr || size == 0 ) {
+    size = dump_size;
+    UPDOWN_INFOMSG( "DRAM Dump size (from dump file): %lu", size );
+  } else {
+    UPDOWN_INFOMSG( "DRAM Dump size (user specified): %lu", size );
+  }
+
+  if( this->mm_malloc_global_at_addr( vaddr, size ) == nullptr &&
+      this->mm_malloc_at_addr( vaddr, size ) == nullptr ) {  // allocate memory
+    UPDOWN_ERROR( "DRAM dump load failed! Cannot allocate memory at (%p, %lu)",
+                  vaddr,
+                  size );
+  }
+
+  // Read the entire file to the allocated dram address
+  // TODO check stack limitations.
+  assert( size % sizeof( uint64_t ) == 0 );  // make sure aligned uint64_t;
+  rev_read( fd, (char*) vaddr, size );
+  rev_close( fd );
+
+  return std::make_pair( vaddr, size );
+#elif defined( GEM5_MODE )
+  FILE* mem_file = fopen( filename, "rb" );
+  if( !mem_file ) {
+    printf( "Could not open %s\n", filename );
+    exit( 1 );
+  }
+
+  fseek( mem_file, 0, SEEK_SET );
+  // Read 'F' to indicate dump by Fastsim
+  char dump_type;
+  fread( &dump_type, sizeof( char ), 1, mem_file );
+  UPDOWN_ERROR_IF( dump_type != 'G',
+                   "DRAM dump load failed! Not a Gem5 dump file!\n" );
+  // Read 'D' to indicate DRAM dump
+  fread( &dump_type, sizeof( char ), 1, mem_file );
+  UPDOWN_ERROR_IF( dump_type != 'D',
+                   "DRAM dump load failed! Not a DRAM dump file!\n" );
+  // Read dump start file offset
+  uint64_t dump_start_file_offset;
+  fread( &dump_start_file_offset, sizeof( uint64_t ), 1, mem_file );
+  UPDOWN_INFOMSG( "DRAM Dump start file offset: %lu", dump_start_file_offset );
+  // Read dump vaddr
+  uint64_t dump_vaddr;
+  fread( &dump_vaddr, sizeof( uint64_t ), 1, mem_file );
+  if( vaddr == nullptr ) {
+    vaddr = reinterpret_cast< void* >( dump_vaddr );
+    UPDOWN_INFOMSG( "DRAM Dump vaddr (from dump file): %p", vaddr );
+  } else {
+    UPDOWN_INFOMSG( "DRAM Dump vaddr (user specified): %p", vaddr );
+  }
+  // Read dump size
+  uint64_t dump_size;
+  fread( &dump_size, sizeof( uint64_t ), 1, mem_file );
+  if( vaddr == nullptr || size == 0 ) {
+    size = dump_size;
+    UPDOWN_INFOMSG( "DRAM Dump size (from dump file): %lu", size );
+  } else {
+    UPDOWN_INFOMSG( "DRAM Dump size (user specified): %lu", size );
+  }
+  fclose( mem_file );
+
+  if( this->mm_malloc_global_at_addr( vaddr, size ) == nullptr &&
+      this->mm_malloc_at_addr( vaddr, size ) == nullptr ) {  // allocate memory
+    UPDOWN_ERROR( "DRAM dump load failed! Cannot allocate memory at (%p, %lu)",
+                  vaddr,
+                  size );
+  }
+
+  m5_load_mem( vaddr, size, filename );
+  // m5_load_mem(0, 0, filename);
+
+  return std::make_pair( vaddr, size );
+#else
+  return std::make_pair( nullptr, 0 );
+#endif
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::dumpLocalMemory( const char* filename,
+                                                       networkid_t start_nwid,
+                                                       uint64_t    num_lanes ) {
+#ifdef ASST
+  assert( false );  // TODO
+#elif defined( GEM5_MODE )
+  if( start_nwid.get_NetworkId_UdName() == 0 && num_lanes == 0 ) {
+    num_lanes = this->MachineConfig.NumLanes * this->MachineConfig.NumUDs *
+                this->MachineConfig.NumStacks * this->MachineConfig.NumNodes;
+  }
+  m5_dump_udlm(
+    BaseAddrs.spaddr, start_nwid.get_NetworkId_UdName(), num_lanes, filename );
+#endif
+}
+
+template< class AllocationPolicy >
+std::pair< networkid_t, uint64_t >
+  UDRuntime_t< AllocationPolicy >::loadLocalMemory( const char* filename,
+                                                    networkid_t start_nwid,
+                                                    uint64_t    num_lanes ) {
+#ifdef ASST
+  assert( false );  // TODO
+  return std::make_pair( networkid_t( 0, false, 0 ), 0 );
+#elif defined( GEM5_MODE )
+  FILE* spd_file = fopen( filename, "rb" );
+  if( !spd_file ) {
+    printf( "Could not open %s\n", filename );
+    exit( 1 );
+  }
+
+  fseek( spd_file, 0, SEEK_SET );
+  // Read 'F' to indicate dump by Fastsim
+  char dump_type;
+  fread( &dump_type, sizeof( char ), 1, spd_file );
+  UPDOWN_ERROR_IF( dump_type != 'G',
+                   "DRAM dump load failed! Not a Gem5 dump file!\n" );
+  // Read 'L' to indicate LM dump
+  fread( &dump_type, sizeof( char ), 1, spd_file );
+  UPDOWN_ERROR_IF( dump_type != 'L',
+                   "DRAM dump load failed! Not a LM dump file!\n" );
+  // Read dump start file offset
+  uint64_t dump_start_file_offset;
+  fread( &dump_start_file_offset, sizeof( uint64_t ), 1, spd_file );
+  UPDOWN_INFOMSG( "LM Dump start file offset: %lu", dump_start_file_offset );
+  // Read dump start nwid (ud_name only)
+  uint64_t dump_start_nwid_raw;
+  fread( &dump_start_nwid_raw, sizeof( uint64_t ), 1, spd_file );
+  networkid_t dump_start_nwid( dump_start_nwid_raw, false, 0 );
+  UPDOWN_INFOMSG( "LM Dump start nwid (from dump file): %lu",
+                  dump_start_nwid_raw );
+  // Read num lanes dumped
+  uint64_t dump_num_lanes;
+  fread( &dump_num_lanes, sizeof( uint64_t ), 1, spd_file );
+  UPDOWN_INFOMSG( "LM Dump num lanes (from dump file): %lu", dump_num_lanes );
+  // Read LM size per lane
+  uint64_t lane_lm_size;
+  fread( &lane_lm_size, sizeof( uint64_t ), 1, spd_file );
+  UPDOWN_INFOMSG( "LM Dump size per lane (from dump file): %lu", lane_lm_size );
+
+  // FIXME
+  // Disable using the pseudo instruction interface due to crash
+  // m5_load_udlm(BaseAddrs.spaddr, start_nwid.get_NetworkId_UdName(), num_lanes, filename);
+
+  // Use t2ud_memcpy interface for now. this should be executed before switch_cpus (for fast simulation time)
+  fseek( spd_file, dump_start_file_offset, SEEK_SET );
+  uint8_t* data = nullptr;
+  if( start_nwid.get_NetworkId_UdName() == 0 && num_lanes == 0 ) {
+    // LM specified from the dump
+    uint64_t total_lm_size = dump_num_lanes * lane_lm_size;
+    data = (uint8_t*) malloc( total_lm_size * sizeof( uint8_t ) );
+    fread( data, sizeof( uint8_t ), total_lm_size, spd_file );
+    uint64_t lm_offset = 0;
+    for( uint32_t i = dump_start_nwid.get_NetworkId_UdName();
+         i < dump_start_nwid.get_NetworkId_UdName() + dump_num_lanes;
+         i++ ) {
+      t2ud_memcpy(
+        &data[lm_offset], lane_lm_size, networkid_t( i, false, 0 ), 0 );
+      lm_offset += lane_lm_size;
+    }
+  } else {
+    // all LMs
+    uint64_t total_lm_size = num_lanes * DEF_SPMEM_BANK_SIZE;
+    data = (uint8_t*) malloc( total_lm_size * sizeof( uint8_t ) );
+    fread( data, sizeof( uint8_t ), total_lm_size, spd_file );
+    uint64_t lm_offset = 0;
+    for( uint32_t i = start_nwid.get_NetworkId_UdName();
+         i < start_nwid.get_NetworkId_UdName() + num_lanes;
+         i++ ) {
+      t2ud_memcpy(
+        &data[lm_offset], DEF_SPMEM_BANK_SIZE, networkid_t( i, false, 0 ), 0 );
+      lm_offset += DEF_SPMEM_BANK_SIZE;
+    }
+  }
+
+  fclose( spd_file );
+
+  if( start_nwid.get_NetworkId_UdName() == 0 && num_lanes == 0 ) {
+    return std::make_pair( dump_start_nwid, dump_num_lanes );
+  } else {
+    return std::make_pair( start_nwid, num_lanes );
+  }
+#else
+  return std::make_pair( networkid_t( 0, false, 0 ), 0 );
+#endif
+}
+
+template< class AllocationPolicy >
+void* UDRuntime_t< AllocationPolicy >::mm_malloc( uint64_t size ) {
+  UPDOWN_INFOMSG( "Calling mm_malloc %lu", size );
+  return MappedMemoryManager->get_region( size, false );
+}
+
+template< class AllocationPolicy >
+void* UDRuntime_t< AllocationPolicy >::mm_malloc_at_addr( void*    addr,
+                                                          uint64_t size ) {
+#ifndef ASST
+  UPDOWN_INFOMSG( "Calling mm_malloc_at_addr (%p, %lu)", addr, size );
+#else
+  UPDOWN_INFOMSG( "Calling mm_malloc_at_addr (0x%lx, %lu)",
+                  reinterpret_cast< uint64_t >( addr ),
+                  size );
+#endif
+
+  return MappedMemoryManager->get_region_at_addr( addr, size, false );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::mm_free( void* ptr ) {
+  UPDOWN_INFOMSG( "Calling mm_free  0x%lX",
+                  reinterpret_cast< uint64_t >( ptr ) );
+  return MappedMemoryManager->remove_region( ptr, false );
+}
+
+template< class AllocationPolicy >
+void* UDRuntime_t< AllocationPolicy >::mm_malloc_global( uint64_t size ) {
+  UPDOWN_INFOMSG( "Calling mm_malloc_global %lu", size );
+  return MappedMemoryManager->get_region( size, true );
+}
+
+template< class AllocationPolicy >
+void* UDRuntime_t< AllocationPolicy >::mm_malloc_global_at_addr(
+  void* addr, uint64_t size ) {
+#ifndef ASST
+  UPDOWN_INFOMSG( "Calling mm_malloc_global_at_addr (%p, %lu)", addr, size );
+#else
+  UPDOWN_INFOMSG( "Calling mm_malloc_global_at_addr (0x%lx, %lu)",
+                  reinterpret_cast< uint64_t >( addr ),
+                  size );
+#endif
+  return MappedMemoryManager->get_region_at_addr( addr, size, true );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::mm_free_global( void* ptr ) {
+  UPDOWN_INFOMSG( "Calling mm_free_global  0x%lX",
+                  reinterpret_cast< uint64_t >( ptr ) );
+  return MappedMemoryManager->remove_region( ptr, true );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::mm2t_memcpy( uint64_t offset,
+                                                   void*    dst,
+                                                   uint64_t size ) {
+  ptr_t src = BaseAddrs.mmaddr + offset / sizeof( word_t );
+  UPDOWN_ASSERT(
+    src + size / sizeof( word_t ) <
+      BaseAddrs.mmaddr + MachineConfig.MapMemSize / sizeof( word_t ),
+    "mm2t_memcpy: memory access to 0x%lX out of mapped memory bounds "
+    "with offset %lu bytes and size %lu bytes. Mapped memory Base Address "
+    "0x%lX mapped memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.mmaddr + offset ),
+    (unsigned long) ( offset * sizeof( word_t ) ),
+    (unsigned long) size,
+    (unsigned long) BaseAddrs.mmaddr,
+    (unsigned long) MachineConfig.MapMemSize );
+  UPDOWN_INFOMSG(
+    "Copying %lu bytes from mapped memory (0x%lX = %ld) to top (0x%lX = %ld)",
+    size,
+    reinterpret_cast< uint64_t >( src ),
+    *src,
+    reinterpret_cast< uint64_t >( dst ),
+    *reinterpret_cast< word_t* >( dst ) );
+  std::memcpy( dst, src, size );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::t2mm_memcpy( uint64_t offset,
+                                                   void*    src,
+                                                   uint64_t size ) {
+  ptr_t dst = BaseAddrs.mmaddr + offset / sizeof( word_t );
+  UPDOWN_ASSERT(
+    dst + size / sizeof( word_t ) <
+      BaseAddrs.mmaddr + MachineConfig.MapMemSize / sizeof( word_t ),
+    "t2mm_memcpy: memory access to 0x%lX out of mapped memory bounds "
+    "with offset %lu bytes and size %lu bytes. Mapped memory Base "
+    "Address 0x%lX mapped memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.mmaddr + offset ),
+    (unsigned long) ( offset * sizeof( word_t ) ),
+    (unsigned long) size,
+    (unsigned long) BaseAddrs.mmaddr,
+    MachineConfig.MapMemSize );
+  UPDOWN_INFOMSG(
+    "Copying %lu bytes from top (0x%lX = %ld) to mapped memory (0x%lX = %ld)",
+    size,
+    reinterpret_cast< uint64_t >( src ),
+    *reinterpret_cast< word_t* >( src ),
+    reinterpret_cast< uint64_t >( dst ),
+    *dst );
+  std::memcpy( dst, src, size );
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::t2ud_memcpy( void*       data,
+                                                   uint64_t    size,
+                                                   networkid_t nwid,
+                                                   uint32_t    offset ) {
+  uint64_t apply_offset = get_lane_aligned_offset( nwid, offset );
+  apply_offset /= sizeof( word_t );
+  UPDOWN_ASSERT(
+    BaseAddrs.spaddr + apply_offset + size / sizeof( word_t ) <
+      BaseAddrs.spaddr + MachineConfig.SPSize() / sizeof( word_t ),
+    "t2ud_memcpy: memory access to 0x%lX out of scratchpad memory bounds "
+    "with offset %lu bytes and size %lu bytes. Scratchpad memory Base "
+    "Address 0x%lX scratchpad memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.spaddr + apply_offset ),
+    (unsigned long) ( apply_offset * sizeof( word_t ) ),
+    (unsigned long) size,
+    (unsigned long) BaseAddrs.spaddr,
+    MachineConfig.SPSize() );
+  std::memcpy( BaseAddrs.spaddr + apply_offset, data, size );
+#ifndef ASST
+  UPDOWN_INFOMSG(
+    "Copying %lu bytes from Top to Node:%u, Stack:%u, UD %u, "
+    "Lane %u, offset %u, Apply offset %lu. Signal in 0x%lX",
+    size,
+    nwid.get_NodeId(),
+    nwid.get_StackId(),
+    nwid.get_UdId(),
+    nwid.get_LaneId(),
+    offset,
+    apply_offset,
+    reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ) );
+#else
+  UPDOWN_INFOMSG( "Copying %lu bytes from Top to Node:%u, Stack:%u, UD %u, "
+                  "Lane %u, ",
+                  size,
+                  nwid.get_NodeId(),
+                  nwid.get_StackId(),
+                  nwid.get_UdId(),
+                  nwid.get_LaneId() );
+  UPDOWN_INFOMSG(
+    "offset %u, Apply offset %lu. Signal in 0x%lX\n",
+    offset,
+    apply_offset,
+    reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ) );
+#endif
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::ud2t_memcpy( void*       data,
+                                                   uint64_t    size,
+                                                   networkid_t nwid,
+                                                   uint32_t    offset ) {
+  uint64_t apply_offset = get_lane_aligned_offset( nwid, offset );
+  apply_offset /= sizeof( word_t );
+  UPDOWN_ASSERT(
+    BaseAddrs.spaddr + apply_offset + size / sizeof( word_t ) <
+      BaseAddrs.spaddr + MachineConfig.SPSize() / sizeof( word_t ),
+    "ud2t_memcpy: memory access to 0x%lX out of scratchpad memory bounds "
+    "with offset %lu bytes and size %lu bytes. Scratchpad memory Base "
+    "Address 0x%lX scratchpad memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.spaddr + apply_offset ),
+    (unsigned long) ( apply_offset * sizeof( word_t ) ),
+    (unsigned long) size,
+    (unsigned long) BaseAddrs.spaddr,
+    MachineConfig.SPSize() );
+  std::memcpy( data, BaseAddrs.spaddr + apply_offset, size );
+  UPDOWN_INFOMSG(
+    "Copying %lu bytes from UD %u, Lane %u to Top, offset %u, "
+    "Apply offset %lu. Signal in 0x%lX",
+    size,
+    nwid.get_UdId(),
+    nwid.get_LaneId(),
+    offset,
+    apply_offset,
+    reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ) );
+}
+
+template< class AllocationPolicy >
+bool UDRuntime_t< AllocationPolicy >::test_addr( networkid_t nwid,
+                                                 uint32_t    offset,
+                                                 word_t      expected ) {
+  uint64_t apply_offset = get_lane_aligned_offset( nwid, offset );
+  apply_offset /= sizeof( word_t );
+  UPDOWN_ASSERT(
+    BaseAddrs.spaddr + apply_offset <
+      BaseAddrs.spaddr + MachineConfig.SPSize() / sizeof( word_t ),
+    "test_addr: memory access to 0x%lX out of scratchpad memory bounds "
+    "with offset %lu bytes and size 4 bytes. Scratchpad memory Base Address "
+    "0x%lX scratchpad memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.spaddr + apply_offset ),
+    (unsigned long) ( apply_offset * sizeof( word_t ) ),
+    (unsigned long) BaseAddrs.spaddr,
+    MachineConfig.SPSize() );
+  UPDOWN_INFOMSG(
+    "Testing UD %u, Lane %u to Top, offset %u."
+    " Addr 0x%lX. Expected = %lu, read = %lu",
+    nwid.get_UdId(),
+    nwid.get_LaneId(),
+    offset,
+    reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ),
+    expected,
+    *( BaseAddrs.spaddr + apply_offset ) );
+  return *( BaseAddrs.spaddr + apply_offset ) == expected;
+}
+
+template< class AllocationPolicy >
+void UDRuntime_t< AllocationPolicy >::test_wait_addr( networkid_t nwid,
+                                                      uint32_t    offset,
+                                                      word_t      expected ) {
+  uint64_t apply_offset = get_lane_aligned_offset( nwid, offset );
+  apply_offset /= sizeof( word_t );
+  UPDOWN_ASSERT(
+    BaseAddrs.spaddr + apply_offset <
+      BaseAddrs.spaddr + MachineConfig.SPSize() / sizeof( word_t ),
+    "test_wait_addr: memory access to 0x%lX out of scratchpad memory bounds "
+    "with offset %lu bytes and size 4 bytes. Scratchpad memory Base Address "
+    "0x%lX scratchpad memory size %lu bytes",
+    (unsigned long) ( BaseAddrs.spaddr + apply_offset ),
+    (unsigned long) ( apply_offset * sizeof( word_t ) ),
+    (unsigned long) BaseAddrs.spaddr,
+    MachineConfig.SPSize() );
+#ifndef ASST
+  UPDOWN_INFOMSG(
+    "Testing UD %u, Lane %u to Top, offset %u."
+    " Addr 0x%lX. Expected = %lu, read = %lu. (%s)",
+    nwid.get_UdId(),
+    nwid.get_LaneId(),
+    offset,
+    reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ),
+    expected,
+    *( BaseAddrs.spaddr + apply_offset ),
+    *( BaseAddrs.spaddr + apply_offset ) != expected ? "Waiting" :
+                                                       "Returning" );
+#else
+  if( *( BaseAddrs.spaddr + apply_offset ) != expected ) {
+    UPDOWN_INFOMSG(
+      "Testing UD %u, Lane %u to Top, offset %u."
+      " Addr 0x%lX. Expected = %lu, read = %lu. (Waiting)",
+      nwid.get_UdId(),
+      nwid.get_LaneId(),
+      offset,
+      reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ),
+      expected,
+      *( BaseAddrs.spaddr + apply_offset ) );
+  } else {
+    UPDOWN_INFOMSG(
+      "Testing UD %u, Lane %u to Top, offset %u."
+      " Addr 0x%lX. Expected = %lu, read = %lu. (Returning)",
+      nwid.get_UdId(),
+      nwid.get_LaneId(),
+      offset,
+      reinterpret_cast< uint64_t >( BaseAddrs.spaddr + apply_offset ),
+      expected,
+      *( BaseAddrs.spaddr + apply_offset ) );
+  }
+#endif
+  while( *( BaseAddrs.spaddr + apply_offset ) != expected )
+    ;
+}
+
+}  // namespace UpDown
+#endif

--- a/test/udruntime/include/updown_config.h
+++ b/test/udruntime/include/updown_config.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 University of Chicago
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met: redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer;
+ * redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution;
+ * neither the name of the copyright holders nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Author - Andronicus
+ * Initial UpStream Program to do a basic operation on data
+ * Add and return value
+ *
+ */
+#ifndef UPSTREAM_H
+#define UPSTREAM_H
+
+#include <stdint.h>
+
+// Node configuration is controlled in cmake
+// Default is 1 node
+#ifdef NODE64
+#define DEF_NUM_NODES 64  // 64 Node system
+#elif NODE32
+#define DEF_NUM_NODES 32  // 32 Node system
+#elif NODE8
+#define DEF_NUM_NODES 8  // 8 node system
+#else
+#define DEF_NUM_NODES 1  // 1 node system
+#endif
+
+#define DEF_NUM_LANES       64     // Number of lanes per CU
+#define DEF_NUM_UDS         4      // Number of CUs
+#define DEF_NUM_STACKS      8      // Number of Stacks per Node
+#define DEF_SPMEM_BANK_SIZE 65536  // Scratchpad Memory size per lane
+#define DEF_WORD_SIZE       8      // Wordsize
+#define DEF_MAPPED_SIZE     1UL << 32
+//#define DEF_GMAPPED_SIZE 1UL << 32
+#define DEF_GMAPPED_SIZE    1UL << 36
+
+
+// This address space can support 64 nodes
+#ifndef GEM5_MODE
+// Base address for scratchpad memories
+// In latest: #define BASE_SPMEM_ADDR 0x7FC0'0000'0000llu // what is this?
+#define BASE_SPMEM_ADDR 0x400000000
+// Base address for memory mapped control registers
+#define BASE_CTRL_ADDR  0x600000000
+// Base address for UpDown Program
+#define BASE_PROG_ADDR  0x800000000
+#else
+// Base address for scratchpad memories
+#define BASE_SPMEM_ADDR 0x20000000000
+// Base address for memory mapped control registers
+#define BASE_CTRL_ADDR  0x26000000000
+// Base address for UpDown Program
+#define BASE_PROG_ADDR  0x28000000000
+#endif
+
+// Control signals address space capacity. Number of control registers may
+#define CONTROL_CAPACITY_PER_LANE 32
+
+// Scratchpad address space maximum capacity = def currently
+#define SPMEM_CAPACITY_PER_LANE   65536
+
+// Number of lanes capacity - Max = Def currently
+#define NUM_LANES_CAPACITY        64
+// #define NUM_LANES_CAPACITY DEF_NUM_LANES
+
+// Number of UDs capacity - UD capacity
+// #define NUM_UDS_CAPACITY DEF_NUM_UDS
+#define NUM_UDS_CAPACITY          4
+
+// Number of nodes capacity
+// #define NUM_NODES_CAPACITY DEF_NUM_NODES
+#define NUM_NODES_CAPACITY        16
+
+// Number of stacks capacity
+// #define NUM_STACKS_CAPACITY DEF_NUM_STACKS
+#define NUM_STACKS_CAPACITY       8
+
+// Base address mapped memory - This is due to simulation
+#define BASE_SYNC_SPACE           0x7FFF0000
+
+// Revisit this
+// #ifndef GEM5_MODE
+// #define BASE_MAPPED_ADDR 0x7FD0'0000'0000llu
+// #define BASE_MAPPED_GLOBAL_ADDR 0x2'0000'0000llu
+// #else
+// #define BASE_MAPPED_ADDR 0x8000'0000llu
+// #define BASE_MAPPED_GLOBAL_ADDR 0x2'0000'0000llu
+// #endif
+#define BASE_MAPPED_ADDR          0x80000000
+#define BASE_MAPPED_GLOBAL_ADDR   0x200000000
+
+// CONTROL SIGNALES OFFSET IN WORDS
+#define EVENT_QUEUE_OFFSET        0x0
+#define OPERAND_QUEUE_OFFSET      0x1
+#define START_EXEC_OFFSET         0x2
+#define LOCK_OFFSET               0x3
+
+namespace UpDown {
+
+// Depending of the word size we change the pointer type
+#if DEF_WORD_SIZE == 4
+typedef uint32_t word_t;
+#elif DEF_WORD_SIZE == 8
+typedef uint64_t word_t;
+#else
+#error Unknown default word size
+#endif
+
+typedef word_t*          ptr_t;
+static constexpr uint8_t CREATE_THREAD = 0xFF;
+
+}  // namespace UpDown
+
+#endif

--- a/test/udruntime/src/updown.cpp
+++ b/test/udruntime/src/updown.cpp
@@ -1,0 +1,1 @@
+#include "updown.h"

--- a/test/udruntime/test/.gitignore
+++ b/test/udruntime/test/.gitignore
@@ -1,0 +1,9 @@
+*#
+*~
+*.log
+*.tmplog
+*.exe
+*.csv
+*.trc
+*.dis
+*.bin

--- a/test/udruntime/test/Makefile
+++ b/test/udruntime/test/Makefile
@@ -1,0 +1,94 @@
+#
+# Makefile
+#
+# makefile: udruntime/test
+# This area checks out runtime on REV  without any dependencies
+# on updown install or lib
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+ifdef GEM5_MODE
+$(error Cannot set GEM5_MODE)
+endif
+
+ifdef FASTSIM
+$(error Cannot set FASTSIM)
+endif
+
+# Python configuration file
+REVCFG ?= ./rev-memh.py
+#REVCFG ?= ./rev-mem.py
+
+# Rev toolchain
+CC=riscv64-unknown-elf-g++
+# CC=riscv64-unknown-elf-gcc
+REVHOME ?= $(realpath ../../../)
+REVLIBPATH ?= $(REVHOME)/build/src
+OBJDUMP   = ${RISCV}/bin/riscv64-unknown-elf-objdump -S -dC -Mno-aliases
+
+# Rev runtime includes
+INCLUDE  := -I$(REVHOME)/common/include
+INCLUDE  := -I$(REVHOME)/common/syscalls
+INCLUDE  += -I$(REVHOME)/test/include
+INCLUDE  += -I../include
+INCLUDE  += -I../src
+
+# configuration
+CCOPT ?= -O0
+# CCOPT ?= -O2
+# debug flags require custom syscalls in ud-sys-dev branch
+# DEBUG_FLAGS += -DDEBUG_MODE
+FLAGS     := $(CCOPT) -DASST $(DEBUG_FLAGS) -g -static -lm -fpermissive
+ARCH      := rv64gc
+ABI       := -mabi=lp64d
+
+# Targets
+TLIST ?= $(patsubst %.cpp,%,$(wildcard *.cpp))
+EXES   = $(addsuffix .exe,$(TLIST))
+DIASMS = $(addsuffix .dis,$(TLIST))
+LOGS   = $(addsuffix .log,$(TLIST))
+TARGS  = $(EXES) $(DIASMS) $(LOGS)
+# BINS   = $(addsuffix .bin,$(TLIST))
+TMPS   = $(addsuffix .tmplog,$(TLIST))
+
+# Recipes
+all: $(TARGS)
+
+#compile: $(EXES) $(DIASMS)
+compile: $(EXES)
+
+run: $(LOGS)
+
+%.dis: %.exe
+	$(OBJDUMP) $< > $@
+
+%.exe: %.cpp
+	$(CC) $(FLAGS) -o $@ $< -march=$(ARCH) $(ABI) $(INCLUDE) $(LIBS)
+
+# Append 'c' to ARCH since stdlib includes compact instructions
+# If test fails the log file will be in testname.tmplog
+%.log: %.exe
+	@$(eval tmp = $(basename $@).tmplog)
+	REV_EXE=$<
+	REV_EXE=$< ARCH=$(ARCH) sst --add-lib-path=$(REVLIBPATH) $(REVCFG) > $(tmp)
+	mv $(tmp) $@
+
+.PHONY: clean run
+
+clean:
+	rm -f $(TARGS) $(TMPS)
+
+.PHONY: help
+help:
+	@echo make compile
+	@echo make run
+	@echo make
+
+
+.SECONDARY:
+
+#-- EOF

--- a/test/udruntime/test/event_t.cpp
+++ b/test/udruntime/test/event_t.cpp
@@ -1,0 +1,97 @@
+#include "updown.h"
+
+#include "rev-macros.h"
+#include "syscalls.h"
+#undef assert
+#define assert TRACE_ASSERT
+
+#ifdef DEBUG_MODE
+#define printf rev_fast_print
+#else
+#define printf( ... )
+#endif
+
+//Fine to overload new at global scope, could also be done per class
+
+/*void* operator new(std::size_t t){
+     void* p = reinterpret_cast<void*>(rev_mmap(0,
+              t,
+              PROT_READ | PROT_WRITE | PROT_EXEC,
+              MAP_PRIVATE | MAP_ANONYMOUS,
+              -1,
+              0));
+    return p;
+}*/
+
+void printEvent( UpDown::event_t& ev ) {
+  printf( "Setting the event word = %d, lane_id = %d, "
+          "thread_id = %d, num_operands = %d, ev_word = 0x%lX\n",
+          ev.get_EventLabel(),
+          ( ev.get_NetworkId() ).get_LaneId(),
+          ev.get_ThreadId(),
+          ev.get_NumOperands(),
+          ev.get_EventWord() );
+}
+
+void test1();
+
+int  main() {
+
+   // Create an empty event_
+  UpDown::event_t empty_evnt;
+  printEvent( empty_evnt );
+  UpDown::event_t def_envt( 10, UpDown::networkid_t( 11 ) );
+  printEvent( def_envt );
+  UpDown::event_t def_envt2( 12, UpDown::networkid_t( 13, 14 ) );
+  printEvent( def_envt2 );
+  UpDown::event_t def_envt3( 15, UpDown::networkid_t( 16, 17 ), 18 );
+  printEvent( def_envt3 );
+
+  // Help operands
+  UpDown::word_t     ops_data[] = { 1, 2, 3, 4 };
+  UpDown::operands_t ops( 4, ops_data );
+
+  // Events with operands
+  UpDown::event_t    evnt_ops( 15, UpDown::networkid_t( 16, 17 ), 18, &ops );
+  printEvent( evnt_ops );
+
+ #if 0
+  //
+  // (bug) Cannot have empty ops
+  //
+  def_envt.set_event(1, UpDown::networkid_t(2));
+  printEvent(def_envt);
+  def_envt.set_event(3, UpDown::networkid_t(4, 5));
+  printEvent(def_envt);
+  def_envt.set_event(3, UpDown::networkid_t(4, 5), 6);
+  printEvent(def_envt);
+#endif
+
+  def_envt.set_event( 3, UpDown::networkid_t( 4, 5 ), 6, &ops );
+  printEvent( def_envt );
+
+  test1();
+
+  return 0;
+}
+
+void test1() {
+  uint64_t           minus1     = 0xffffffffffffffffULL;
+  uint64_t           ops_data[] = { minus1, minus1 - 1, minus1 - 2 };
+  UpDown::operands_t ops( 3, ops_data );
+  UpDown::event_t    e = UpDown::event_t(
+    15, UpDown::networkid_t( 5 ), UpDown::CREATE_THREAD, &ops );
+  // retrieve and check the ops
+  uint64_t* p_data = e.get_Operands()->get_Data();
+  assert( ops_data[0] == (uint64_t) p_data[1] );
+  assert( ops_data[1] == (uint64_t) p_data[2] );
+  assert( ops_data[2] == (uint64_t) p_data[3] );
+  // check the remaining fields
+  assert( e.get_EventWord() == ( 5UL << 32 ) | ( 0x0ffUL << 24 ) | 15 );
+  assert( e.get_ThreadId() == UpDown::CREATE_THREAD );
+  assert( e.get_NumOperands() == 3 );
+  assert( e.get_EventLabel() == 15 );
+
+  UpDown::networkid_t nwid2 = e.get_NetworkId();
+  assert( nwid2.get_NetworkId() == 5 );
+}

--- a/test/udruntime/test/laneSanity.cpp
+++ b/test/udruntime/test/laneSanity.cpp
@@ -1,0 +1,154 @@
+/*
+ * laneLatency.cpp - modified to just check the runtime
+ * Environment
+ *    UPDOWN=1
+ *    PIM_TYPE=2
+ */
+
+// Standards includes
+#include "stdlib.h"
+
+// Updown includes
+// Runtime modifications are required for C++ on REV
+// <rev-home>/test/udruntime/include
+#define GEM5_MODE
+#include "updown.h"
+
+// Rev includes
+#include "rev-macros.h"
+#include "syscalls.h"
+
+// Assert customization (must be after all include directives)
+#undef assert
+#define assert         TRACE_ASSERT
+
+// PIM backend simulator types
+#define PIM_TYPE_NONE  0
+#define PIM_TYPE_TEST  1
+#define PIM_TYPE_BASIM 2
+
+// REV Runtime port
+using namespace UpDown;
+typedef UDRuntime_t< UpDown::RevRTAllocPolicy< UpDown::ud_mapped_memory_t > >
+  Runtime_t;
+
+#if 0
+#define USAGE                                                              \
+  "USAGE: ./lanelatency <num_lanes>  <num_uds> <num_stacks>  <num_nodes> " \
+  " <souce_nwid> <dest_nwid> <num_trans>"
+#endif
+
+void isav2test( uint32_t              core_id,
+                uint32_t              source_nwid,
+                uint32_t              dest_nwid,
+                Runtime_t*            rt,
+                UpDown::ud_machine_t* machine,
+                uint32_t              num_trans ) {
+
+  UpDown::operands_t ops( 2 );
+  uint32_t node_id = source_nwid / ( machine->NumUDs * machine->NumStacks );
+  assert( node_id == 0 );  // TODO remove constraint
+
+  uint32_t cl_id   = source_nwid / machine->NumUDs;
+  uint32_t ud_id   = source_nwid % machine->NumUDs;
+  uint32_t lane_id = source_nwid % machine->NumLanes;
+
+  assert( cl_id == 0 );    // 2/4  = 0
+  assert( ud_id == 2 );    // 2%4  = 2
+  assert( lane_id == 2 );  // 2%64 = 2
+
+  uint32_t check_nwid = ( ud_id << 6 ) & 0xc0 | ( lane_id & 0x3f );
+#if 1
+  assert( check_nwid == 0x82 );
+#endif
+
+#if 1
+  UpDown::networkid_t nwid( lane_id, ud_id, cl_id, node_id );
+#else
+  //UpDown::networkid_t nwid(check_nwid, 0, 0);
+  UpDown::networkid_t nwid;
+  nwid.set( lane_id, ud_id, cl_id, node_id );
+#endif
+
+#if 1
+  assert( nwid.get_LaneId() == 2 );
+  assert( nwid.get_UdId() == 2 );
+  assert( nwid.get_NetworkId() ==
+          0x82 );  // 2<<6 | 2 = 0x82  (has passed before)
+#endif
+
+  // printf("start nwid = %d, end nwid = %d num trans =%d\n", source_nwid, dest_nwid, num_trans);
+  ops.set_operand( 0, dest_nwid );
+  ops.set_operand( 1, num_trans );
+
+  // Events with operands
+
+  UpDown::event_t evnt_ops( 0 /*Event Label*/,
+                            nwid /*Lane ID*/,
+                            UpDown::CREATE_THREAD /*Thread ID*/,
+                            &ops /*Operands*/ );
+
+  assert( evnt_ops.get_EventWord() == 0x82ff000000 );
+  assert( evnt_ops.get_ThreadId() == 0xff );
+  assert( evnt_ops.get_NumOperands() == 2 );
+  networkid_t enwid = evnt_ops.get_NetworkId();
+  assert( enwid.get_LaneId() == 2 );
+  assert( enwid.get_UdId() == 2 );
+  assert( enwid.get_NetworkId() == 0x82 );
+
+
+  //rt->send_event(evnt_ops);
+  //rt->start_exec(nwid);
+
+  //printf("Check for termination now\n");
+  //rt->test_wait_addr(nwid, 0 /*Offset*/, 1 /*Expected value*/);
+
+  //printf("All Events launched and threads terminated\n");
+}
+
+/// TODO: This microbenchmark does not support multiple UDs or Threads. Fixme
+int main( int argc, char* argv[] ) {
+
+#if 1
+  // Issue #214
+  uint32_t source_nwid = 2;
+  uint32_t dest_nwid   = 8;
+  uint32_t num_trans   = 16;
+  uint32_t core_id     = 0;
+#else
+  char* testname;
+  if( argc < 2 ) {
+    printf( "Insufficient Input Params\n" );
+    printf( "%s\n", USAGE );
+    exit( 1 );
+  }
+
+  uint32_t source_nwid = atoi( argv[1] );
+  uint32_t dest_nwid   = atoi( argv[2] );
+  uint32_t num_trans   = atoi( argv[3] );
+  uint32_t core_id     = atoi( argv[4] );
+#endif
+
+  // printf("Sending %d transactions from SRD:%d to DEST:%d\n", num_trans, source_nwid, dest_nwid);
+
+  UpDown::ud_machine_t machine;
+  machine.LocalMemAddrMode = 1;
+
+  assert( machine.NumStacks == 8 );
+  assert( machine.NumUDs == 4 );
+
+  // auto *rt = new Runtime_t(machine);
+  Runtime_t rt = Runtime_t( machine );
+
+  // #if 1
+  // // sanity check backend simulator type
+  // uint64_t pim_id = 0;
+  // networkid_t nwid(0);
+  // rt.ud2t_memcpy(&pim_id, 8, nwid, 0);
+  // assert(pim_id==PIM_TYPE_BASIM);
+  // #endif
+
+  isav2test( core_id, source_nwid, dest_nwid, &rt, &machine, num_trans );
+
+  //printf("ISAv2 test done\n");
+}

--- a/test/udruntime/test/network_id_copy.cpp
+++ b/test/udruntime/test/network_id_copy.cpp
@@ -1,0 +1,54 @@
+#include "rev-macros.h"
+#include <updown.h>
+#undef assert
+#define assert TRACE_ASSERT
+
+int main() {
+
+  UpDown::ud_machine_t machine;
+  uint32_t             source_nwid = 2;
+  uint32_t             node_id     = 0;
+  uint32_t             cl_id       = source_nwid / machine.NumUDs;
+  uint32_t             ud_id       = source_nwid % machine.NumUDs;
+  uint32_t             lane_id     = source_nwid % machine.NumLanes;
+
+  assert( cl_id == 0 );    // 2/4  = 0
+  assert( ud_id == 2 );    // 2%4  = 2
+  assert( lane_id == 2 );  // 2%64 = 2
+
+  uint32_t check_nwid = ( ud_id << 6 ) & 0xc0 | ( lane_id & 0x3f );
+  assert( check_nwid == 0x82 );
+
+  UpDown::networkid_t nwid1( lane_id, ud_id, cl_id, node_id );
+  assert( nwid1.get_NetworkId() == 0x82 );  // 2<<6 | 2 = 0x82
+
+  UpDown::networkid_t nwid2( check_nwid, 0, 0 );
+  assert( nwid2.get_NetworkId() == 0x82 );  // 2<<6 | 2 = 0x82
+
+
+  UpDown::word_t     op_data[3];
+  UpDown::operands_t ops( 3, op_data );
+  ops.set_operand( 0, 0x8000 );
+  ops.set_operand( 1, 0x100 );
+  for( int ln = 0; ln < 64; ln += 8 ) {
+    for( int udid = 0; udid < 4; udid++ ) {
+      for( int stack_id = 0; stack_id < 8; stack_id++ ) {
+        for( int node_id = 0; node_id < 8; node_id += 2 ) {
+          UpDown::networkid_t nwid( ln, udid, stack_id, node_id );
+          ops.set_operand( 2, 0x1000 * ln );
+          UpDown::event_t ev( 0, nwid, 0xff, &ops );
+          assert( nwid.get_LaneId() == ln );
+          assert( ev.get_NetworkId().get_LaneId() == ln );
+          assert( nwid.get_UdId() == udid );
+          assert( ev.get_NetworkId().get_UdId() == udid );
+          assert( nwid.get_StackId() == stack_id );
+          assert( ev.get_NetworkId().get_StackId() == stack_id );
+          assert( nwid.get_NodeId() == node_id );
+          assert( ev.get_NetworkId().get_NodeId() == node_id );
+        }
+      }
+    }
+  }
+
+  return 0;
+}

--- a/test/udruntime/test/nwid_simple.cpp
+++ b/test/udruntime/test/nwid_simple.cpp
@@ -1,0 +1,65 @@
+#include "rev-macros.h"
+#include "updown.h"
+#undef assert
+#define assert TRACE_ASSERT
+
+int main() {
+
+  // constructor using total lanes and bool
+  uint64_t            total_lanes = 0x100;
+  UpDown::networkid_t tl_nwid( total_lanes, false, 0 );
+  assert( tl_nwid.get_NetworkId_UdName() == 0x100 );
+  assert( tl_nwid.get_TopUd() == 0 );
+  assert( tl_nwid.get_SendPolicy() == 0 );
+  assert( tl_nwid.get_NodeId() == 0 );
+  assert( tl_nwid.get_StackId() == 1 );
+  assert( tl_nwid.get_UdId() == 0 );
+  assert( tl_nwid.get_LaneId() == 0 );
+  assert( tl_nwid.get_NetworkId() == 0x100 );
+
+  total_lanes = 0x283;
+  tl_nwid     = UpDown::networkid_t( total_lanes, false, 1 );
+  assert( tl_nwid.get_NetworkId_UdName() == 0x283 );
+  assert( tl_nwid.get_TopUd() == 0 );
+  assert( tl_nwid.get_SendPolicy() == 1 );
+  assert( tl_nwid.get_NodeId() == 0 );
+  assert( tl_nwid.get_StackId() == 2 );
+  assert( tl_nwid.get_UdId() == 2 );
+  assert( tl_nwid.get_LaneId() == 3 );
+  assert( tl_nwid.get_NetworkId() == 0x283 + ( 1 << 27 ) );
+
+  total_lanes = -1;
+  tl_nwid     = UpDown::networkid_t( total_lanes, false, 1 );
+  assert( tl_nwid.get_NetworkId_UdName() == 0x7ffffff );
+  assert( tl_nwid.get_TopUd() == 0 );
+  assert( tl_nwid.get_SendPolicy() == 1 );
+  assert( tl_nwid.get_NodeId() == 0xffff );
+  assert( tl_nwid.get_StackId() == 7 );
+  assert( tl_nwid.get_UdId() == 3 );
+  assert( tl_nwid.get_LaneId() == 63 );
+  assert( tl_nwid.get_NetworkId() == 0x7ffffff + ( 1 << 27 ) );
+
+  UpDown::ud_machine_t machine;
+  uint32_t             source_nwid = 7;
+  uint32_t             node_id     = 3;
+  uint32_t             cl_id       = source_nwid / machine.NumUDs;
+  uint32_t             ud_id       = source_nwid % machine.NumUDs;
+  uint32_t             lane_id     = source_nwid % machine.NumLanes;
+
+  assert( cl_id == 1 );    // 7/4  = 1
+  assert( ud_id == 3 );    // 7%4  = 3
+  assert( lane_id == 7 );  // 7%64 = 7
+
+  uint32_t check_nwid =
+    ( node_id << 11 ) | ( cl_id << 8 ) | ( ud_id << 6 ) | ( lane_id );
+  assert( check_nwid == 0x19c7 );
+
+  UpDown::networkid_t nwid1( lane_id, ud_id, cl_id, node_id );
+  assert( nwid1.get_NetworkId() == 0x19c7 );
+
+  UpDown::networkid_t nwid2( check_nwid, 0, 0 );
+  assert( nwid2.get_NetworkId() == 0x19c7 );
+
+
+  return 0;
+}

--- a/test/udruntime/test/operands_t.cpp
+++ b/test/udruntime/test/operands_t.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <updown.h>
+
+int main() {
+  // Create an empty operands_t
+  UpDown::operands_t empty_ops;
+
+  // Create an operand_t with operands
+  UpDown::word_t     ops_data[] = { 1, 2, 3, 4 };
+  UpDown::operands_t set_ops( 4, ops_data );
+
+  // Create an event with a continuation
+  UpDown::operands_t set_ops_cont( 4, ops_data, 99 );
+  for( uint8_t i = 0; i < set_ops_cont.get_NumOperands() + 1; i++ )
+    set_ops_cont.get_Data()[i];
+  return 0;
+}

--- a/test/udruntime/test/rev-memh.py
+++ b/test/udruntime/test/rev-memh.py
@@ -1,0 +1,116 @@
+#
+# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-memh.py
+#
+
+import os
+import sst
+
+# Environment settings
+rev_exe = os.getenv("REV_EXE", "")
+arch = os.getenv("ARCH","RV64GC").upper()
+
+DEBUG_L1 = 0
+DEBUG_MEM = 0
+DEBUG_LEVEL = 10
+VERBOSE = 2
+MEM_SIZE = 128*1024*1024*1024-1
+
+if ( rev_exe == "" ):
+  print("ERROR: REV_EXE is not set",file=sys.stderr);
+  exit(1);
+
+print(f"REV_EXE={rev_exe}")
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+# sst.setStatisticLoadLevel(4)
+
+max_addr_gb = 1
+
+# Define the simulation components
+# Instantiate all the CPUs
+simNodes = 1
+numHarts = 1
+for i in range(0, simNodes):
+  print("Building "+ str(i))
+  comp_cpu = sst.Component("cpu" + str(i), "revcpu.RevCPU")
+  comp_cpu.addParams({
+        "verbose" : 2,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "numHarts" : numHarts,                        # Number of harts
+	      "clock" : "1.0GHz",                     # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : f"[CORES:{arch}]",                # Core:Config; common arch for all
+        #"startAddr" : "[CORES:0x00000000]",           # Starting address for core 0
+        # "startSymbol" : "[0:_start]",
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : rev_exe,                          # Target executable
+        #"args"    : testArgs,                        # Program arguments
+        #"trcStartCycle" : 1,                          # Trace everything after this cycle
+        "enableUpDown" : 1,                           # Enable UpDown Support
+        "enable_memH" : 1,                            # Enable memHierarchy support
+        "splash" : 0,                                 # Display the splash message
+        })
+#comp_cpu.enableAllStatistics()
+
+# Use coprocessor as UpDown Accelerator wrapper
+udaccel = comp_cpu.setSubComponent("RevUpDownCoProc", "revcpu.RevUpDownCoProc")
+udaccel.addParams({
+  "clockFreq"  : "1.5Ghz",
+  "verbose" : 10
+})
+
+# Create the RevMemCtrl subcomponent
+comp_lsq = comp_cpu.setSubComponent("memory", "revcpu.RevBasicMemCtrl");
+comp_lsq.addParams({
+      "verbose"         : "5",
+      "clock"           : "2.0Ghz",
+      "max_loads"       : 16,
+      "max_stores"      : 16,
+      "max_flush"       : 16,
+      "max_llsc"        : 16,
+      "max_readlock"    : 16,
+      "max_writeunlock" : 16,
+      "max_custom"      : 16,
+      "ops_per_cycle"   : 16
+})
+#comp_lsq.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+iface = comp_lsq.setSubComponent("memIface", "memHierarchy.standardInterface")
+iface.addParams({
+      "verbose" : VERBOSE
+})
+
+
+memctrl = sst.Component("memory", "memHierarchy.MemController")
+memctrl.addParams({
+    "debug" : DEBUG_MEM,
+    "debug_level" : DEBUG_LEVEL,
+    "clock" : "2GHz",
+    "verbose" : VERBOSE,
+    "addr_range_start" : 0,
+    "addr_range_end" : MEM_SIZE,
+    "backing" : "malloc"
+})
+
+memory = memctrl.setSubComponent("backend", "memHierarchy.simpleMem")
+memory.addParams({
+    "access_time" : "100ns",
+    "mem_size" : "512GB"
+})
+
+link_iface_mem = sst.Link("link_iface_mem")
+link_iface_mem.connect( (iface, "port", "50ps"), (memctrl, "direct_link", "50ps") )
+
+#sst.setStatisticOutput("sst.statOutputCSV")
+#sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/udruntime/test/rt_calc_addrmap.cpp
+++ b/test/udruntime/test/rt_calc_addrmap.cpp
@@ -1,0 +1,29 @@
+#include "updown.h"
+#include <iostream>
+
+int main() {
+  // Default configurations runtime
+  UpDown::UDRuntime_t< UpDown::RevRTAllocPolicy< UpDown::ud_mapped_memory_t > >
+                       test_rt = UpDown::UDRuntime_t< UpDown::RevRTAllocPolicy<
+      UpDown::ud_mapped_memory_t > >();  // = new UpDown::UDRuntime_t();
+
+  //  test_rt->dumpBaseAddrs();
+  //  test_rt->dumpMachineConfig();
+
+  //  delete test_rt;
+
+  UpDown::ud_machine_t machine;
+
+  machine.NumUDs   = 64;
+  machine.NumLanes = 64;
+
+  test_rt          = UpDown::UDRuntime_t<
+    UpDown::RevRTAllocPolicy< UpDown::ud_mapped_memory_t > >(
+    machine );  // new UpDown::UDRuntime_t(machine);
+
+  //  test_rt.dumpBaseAddrs();
+  // test_rt.dumpMachineConfig();
+
+
+  return 0;
+}

--- a/test/udruntime/test/rt_mm_malloc_free.cpp
+++ b/test/udruntime/test/rt_mm_malloc_free.cpp
@@ -1,0 +1,44 @@
+#include "updown.h"
+#include <iostream>
+
+int main() {
+  // Default configurations runtime
+  UpDown::UDRuntime_t< UpDown::RevRTAllocPolicy< UpDown::ud_mapped_memory_t > >
+                test_rt = UpDown::UDRuntime_t< UpDown::RevRTAllocPolicy<
+      UpDown::ud_mapped_memory_t > >();  // = new UpDown::UDRuntime_t();
+  //UpDown::UDRuntime_t *test_rt = new UpDown::UDRuntime_t();
+
+  // printf("=== Base Addresses ===\n");
+  //  test_rt->dumpBaseAddrs();
+  // printf("\n=== Machine Config ===\n");
+  // test_rt->dumpMachineConfig();
+
+  UpDown::ptr_t a_ptr, a_ptr2, a_ptr3, a_ptr4, a_ptr5, a_ptr6, a_ptr7, a_ptr8;
+
+  a_ptr  = (UpDown::ptr_t) test_rt.mm_malloc( 100 * sizeof( UpDown::word_t ) );
+  a_ptr2 = (UpDown::ptr_t) test_rt.mm_malloc( 200 * sizeof( UpDown::word_t ) );
+  a_ptr3 = (UpDown::ptr_t) test_rt.mm_malloc( 300 * sizeof( UpDown::word_t ) );
+  a_ptr4 = (UpDown::ptr_t) test_rt.mm_malloc( 400 * sizeof( UpDown::word_t ) );
+  a_ptr5 =
+    (UpDown::ptr_t) test_rt.mm_malloc_global( 100 * sizeof( UpDown::word_t ) );
+  a_ptr6 =
+    (UpDown::ptr_t) test_rt.mm_malloc_global( 200 * sizeof( UpDown::word_t ) );
+  a_ptr7 =
+    (UpDown::ptr_t) test_rt.mm_malloc_global( 300 * sizeof( UpDown::word_t ) );
+  a_ptr8 =
+    (UpDown::ptr_t) test_rt.mm_malloc_global( 400 * sizeof( UpDown::word_t ) );
+
+  /*
+  test_rt->mm_free(a_ptr2);
+  test_rt->mm_free(a_ptr3);
+  a_ptr5 = (UpDown::ptr_t)test_rt->mm_malloc(50*sizeof(UpDown::word_t));
+  printf("a_ptr5 = 0x%lX\n", reinterpret_cast<uint64_t>(a_ptr5));
+  test_rt->mm_free(a_ptr4);
+  test_rt->mm_free(a_ptr);
+  test_rt->mm_free(a_ptr5);
+  test_rt->mm_free_global(a_ptr6);
+  test_rt->mm_free_global(a_ptr7);
+  test_rt->mm_free_global(a_ptr8);*/
+
+  return 0;
+}

--- a/test/udruntime/test/run-test.bash
+++ b/test/udruntime/test/run-test.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+rm -f O0.log O2.log O2_WORKAROUND.log
+
+echo -n "Testing -O0 ... "
+make clean -s && make CCOPT=-O0 -j >& O0.log && echo "Passed" || echo "Failed"
+echo "See O0.log"
+
+echo "Testing -O2 with O2_WORKAROUND"
+make clean -s  && make -j -s CCOPT=-O2 DEBUG_FLAGS=-DO2_WORKAROUND >& O2_WORKAROUND.log && echo "Passed" || echo "Failed"
+echo "See O2_WORKAROUND.log"
+
+echo "Testing -O2 without O2_WORKAROUND"
+make clean -s  && make -j -s CCOPT=-O2 >& O2.log && echo "Passed" || echo "Failed"
+echo "See O2.log"
+
+echo "Done with testing"
+


### PR DESCRIPTION
In order to port more complex workloads to REV I'm finding it extremely challenging to get functionally correct code using C++ constructs. Seeming trivial code changes can lead to wildly different behaviors.

This PR is intended to nail down a baseline minimum set of C++ code supported on rev and document the associated methods and workarounds (if necessary).

A test script is provided that runs the suite using these compiler flags:
-O0 (expected to pass)
-O2 (expected to fail)
-O2 -DO2_WORKAROUND (expected to pass)

The test suite passes except for a single test using the -O2 compiler optimizations. The failure mode suggests a stack pointer corruption issue.

To run:
```
cd test/udruntime
./run-test.bash
```

Result:
```
Testing -O0 ... Passed
See O0.log
Testing -O2 with O2_WORKAROUND
Passed
See O2_WORKAROUND.log
Testing -O2 without O2_WORKAROUND
Failed
See O2.log
Done with testing
```

The O2_WORKAROUND simply saves a function argument in a static variable which appears to affect the compilation. Without the workaround the core gets a bad pointer from the stack and crashes.

Obviously, this workaround is empirically derived an unreliable so this runtime library has limited use beyond limited prototype code.



