### PR TITLE
Add struct declarations to remove warnings

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -249,7 +249,10 @@ struct clone_args;
 struct open_how;
 struct mount_attr;
 struct landlock_ruleset_attr;
-
+struct old_timespec32;
+struct __kernel_itimerspec;
+struct sigevent;
+struct sigaction;
 
 typedef uint32_t      rwf_t;
 typedef unsigned long aio_context_t;


### PR DESCRIPTION
Removes  warnings such as:
```
syscalls.h:420:98: warning: 'struct old_timespec32' declared inside parameter list will not be visible outside of this definition or declaration
````
