### PR TITLE
Tracer assertion macro fix

### DIFF
--- a/test/include/rev-macros.h
+++ b/test/include/rev-macros.h
@@ -11,9 +11,9 @@
 #define TRACE_PUSH_OFF asm volatile("slli x0,x0,2");
 #define TRACE_PUSH_ON  asm volatile("slli x0,x0,3");
 #define TRACE_POP      asm volatile("slli x0,x0,4");
-#define TRACE_ASSERT(x) { TRACE_PUSH_ON; \
+#define TRACE_ASSERT(x) do { TRACE_PUSH_ON; \
   if (!(x)) { asm volatile(".word 0x0"); }; \
-  TRACE_POP }
+  TRACE_POP } while (0)
 #else
 #define TRACE_OFF
 #define TRACE_ON

--- a/test/include/rev-macros.h
+++ b/test/include/rev-macros.h
@@ -13,7 +13,7 @@
 #define TRACE_POP      asm volatile("slli x0,x0,4");
 #define TRACE_ASSERT(x) { TRACE_PUSH_ON; \
   if (!(x)) { asm volatile(".word 0x0"); }; \
-  TRACE_PUSH_OFF }
+  TRACE_POP }
 #else
 #define TRACE_OFF
 #define TRACE_ON


### PR DESCRIPTION
This is a trivial fix to avoid having the TRACE_ASSERT macro turn off the tracer which may have been enabled in the calling program. This simply changes the TRACE_PUSH_OFF to TRACE_POP which restores the state as originally intended with this macro. Unrelated to the functional fix, I'd ppreciate review of the macro definition to avoid other unintended pitfalls.