### PR TITLE
change clang-format to not align declarations across blank lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,7 +59,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 2
 AlignArrayOfStructures: Right
 AlignConsecutiveAssignments: AcrossEmptyLinesAndComments
-AlignConsecutiveDeclarations: AcrossEmptyLinesAndComments
+AlignConsecutiveDeclarations: Consecutive
 AlignConsecutiveMacros: AcrossEmptyLinesAndComments
 AlignConsecutiveBitFields: AcrossEmptyLinesAndComments
 AlwaysBreakTemplateDeclarations: Yes

--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -127,12 +127,12 @@ struct MemReq {
     return std::make_pair( LSQHash(), *this );
   }
 
-  uint64_t                               Addr    = _INVALID_ADDR_;
-  uint16_t                               DestReg = 0;
-  RevRegClass                            RegType = RevRegClass::RegUNKNOWN;
-  unsigned                               Hart    = _REV_INVALID_HART_ID_;
-  MemOp                                  ReqType = MemOp::MemOpCUSTOM;
-  bool                                   isOutstanding        = false;
+  uint64_t    Addr          = _INVALID_ADDR_;
+  uint16_t    DestReg       = 0;
+  RevRegClass RegType       = RevRegClass::RegUNKNOWN;
+  unsigned    Hart          = _REV_INVALID_HART_ID_;
+  MemOp       ReqType       = MemOp::MemOpCUSTOM;
+  bool        isOutstanding = false;
 
   std::function< void( const MemReq& ) > MarkLoadCompleteFunc = nullptr;
 

--- a/include/RevCPU.h
+++ b/include/RevCPU.h
@@ -251,14 +251,14 @@ private:
   bool ThreadCanProceed( const std::unique_ptr< RevThread >& Thread );
 
   // vector of Threads which are ready to be scheduled
-  std::vector< std::unique_ptr< RevThread > > ReadyThreads   = {};
+  std::vector< std::unique_ptr< RevThread > > ReadyThreads = {};
 
   // List of Threads that are currently blocked (waiting for their WaitingOnTID to be a key in CompletedThreads).
-  std::list< std::unique_ptr< RevThread > >   BlockedThreads = {};
+  std::list< std::unique_ptr< RevThread > > BlockedThreads = {};
 
   // Set of Thread IDs and their corresponding RevThread that have completed their execution on this RevCPU
   std::unordered_map< uint32_t, std::unique_ptr< RevThread > >
-           CompletedThreads = {};
+    CompletedThreads = {};
 
   // Generates a new Thread ID using the RNG.
   uint32_t GetNewThreadID() {
@@ -268,7 +268,7 @@ private:
   uint8_t  PrivTag;  ///< RevCPU: private tag locator
   uint32_t LToken;   ///< RevCPU: token identifier for PAN Test
 
-  int      address;  ///< RevCPU: local network address
+  int address;  ///< RevCPU: local network address
 
   unsigned fault_width;  ///< RevCPU: the width (in bits) for target faults
   int64_t  fault_range;  ///< RevCPU: the range of cycles to inject the fault
@@ -276,9 +276,9 @@ private:
 
   uint64_t PrevAddr;  ///< RevCPU: previous address for handling PAN messages
 
-  bool     EnableNIC;   ///< RevCPU: Flag for enabling the NIC
-  bool     EnableMemH;  ///< RevCPU: Enable memHierarchy
-  bool EnableCoProc;    ///< RevCPU: Enable a co-processor attached to all cores
+  bool EnableNIC;     ///< RevCPU: Flag for enabling the NIC
+  bool EnableMemH;    ///< RevCPU: Enable memHierarchy
+  bool EnableCoProc;  ///< RevCPU: Enable a co-processor attached to all cores
 
   bool EnableFaults;       ///< RevCPU: Enable fault injection logic
   bool EnableCrackFaults;  ///< RevCPU: Enable Crack+Decode Faults
@@ -291,8 +291,8 @@ private:
   TimeConverter* timeConverter;  ///< RevCPU: SST time conversion handler
   SST::Output    output;         ///< RevCPU: SST output handler
 
-  nicAPI*        Nic;   ///< RevCPU: Network interface controller
-  RevMemCtrl*    Ctrl;  ///< RevCPU: Rev memory controller
+  nicAPI*     Nic;   ///< RevCPU: Network interface controller
+  RevMemCtrl* Ctrl;  ///< RevCPU: Rev memory controller
 
   std::vector< RevCoProc* > CoProcs;  ///< RevCPU: CoProcessor attached to Rev
 
@@ -311,7 +311,7 @@ private:
                            unsigned,
                            int,
                            uint64_t > >
-                         ReadQueue;  ///< RevCPU: outgoing memory read queue
+    ReadQueue;  ///< RevCPU: outgoing memory read queue
   ///<         - Tag
   ///<         - Size
   ///<         - Cost
@@ -387,37 +387,37 @@ private:
   //-------------------------------------------------------
 
   /// RevCPU: decode the fault codes
-  void    DecodeFaultCodes( const std::vector< std::string >& faults );
+  void DecodeFaultCodes( const std::vector< std::string >& faults );
 
   /// RevCPU:: decode the fault width
-  void    DecodeFaultWidth( const std::string& width );
+  void DecodeFaultWidth( const std::string& width );
 
   /// RevCPU: RevNIC message handler
-  void    handleMessage( SST::Event* ev );
+  void handleMessage( SST::Event* ev );
 
   /// RevCPU: Creates a unique tag for this message
   uint8_t createTag();
 
   /// RevCPU: Registers all the internal statistics
-  void    registerStatistics();
+  void registerStatistics();
 
   /// RevCPU: handle fault injection
-  void    HandleFaultInjection( SST::Cycle_t currentCycle );
+  void HandleFaultInjection( SST::Cycle_t currentCycle );
 
   /// RevCPU: handle crack+decode fault injection
-  void    HandleCrackFault( SST::Cycle_t currentCycle );
+  void HandleCrackFault( SST::Cycle_t currentCycle );
 
   /// RevCPU: handle memory fault
-  void    HandleMemFault( SST::Cycle_t currentCycle );
+  void HandleMemFault( SST::Cycle_t currentCycle );
 
   /// RevCPU: handle register fault
-  void    HandleRegFault( SST::Cycle_t currentCycle );
+  void HandleRegFault( SST::Cycle_t currentCycle );
 
   /// RevCPU: handle ALU fault
-  void    HandleALUFault( SST::Cycle_t currentCycle );
+  void HandleALUFault( SST::Cycle_t currentCycle );
 
   /// RevCPU: updates sst statistics on a per core basis
-  void    UpdateCoreStatistics( unsigned coreNum );
+  void UpdateCoreStatistics( unsigned coreNum );
 
 };  // class RevCPU
 

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -150,7 +150,7 @@ public:
   /// RevSimpleCoProc: clock tick function - currently not registeres with SST, called by RevCPU
   virtual bool ClockTick( SST::Cycle_t cycle );
 
-  void         registerStats();
+  void registerStats();
 
   /// RevSimpleCoProc: Enqueue Inst into the InstQ and return
   virtual bool
@@ -188,12 +188,12 @@ private:
   };
 
   /// RevSimpleCoProc: Total number of instructions retired
-  Statistic< uint64_t >*      num_instRetired;
+  Statistic< uint64_t >* num_instRetired;
 
   /// Queue of instructions sent from attached RevCore
   std::queue< RevCoProcInst > InstQ;
 
-  SST::Cycle_t                cycleCount;
+  SST::Cycle_t cycleCount;
 
 };  //class RevSimpleCoProc
 

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -72,19 +72,19 @@ public:
   ~RevCore() = default;
 
   /// RevCore: per-processor clock function
-  bool     ClockTick( SST::Cycle_t currentCycle );
+  bool ClockTick( SST::Cycle_t currentCycle );
 
   /// RevCore: Called by RevCPU when there is no more work to do (ie. All RevThreads are ThreadState::DONE )
-  void     PrintStatSummary();
+  void PrintStatSummary();
 
   /// RevCore: halt the CPU
-  bool     Halt();
+  bool Halt();
 
   /// RevCore: resume the CPU
-  bool     Resume();
+  bool Resume();
 
   /// RevCore: execute a single step
-  bool     SingleStepHart();
+  bool SingleStepHart();
 
   /// RevCore: retrieve the local PC for the correct feature set
   uint64_t GetPC() const {
@@ -173,7 +173,7 @@ public:
   }
 
   ///< RevCore: SpawnThread creates a new thread and returns its ThreadID
-  void     CreateThread( uint32_t NewTid, uint64_t fn, void* arg );
+  void CreateThread( uint32_t NewTid, uint64_t fn, void* arg );
 
   ///< RevCore: Returns the current HartToExecID active pid
   uint32_t GetActiveThreadID() {
@@ -278,26 +278,26 @@ public:
   ///  unitl ExternalReleaseHart() is called. Note the RevCorePassKey may only
   ///  be created by a RevCoProc (or a class derived from RevCoProc) so this funciton may not be called from even within
   ///  RevCore
-  void     ExternalStallHart( RevCorePasskey< RevCoProc >, uint16_t HartID );
+  void ExternalStallHart( RevCorePasskey< RevCoProc >, uint16_t HartID );
 
   ///< RevCore: Allow a co-processor to release the pipeline of this proc and allow a hart to continue
   ///  execution (this un-does the ExternalStallHart() function ). Note the RevCorePassKey may only
   ///  be created by a RevCoProc (or a class derived from RevCoProc) so this funciton may not be called from even within
   ///  RevCore
-  void     ExternalReleaseHart( RevCorePasskey< RevCoProc >, uint16_t HartID );
+  void ExternalReleaseHart( RevCorePasskey< RevCoProc >, uint16_t HartID );
   //------------- END External Interface -------------------------------
 
   ///< RevCore: Used for loading a software thread into a RevHart
-  void     AssignThread( std::unique_ptr< RevThread > ThreadToAssign );
+  void AssignThread( std::unique_ptr< RevThread > ThreadToAssign );
 
   ///< RevCore:
-  void     UpdateStatusOfHarts();
+  void UpdateStatusOfHarts();
 
   ///< RevCore: Returns the id of an idle hart (or _INVALID_HART_ID_ if none are idle)
   unsigned FindIdleHartID() const;
 
   ///< RevCore: Returns true if all harts are available (ie. There is nothing executing on this Proc)
-  bool     HasNoBusyHarts() const {
+  bool HasNoBusyHarts() const {
     return IdleHarts == ValidHarts;
   }
 
@@ -360,17 +360,17 @@ private:
     LSQueue;  ///< RevCore: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
   TimeConverter* timeConverter;  ///< RevCore: Time converter for RTC
 
-  RevRegFile*    RegFile =
+  RevRegFile* RegFile =
     nullptr;  ///< RevCore: Initial pointer to HartToDecodeID RegFile
   uint32_t ActiveThreadID =
     _INVALID_TID_;  ///< Software ThreadID (Not the Hart) that belongs to the Hart currently decoding
 
-  RevTracer*                 Tracer = nullptr;  ///< RevCore: Tracer object
+  RevTracer* Tracer = nullptr;  ///< RevCore: Tracer object
 
   std::bitset< _MAX_HARTS_ > CoProcStallReq;
   ///< RevCore: Utility function for system calls that involve reading a string from memory
-  EcallStatus                EcallLoadAndParseString( uint64_t straddr,
-                                                      std::function< void() > );
+  EcallStatus EcallLoadAndParseString( uint64_t straddr,
+                                       std::function< void() > );
 
   // - Many of these are not implemented
   // - Their existence in the ECalls table is solely to not throw errors
@@ -704,13 +704,13 @@ private:
 
   /// RevCore: Table of ecall codes w/ corresponding function pointer implementations
   static const std::unordered_map< uint32_t, EcallStatus ( RevCore::* )() >
-                              Ecalls;
+    Ecalls;
 
   /// RevCore: Execute the Ecall based on the code loaded in RegFile->GetSCAUSE()
-  bool                        ExecEcall();
+  bool ExecEcall();
 
   /// RevCore: Get a pointer to the register file loaded into Hart w/ HartID
-  RevRegFile*                 GetRegFile( unsigned HartID ) const;
+  RevRegFile* GetRegFile( unsigned HartID ) const;
 
   std::vector< RevInstEntry > InstTable;  ///< RevCore: target instruction table
 
@@ -728,7 +728,7 @@ private:
     CEncToEntry;  ///< RevCore: compressed instruction encoding to table entry mapping
 
   std::unordered_map< unsigned, std::pair< unsigned, unsigned > >
-       EntryToExt;  ///< RevCore: instruction entry to extension object mapping
+    EntryToExt;  ///< RevCore: instruction entry to extension object mapping
   ///           first = Master table entry number
   ///           second = pair<Extension Index, Extension Entry>
 
@@ -760,88 +760,88 @@ private:
   bool ReadOverrideTables();
 
   /// RevCore: compresses the encoding structure to a single value
-  uint32_t    CompressEncoding( RevInstEntry Entry );
+  uint32_t CompressEncoding( RevInstEntry Entry );
 
   /// RevCore: compressed the compressed encoding structure to a single value
-  uint32_t    CompressCEncoding( RevInstEntry Entry );
+  uint32_t CompressCEncoding( RevInstEntry Entry );
 
   /// RevCore: extracts the instruction mnemonic from the table entry
   std::string ExtractMnemonic( RevInstEntry Entry );
 
   /// RevCore: reset the core and its associated features
-  bool        Reset();
+  bool Reset();
 
   /// RevCore: set the PC
-  void        SetPC( uint64_t PC ) {
+  void SetPC( uint64_t PC ) {
     RegFile->SetPC( PC );
   }
 
   /// RevCore: prefetch the next instruction
-  bool     PrefetchInst();
+  bool PrefetchInst();
 
   /// RevCore: decode the instruction at the current PC
-  RevInst  FetchAndDecodeInst();
+  RevInst FetchAndDecodeInst();
 
   /// RevCore: decode a particular instruction opcode
-  RevInst  DecodeInst( uint32_t Inst ) const;
+  RevInst DecodeInst( uint32_t Inst ) const;
 
   /// RevCore: decode a compressed instruction
-  RevInst  DecodeCompressed( uint32_t Inst ) const;
+  RevInst DecodeCompressed( uint32_t Inst ) const;
 
   /// RevCore: decode an R-type instruction
-  RevInst  DecodeRInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeRInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode an I-type instruction
-  RevInst  DecodeIInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeIInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode an S-type instruction
-  RevInst  DecodeSInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeSInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a U-type instruction
-  RevInst  DecodeUInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeUInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a B-type instruction
-  RevInst  DecodeBInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeBInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a J-type instruction
-  RevInst  DecodeJInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeJInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode an R4-type instruction
-  RevInst  DecodeR4Inst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeR4Inst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CR-type isntruction
-  RevInst  DecodeCRInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCRInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CI-type isntruction
-  RevInst  DecodeCIInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CSS-type isntruction
-  RevInst  DecodeCSSInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSSInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CIW-type isntruction
-  RevInst  DecodeCIWInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIWInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CL-type isntruction
-  RevInst  DecodeCLInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCLInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CS-type isntruction
-  RevInst  DecodeCSInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CA-type isntruction
-  RevInst  DecodeCAInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCAInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CB-type isntruction
-  RevInst  DecodeCBInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCBInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CJ-type isntruction
-  RevInst  DecodeCJInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCJInst( uint16_t Inst, unsigned Entry ) const;
 
   /// RevCore: Determine next thread to execute
   unsigned GetNextHartToDecodeID() const;
 
   /// RevCore: Whether any scoreboard bits are set
-  bool     AnyDependency( unsigned    HartID,
-                          RevRegClass regClass = RevRegClass::RegUNKNOWN ) const {
+  bool AnyDependency( unsigned    HartID,
+                      RevRegClass regClass = RevRegClass::RegUNKNOWN ) const {
     const RevRegFile* regFile = GetRegFile( HartID );
     switch( regClass ) {
     case RevRegClass::RegGPR: return regFile->RV_Scoreboard.any();

--- a/include/RevExt.h
+++ b/include/RevExt.h
@@ -64,10 +64,10 @@ struct RevExt {
   }
 
   /// RevExt: baseline execution function
-  bool                               Execute( unsigned       Inst,
-                                              const RevInst& Payload,
-                                              uint16_t       HartID,
-                                              RevRegFile*    regFile );
+  bool Execute( unsigned       Inst,
+                const RevInst& Payload,
+                uint16_t       HartID,
+                RevRegFile*    regFile );
 
   /// RevExt: retrieves the extension's instruction table
   const std::vector< RevInstEntry >& GetInstTable() {
@@ -85,15 +85,15 @@ struct RevExt {
   }
 
 private:
-  std::string_view const      name;     ///< RevExt: extension name
-  RevFeature* const           feature;  ///< RevExt: feature object
-  RevMem* const               mem;      ///< RevExt: memory object
-  SST::Output* const          output;   ///< RevExt: output handler
+  std::string_view const name;     ///< RevExt: extension name
+  RevFeature* const      feature;  ///< RevExt: feature object
+  RevMem* const          mem;      ///< RevExt: memory object
+  SST::Output* const     output;   ///< RevExt: output handler
 
   std::vector< RevInstEntry > table;   ///< RevExt: instruction table
   std::vector< RevInstEntry > ctable;  ///< RevExt: compressed instruction table
   std::vector< RevInstEntry >
-       otable;  ///< RevExt: optional compressed instruction table
+    otable;  ///< RevExt: optional compressed instruction table
 
   auto SetFPEnv( unsigned       Inst,
                  const RevInst& Payload,

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -60,7 +60,7 @@ public:
   RevFeature& operator=( const RevFeature& ) = delete;
 
   /// IsModeEnabled: determines if the target mode is enabled
-  bool        IsModeEnabled( RevFeatureType Type ) const {
+  bool IsModeEnabled( RevFeatureType Type ) const {
     return ( features & Type ) == Type;
   }
 
@@ -140,7 +140,7 @@ private:
   unsigned       xlen;      ///< RevFeature: RISC-V Xlen
 
   /// ParseMachineModel: parse the machine model string
-  bool           ParseMachineModel();
+  bool ParseMachineModel();
 };  // class RevFeature
 
 }  // namespace SST::RevCPU

--- a/include/RevFenv.h
+++ b/include/RevFenv.h
@@ -30,7 +30,7 @@ namespace SST::RevCPU {
 // TODO: Right now we only need to save/restore rounding mode.
 // Later, we may need to save and restore the entire fenv_t state
 class RevFenv {
-  int         saved_round;  ///< Saved Floating-Point Rounding Mode
+  int saved_round;  ///< Saved Floating-Point Rounding Mode
 
   // We use Meyers singleton to avoid initialization order fiasco
   static int& round() {
@@ -55,12 +55,12 @@ public:
   // We allow moving, but not copying RevFenv
   // This is to ensure that there is only a single copy
   // of the saved state at a time, similar to std::unique_ptr
-  RevFenv( RevFenv&& )                   = default;
-  RevFenv( const RevFenv& )              = delete;
+  RevFenv( RevFenv&& )                 = default;
+  RevFenv( const RevFenv& )            = delete;
 
   // We disallow assigning
-  RevFenv&   operator=( const RevFenv& ) = delete;
-  RevFenv&   operator=( RevFenv&& )      = delete;
+  RevFenv& operator=( const RevFenv& ) = delete;
+  RevFenv& operator=( RevFenv&& )      = delete;
 
   // Get the current FP rounding state
   static int GetRound() {

--- a/include/RevHart.h
+++ b/include/RevHart.h
@@ -20,10 +20,10 @@ namespace SST::RevCPU {
 
 class RevHart {
   ///< RevHart: Id for the Hart (0,1,2,3,etc)
-  unsigned                                                              ID;
+  unsigned ID;
 
   ///< RevHart: State management object when a Hart is executing a system call
-  EcallState                                                            Ecall{};
+  EcallState Ecall{};
 
   ///< RevHart: Pointer to the Proc's LSQueue
   const std::shared_ptr< std::unordered_multimap< uint64_t, MemReq > >& LSQueue;
@@ -32,8 +32,8 @@ class RevHart {
   std::function< void( const MemReq& ) > MarkLoadCompleteFunc;
 
   ///< RevHart: Thread currently executing on this Hart
-  std::unique_ptr< RevThread >           Thread  = nullptr;
-  std::unique_ptr< RevRegFile >          RegFile = nullptr;
+  std::unique_ptr< RevThread >  Thread  = nullptr;
+  std::unique_ptr< RevRegFile > RegFile = nullptr;
 
   ///< RevHart: Make RevCore a friend of this
   friend class RevCore;

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -131,14 +131,14 @@ struct RevInstEntry {
   uint32_t    cost     = 1;      ///< RevInstEntry: instruction code in cycles
 
   // storage
-  uint8_t     opcode   = 0;  ///< RevInstEntry: opcode
-  uint8_t     funct2   = 0;  ///< RevInstentry: compressed funct2 value
-  uint8_t     funct3   = 0;  ///< RevInstEntry: funct3 value
-  uint8_t     funct4   = 0;  ///< RevInstentry: compressed funct4 value
-  uint8_t     funct6   = 0;  ///< RevInstentry: compressed funct6 value
+  uint8_t opcode       = 0;  ///< RevInstEntry: opcode
+  uint8_t funct2       = 0;  ///< RevInstentry: compressed funct2 value
+  uint8_t funct3       = 0;  ///< RevInstEntry: funct3 value
+  uint8_t funct4       = 0;  ///< RevInstentry: compressed funct4 value
+  uint8_t funct6       = 0;  ///< RevInstentry: compressed funct6 value
   uint8_t funct2or7 = 0;  ///< RevInstEntry: uncompressed funct2 or funct7 value
-  uint16_t    offset     = 0;  ///< RevInstEntry: compressed offset value
-  uint16_t    jumpTarget = 0;  ///< RevInstEntry: compressed jump target value
+  uint16_t offset   = 0;  ///< RevInstEntry: compressed offset value
+  uint16_t jumpTarget = 0;  ///< RevInstEntry: compressed jump target value
 
   // register encodings
   RevRegClass rdClass =
@@ -148,13 +148,13 @@ struct RevInstEntry {
   RevRegClass rs2Class =
     RevRegClass::RegGPR;  ///< RevInstEntry: Rs2 register class
   RevRegClass rs3Class =
-    RevRegClass::RegUNKNOWN;     ///< RevInstEntry: Rs3 register class
-  uint16_t   imm12      = 0;     ///< RevInstEntry: imm12 value
-  RevImmFunc imm        = FUnk;  ///< RevInstEntry: does the imm12 exist?
+    RevRegClass::RegUNKNOWN;   ///< RevInstEntry: Rs3 register class
+  uint16_t   imm12    = 0;     ///< RevInstEntry: imm12 value
+  RevImmFunc imm      = FUnk;  ///< RevInstEntry: does the imm12 exist?
 
   // formatting
-  RevInstF   format     = RVTypeR;  ///< RevInstEntry: instruction format
-  bool       compressed = false;    ///< RevInstEntry: compressed instruction
+  RevInstF format     = RVTypeR;  ///< RevInstEntry: instruction format
+  bool     compressed = false;    ///< RevInstEntry: compressed instruction
   uint8_t fpcvtOp = 0;  ///<RevInstEntry: Stores the rs2 field in R-instructions
   bool    raisefpe = false;  ///<RevInstEntry: Whether FP exceptions are raised
 

--- a/include/RevLoader.h
+++ b/include/RevLoader.h
@@ -290,12 +290,12 @@ public:
   uint64_t GetSymbolAddr( std::string Symbol );
 
   /// RevLoader: retrieves the value for 'argc'
-  auto     GetArgc() {
+  auto GetArgc() {
     return argv.size();
   }
 
   /// RevLoader: retrieves the target value within the argv array
-  std::string                GetArgv( unsigned entry );
+  std::string GetArgv( unsigned entry );
 
   /// RevLoader: retrieve the entire argv vector
   std::vector< std::string > GetArgv() {
@@ -311,7 +311,7 @@ public:
   std::map< uint64_t, std::string >* GetTraceSymbols();
 
   /// RevLoader: Gets TLS base address
-  const uint64_t&                    GetTLSBaseAddr() {
+  const uint64_t& GetTLSBaseAddr() {
     return TLSBaseAddr;
   }
 
@@ -328,13 +328,13 @@ private:
   RevMem*      mem;     ///< RevLoader: memory object
   SST::Output* output;  ///< RevLoader: output handler
 
-  uint32_t     RV32Entry;  ///< RevLoader: RV32 entry
-  uint64_t     RV64Entry;  ///< RevLoader: RV64 entry
+  uint32_t RV32Entry;  ///< RevLoader: RV32 entry
+  uint64_t RV64Entry;  ///< RevLoader: RV64 entry
 
-  uint64_t     TLSBaseAddr = 0;
-  uint64_t     TLSSize     = 0;
+  uint64_t TLSBaseAddr = 0;
+  uint64_t TLSSize     = 0;
 
-  ElfInfo      elfinfo;  ///< RevLoader: elf info from the loaded program
+  ElfInfo elfinfo;  ///< RevLoader: elf info from the loaded program
 
   std::map< std::string, uint64_t >
     symtable;  ///< RevLoader: loaded symbol table
@@ -344,31 +344,31 @@ private:
   std::vector< std::string > argv;  ///< RevLoader: The actual argv table
 
   /// Loads the target executable into memory
-  bool                       LoadElf();
+  bool LoadElf();
 
   /// Loads the target program arguments
-  bool                       LoadProgramArgs();
+  bool LoadProgramArgs();
 
   /// Determines if the target header is an Elf header
-  bool                       IsElf( const Elf64_Ehdr eh64 );
+  bool IsElf( const Elf64_Ehdr eh64 );
 
   /// Determines if the target header is an Elf32 header
-  bool                       IsRVElf32( const Elf64_Ehdr eh64 );
+  bool IsRVElf32( const Elf64_Ehdr eh64 );
 
   /// Determines if the target header is an Elf64 header
-  bool                       IsRVElf64( const Elf64_Ehdr eh64 );
+  bool IsRVElf64( const Elf64_Ehdr eh64 );
 
   /// Determines if the target header is little endian
-  bool                       IsRVLittle( const Elf64_Ehdr eh64 );
+  bool IsRVLittle( const Elf64_Ehdr eh64 );
 
   /// Determines if the target header is big endian
-  bool                       IsRVBig( const Elf64_Ehdr eh64 );
+  bool IsRVBig( const Elf64_Ehdr eh64 );
 
   /// Loads a 32bit Elf binary
-  bool                       LoadElf32( char* MemBuf, size_t Size );
+  bool LoadElf32( char* MemBuf, size_t Size );
 
   /// Loads a 64bit Elf binary
-  bool                       LoadElf64( char* MemBuf, size_t Size );
+  bool LoadElf64( char* MemBuf, size_t Size );
 
   ///< Splits a string into tokens
   void splitStr( const std::string& s, char c, std::vector< std::string >& v );

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -130,7 +130,7 @@ public:
   }
 
   /// RevMem: handle memory injection
-  void     HandleMemFault( unsigned width );
+  void HandleMemFault( unsigned width );
 
   /// RevMem: get the stack_top address
   uint64_t GetStackTop() {
@@ -146,7 +146,7 @@ public:
   RevTracer* Tracer = nullptr;
 
   /// RevMem: retrieve the address of the top of memory (not stack)
-  uint64_t   GetMemTop() {
+  uint64_t GetMemTop() {
     return ( _REVMEM_BASE_ + memSize );
   }
 
@@ -156,7 +156,7 @@ public:
   }
 
   /// RevMem: initiate a memory fence
-  bool     FenceMem( unsigned Hart );
+  bool FenceMem( unsigned Hart );
 
   /// RevMem: retrieves the cache line size.  Returns 0 if no cache is configured
   unsigned getLineSize() {
@@ -281,42 +281,42 @@ public:
   // ---- Atomic/Future/LRSC Interfaces
   // ----------------------------------------------------
   /// RevMem: Add a memory reservation for the target address
-  bool     LRBase( unsigned      Hart,
-                   uint64_t      Addr,
-                   size_t        Len,
-                   void*         Data,
-                   uint8_t       aq,
-                   uint8_t       rl,
-                   const MemReq& req,
-                   RevFlag       flags );
+  bool LRBase( unsigned      Hart,
+               uint64_t      Addr,
+               size_t        Len,
+               void*         Data,
+               uint8_t       aq,
+               uint8_t       rl,
+               const MemReq& req,
+               RevFlag       flags );
 
   /// RevMem: Clear a memory reservation for the target address
-  bool     SCBase( unsigned Hart,
-                   uint64_t Addr,
-                   size_t   Len,
-                   void*    Data,
-                   void*    Target,
-                   uint8_t  aq,
-                   uint8_t  rl,
-                   RevFlag  flags );
+  bool SCBase( unsigned Hart,
+               uint64_t Addr,
+               size_t   Len,
+               void*    Data,
+               void*    Target,
+               uint8_t  aq,
+               uint8_t  rl,
+               RevFlag  flags );
 
   /// RevMem: Initiated an AMO request
-  bool     AMOMem( unsigned      Hart,
-                   uint64_t      Addr,
-                   size_t        Len,
-                   void*         Data,
-                   void*         Target,
-                   const MemReq& req,
-                   RevFlag       flags );
+  bool AMOMem( unsigned      Hart,
+               uint64_t      Addr,
+               size_t        Len,
+               void*         Data,
+               void*         Target,
+               const MemReq& req,
+               RevFlag       flags );
 
   /// RevMem: Initiates a future operation [RV64P only]
-  bool     SetFuture( uint64_t Addr );
+  bool SetFuture( uint64_t Addr );
 
   /// RevMem: Revokes a future operation [RV64P only]
-  bool     RevokeFuture( uint64_t Addr );
+  bool RevokeFuture( uint64_t Addr );
 
   /// RevMem: Interrogates the target address and returns 'true' if a future reservation is present [RV64P only]
-  bool     StatusFuture( uint64_t Addr );
+  bool StatusFuture( uint64_t Addr );
 
   /// RevMem: Randomly assign a memory cost
   unsigned RandCost( unsigned Min, unsigned Max ) {
@@ -327,7 +327,7 @@ public:
   uint32_t GetNewThreadPID();
 
   /// RevMem: Used to set the size of the TLBSize
-  void     SetTLBSize( unsigned numEntries ) {
+  void SetTLBSize( unsigned numEntries ) {
     tlbSize = numEntries;
   }
 
@@ -362,7 +362,7 @@ public:
   }
 
   /// RevMem: Add new MemSegment (anywhere) --- Returns BaseAddr of segment
-  uint64_t                      AddMemSeg( const uint64_t& SegSize );
+  uint64_t AddMemSeg( const uint64_t& SegSize );
 
   /// RevMem: Add new thread mem (starting at TopAddr [growing down])
   std::shared_ptr< MemSegment > AddThreadMem();
@@ -385,9 +385,9 @@ public:
   uint64_t AllocMemAt( const uint64_t& BaseAddr, const uint64_t& Size );
 
   /// RevMem: Sets the HeapStart & HeapEnd to EndOfStaticData
-  void     InitHeap( const uint64_t& EndOfStaticData );
+  void InitHeap( const uint64_t& EndOfStaticData );
 
-  void     SetHeapStart( const uint64_t& HeapStart ) {
+  void SetHeapStart( const uint64_t& HeapStart ) {
     heapstart = HeapStart;
   }
 
@@ -399,9 +399,9 @@ public:
     return heapend;
   }
 
-  uint64_t        ExpandHeap( uint64_t Size );
+  uint64_t ExpandHeap( uint64_t Size );
 
-  void            SetTLSInfo( const uint64_t& BaseAddr, const uint64_t& Size );
+  void SetTLSInfo( const uint64_t& BaseAddr, const uint64_t& Size );
 
   // RevMem: Used to get the TLS BaseAddr & Size
   const uint64_t& GetTLSBaseAddr() {
@@ -449,8 +449,8 @@ protected:
   char* physMem = nullptr;  ///< RevMem: memory container
 
 private:
-  RevMemStats   memStats      = {};
-  RevMemStats   memStatsTotal = {};
+  RevMemStats memStats      = {};
+  RevMemStats memStatsTotal = {};
 
   unsigned long memSize;      ///< RevMem: size of the target memory
   unsigned      tlbSize;      ///< RevMem: number of entries in the TLB
@@ -503,9 +503,9 @@ private:
     nextPage;  ///< RevMem: next physical page to be allocated. Will result in index
   /// nextPage * pageSize into physMem
 
-  uint64_t                heapend;       ///< RevMem: top of the stack
-  uint64_t                heapstart;     ///< RevMem: top of the stack
-  uint64_t                stacktop = 0;  ///< RevMem: top of the stack
+  uint64_t heapend;       ///< RevMem: top of the stack
+  uint64_t heapstart;     ///< RevMem: top of the stack
+  uint64_t stacktop = 0;  ///< RevMem: top of the stack
 
   std::vector< uint64_t > FutureRes;  ///< RevMem: future operation reservations
 

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -285,131 +285,131 @@ public:
   virtual ~RevMemCtrl();
 
   /// RevMemCtrl: initialization function
-  virtual void     init( unsigned int phase )                      = 0;
+  virtual void init( unsigned int phase )                      = 0;
 
   /// RevMemCtrl: setup function
-  virtual void     setup()                                         = 0;
+  virtual void setup()                                         = 0;
 
   /// RevMemCtrl: finish function
-  virtual void     finish()                                        = 0;
+  virtual void finish()                                        = 0;
 
   /// RevMemCtrl: determines if outstanding requests exist
-  virtual bool     outstandingRqsts()                              = 0;
+  virtual bool outstandingRqsts()                              = 0;
 
   /// RevMemCtrl: send flush request
-  virtual bool     sendFLUSHRequest( unsigned Hart,
-                                     uint64_t Addr,
-                                     uint64_t PAddr,
-                                     uint32_t Size,
-                                     bool     Inv,
-                                     RevFlag  flags )               = 0;
+  virtual bool sendFLUSHRequest( unsigned Hart,
+                                 uint64_t Addr,
+                                 uint64_t PAddr,
+                                 uint32_t Size,
+                                 bool     Inv,
+                                 RevFlag  flags )               = 0;
 
   /// RevMemCtrl: send a read request
-  virtual bool     sendREADRequest( unsigned      Hart,
+  virtual bool sendREADRequest( unsigned      Hart,
+                                uint64_t      Addr,
+                                uint64_t      PAddr,
+                                uint32_t      Size,
+                                void*         target,
+                                const MemReq& req,
+                                RevFlag       flags )                = 0;
+
+  /// RevMemCtrl: send a write request
+  virtual bool sendWRITERequest( unsigned Hart,
+                                 uint64_t Addr,
+                                 uint64_t PAddr,
+                                 uint32_t Size,
+                                 char*    buffer,
+                                 RevFlag  flags )               = 0;
+
+  /// RevMemCtrl: send an AMO request
+  virtual bool sendAMORequest( unsigned      Hart,
+                               uint64_t      Addr,
+                               uint64_t      PAddr,
+                               uint32_t      Size,
+                               char*         buffer,
+                               void*         target,
+                               const MemReq& req,
+                               RevFlag       flags )                 = 0;
+
+  /// RevMemCtrl: send a readlock request
+  virtual bool sendREADLOCKRequest( unsigned      Hart,
                                     uint64_t      Addr,
                                     uint64_t      PAddr,
                                     uint32_t      Size,
                                     void*         target,
                                     const MemReq& req,
-                                    RevFlag       flags )                = 0;
+                                    RevFlag       flags )            = 0;
 
-  /// RevMemCtrl: send a write request
-  virtual bool     sendWRITERequest( unsigned Hart,
+  /// RevMemCtrl: send a writelock request
+  virtual bool sendWRITELOCKRequest( unsigned Hart,
                                      uint64_t Addr,
                                      uint64_t PAddr,
                                      uint32_t Size,
                                      char*    buffer,
-                                     RevFlag  flags )               = 0;
-
-  /// RevMemCtrl: send an AMO request
-  virtual bool     sendAMORequest( unsigned      Hart,
-                                   uint64_t      Addr,
-                                   uint64_t      PAddr,
-                                   uint32_t      Size,
-                                   char*         buffer,
-                                   void*         target,
-                                   const MemReq& req,
-                                   RevFlag       flags )                 = 0;
-
-  /// RevMemCtrl: send a readlock request
-  virtual bool     sendREADLOCKRequest( unsigned      Hart,
-                                        uint64_t      Addr,
-                                        uint64_t      PAddr,
-                                        uint32_t      Size,
-                                        void*         target,
-                                        const MemReq& req,
-                                        RevFlag       flags )            = 0;
-
-  /// RevMemCtrl: send a writelock request
-  virtual bool     sendWRITELOCKRequest( unsigned Hart,
-                                         uint64_t Addr,
-                                         uint64_t PAddr,
-                                         uint32_t Size,
-                                         char*    buffer,
-                                         RevFlag  flags )           = 0;
+                                     RevFlag  flags )           = 0;
 
   /// RevMemCtrl: send a loadlink request
-  virtual bool     sendLOADLINKRequest( unsigned Hart,
-                                        uint64_t Addr,
-                                        uint64_t PAddr,
-                                        uint32_t Size,
-                                        RevFlag  flags )            = 0;
+  virtual bool sendLOADLINKRequest( unsigned Hart,
+                                    uint64_t Addr,
+                                    uint64_t PAddr,
+                                    uint32_t Size,
+                                    RevFlag  flags )            = 0;
 
   /// RevMemCtrl: send a storecond request
-  virtual bool     sendSTORECONDRequest( unsigned Hart,
-                                         uint64_t Addr,
-                                         uint64_t PAddr,
-                                         uint32_t Size,
-                                         char*    buffer,
-                                         RevFlag  flags )           = 0;
+  virtual bool sendSTORECONDRequest( unsigned Hart,
+                                     uint64_t Addr,
+                                     uint64_t PAddr,
+                                     uint32_t Size,
+                                     char*    buffer,
+                                     RevFlag  flags )           = 0;
 
   /// RevMemCtrl: send an void custom read memory request
-  virtual bool     sendCUSTOMREADRequest( unsigned Hart,
-                                          uint64_t Addr,
-                                          uint64_t PAddr,
-                                          uint32_t Size,
-                                          void*    target,
-                                          unsigned Opc,
-                                          RevFlag  flags )          = 0;
+  virtual bool sendCUSTOMREADRequest( unsigned Hart,
+                                      uint64_t Addr,
+                                      uint64_t PAddr,
+                                      uint32_t Size,
+                                      void*    target,
+                                      unsigned Opc,
+                                      RevFlag  flags )          = 0;
 
   /// RevMemCtrl: send a custom write request
-  virtual bool     sendCUSTOMWRITERequest( unsigned Hart,
-                                           uint64_t Addr,
-                                           uint64_t PAddr,
-                                           uint32_t Size,
-                                           char*    buffer,
-                                           unsigned Opc,
-                                           RevFlag  flags )         = 0;
+  virtual bool sendCUSTOMWRITERequest( unsigned Hart,
+                                       uint64_t Addr,
+                                       uint64_t PAddr,
+                                       uint32_t Size,
+                                       char*    buffer,
+                                       unsigned Opc,
+                                       RevFlag  flags )         = 0;
 
   /// RevMemCtrl: send a FENCE request
-  virtual bool     sendFENCE( unsigned Hart )                      = 0;
+  virtual bool sendFENCE( unsigned Hart )                      = 0;
 
   /// RevMemCtrl: handle a read response
-  virtual void     handleReadResp( StandardMem::ReadResp* ev )     = 0;
+  virtual void handleReadResp( StandardMem::ReadResp* ev )     = 0;
 
   /// RevMemCtrl: handle a write response
-  virtual void     handleWriteResp( StandardMem::WriteResp* ev )   = 0;
+  virtual void handleWriteResp( StandardMem::WriteResp* ev )   = 0;
 
   /// RevMemCtrl: handle a flush response
-  virtual void     handleFlushResp( StandardMem::FlushResp* ev )   = 0;
+  virtual void handleFlushResp( StandardMem::FlushResp* ev )   = 0;
 
   /// RevMemCtrl: handle a custom response
-  virtual void     handleCustomResp( StandardMem::CustomResp* ev ) = 0;
+  virtual void handleCustomResp( StandardMem::CustomResp* ev ) = 0;
 
   /// RevMemCtrl: handle an invalidate response
-  virtual void     handleInvResp( StandardMem::InvNotify* ev )     = 0;
+  virtual void handleInvResp( StandardMem::InvNotify* ev )     = 0;
 
   /// RevMemCtrl: handle RevMemCtrl flags for write responses
-  virtual void     handleFlagResp( RevMemOp* op )                  = 0;
+  virtual void handleFlagResp( RevMemOp* op )                  = 0;
 
   /// RevMemCtrl: handle an AMO for the target READ+MODIFY+WRITE triplet
-  virtual void     handleAMO( RevMemOp* op )                       = 0;
+  virtual void handleAMO( RevMemOp* op )                       = 0;
 
   /// RevMemCtrl: returns the cache line size
-  virtual unsigned getLineSize()                                   = 0;
+  virtual unsigned getLineSize()                               = 0;
 
   /// Assign processor tracer
-  virtual void     setTracer( RevTracer* tracer )                  = 0;
+  virtual void setTracer( RevTracer* tracer )                  = 0;
 
 protected:
   SST::Output* output;            ///< RevMemCtrl: sst output object
@@ -552,15 +552,15 @@ public:
   virtual bool clockTick( Cycle_t cycle );
 
   /// RevBasicMemCtrl: determines if outstanding requests exist
-  bool         outstandingRqsts() override;
+  bool outstandingRqsts() override;
 
   /// RevBasicMemCtrl: returns the cache line size
-  unsigned     getLineSize() override {
+  unsigned getLineSize() override {
     return lineSize;
   }
 
   /// RevBasicMemCtrl: memory event processing handler
-  void         processMemEvent( StandardMem::Request* ev );
+  void processMemEvent( StandardMem::Request* ev );
 
   /// RevBasicMemCtrl: send a flush request
   virtual bool sendFLUSHRequest( unsigned Hart,
@@ -709,48 +709,48 @@ protected:
 
 private:
   /// RevBasicMemCtrl: process the next memory request
-  bool     processNextRqst( unsigned& t_max_loads,
-                            unsigned& t_max_stores,
-                            unsigned& t_max_flush,
-                            unsigned& t_max_llsc,
-                            unsigned& t_max_readlock,
-                            unsigned& t_max_writeunlock,
-                            unsigned& t_max_custom,
-                            unsigned& t_max_ops );
+  bool processNextRqst( unsigned& t_max_loads,
+                        unsigned& t_max_stores,
+                        unsigned& t_max_flush,
+                        unsigned& t_max_llsc,
+                        unsigned& t_max_readlock,
+                        unsigned& t_max_writeunlock,
+                        unsigned& t_max_custom,
+                        unsigned& t_max_ops );
 
   /// RevBasicMemCtrl: determine if we can instantiate the target memory operation
-  bool     isMemOpAvail( RevMemOp* Op,
-                         unsigned& t_max_loads,
-                         unsigned& t_max_stores,
-                         unsigned& t_max_flush,
-                         unsigned& t_max_llsc,
-                         unsigned& t_max_readlock,
-                         unsigned& t_max_writeunlock,
-                         unsigned& t_max_custom );
+  bool isMemOpAvail( RevMemOp* Op,
+                     unsigned& t_max_loads,
+                     unsigned& t_max_stores,
+                     unsigned& t_max_flush,
+                     unsigned& t_max_llsc,
+                     unsigned& t_max_readlock,
+                     unsigned& t_max_writeunlock,
+                     unsigned& t_max_custom );
 
   /// RevBasicMemCtrl: build a standard memory request
-  bool     buildStandardMemRqst( RevMemOp* op, bool& Success );
+  bool buildStandardMemRqst( RevMemOp* op, bool& Success );
 
   /// RevBasicMemCtrl: build raw memory requests with a 1-to-1 mapping to RevMemOps'
-  bool     buildRawMemRqst( RevMemOp* op, RevFlag TmpFlags );
+  bool buildRawMemRqst( RevMemOp* op, RevFlag TmpFlags );
 
   /// RevBasicMemCtrl: build cache-aligned requests
-  bool     buildCacheMemRqst( RevMemOp* op, bool& Success );
+  bool buildCacheMemRqst( RevMemOp* op, bool& Success );
 
   /// RevBasicMemCtrl: determine if there are any pending AMOs that would prevent a request from dispatching
-  bool     isPendingAMO( unsigned Slot );
+  bool isPendingAMO( unsigned Slot );
 
   /// RevBasicMemCtrl: determine if we need to utilize AQ ordering semantics
-  bool     isAQ( unsigned Slot, unsigned Hart );
+  bool isAQ( unsigned Slot, unsigned Hart );
 
   /// RevBasicMemCtrl: determine if we need to utilize RL ordering semantics
-  bool     isRL( unsigned Slot, unsigned Hart );
+  bool isRL( unsigned Slot, unsigned Hart );
 
   /// RevBasicMemCtrl: register statistics
-  void     registerStats();
+  void registerStats();
 
   /// RevBasicMemCtrl: inject statistics data for the target metric
-  void     recordStat( MemCtrlStats Stat, uint64_t Data );
+  void recordStat( MemCtrlStats Stat, uint64_t Data );
 
   /// RevBasicMemCtrl: returns the total number of outstanding requests
   uint64_t getTotalRqsts();
@@ -765,8 +765,8 @@ private:
   unsigned getNumSplitRqsts( RevMemOp* op );
 
   /// RevBasicMemCtrl: perform the MODIFY portion of the AMO (READ+MODIFY+WRITE)
-  void     performAMO(
-        std::tuple< unsigned, char*, void*, RevFlag, RevMemOp*, bool > Entry );
+  void performAMO(
+    std::tuple< unsigned, char*, void*, RevFlag, RevMemOp*, bool > Entry );
 
   // -- private data members
   StandardMem* memIface;  ///< StandardMem memory interface

--- a/include/RevNIC.h
+++ b/include/RevNIC.h
@@ -103,7 +103,7 @@ public:
   virtual void send( nicEvent* ev, int dest )                = 0;
 
   /// nicEvent: retrieve the number of potential destinations
-  virtual int  getNumDestinations()                          = 0;
+  virtual int getNumDestinations()                           = 0;
 
   /// nicEvent: returns the NIC's network address
   virtual SST::Interfaces::SimpleNetwork::nid_t getAddress() = 0;
@@ -159,27 +159,27 @@ public:
   virtual void send( nicEvent* ev, int dest );
 
   /// RevNIC: retrieve the number of destinations
-  virtual int  getNumDestinations();
+  virtual int getNumDestinations();
 
   /// RevNIC: get the endpoint's network address
   virtual SST::Interfaces::SimpleNetwork::nid_t getAddress();
 
   /// RevNIC: callback function for the SimpleNetwork interface
-  bool                                          msgNotify( int virtualNetwork );
+  bool msgNotify( int virtualNetwork );
 
   /// RevNIC: clock function
-  virtual bool                                  clockTick( Cycle_t cycle );
+  virtual bool clockTick( Cycle_t cycle );
 
 protected:
-  SST::Output*                    output;  ///< RevNIC: SST output object
+  SST::Output* output;  ///< RevNIC: SST output object
 
   SST::Interfaces::SimpleNetwork* iFace;  ///< RevNIC: SST network interface
 
-  SST::Event::HandlerBase*        msgHandler;  ///< RevNIC: SST message handler
+  SST::Event::HandlerBase* msgHandler;  ///< RevNIC: SST message handler
 
   bool initBroadcastSent;  ///< RevNIC: has the init bcast been sent?
 
-  int  numDest;  ///< RevNIC: number of SST destinations
+  int numDest;  ///< RevNIC: number of SST destinations
 
   std::queue< SST::Interfaces::SimpleNetwork::Request* >
     sendQ;  ///< RevNIC: buffered send queue

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -63,10 +63,10 @@ private:
   std::vector< MemReq >                  OutstandingFetchQ;
 
   /// fills a missed stream cache instruction
-  void                                   Fill( uint64_t Addr );
+  void Fill( uint64_t Addr );
 
   /// deletes the target stream buffer
-  void                                   DeleteStream( size_t i );
+  void DeleteStream( size_t i );
 
   /// attempts to fetch the upper half of a 32bit word of an unaligned base address
   bool FetchUpper( uint64_t Addr, bool& Fetched, uint32_t& UInst );

--- a/include/RevRand.h
+++ b/include/RevRand.h
@@ -28,7 +28,7 @@ class RevRNG {
 
   // Hardware random seed is different from run to run but fixed during run
   // so that distribution of HWSeed ^ ThreadSeed is uniform
-  static uint32_t       HWSeed() {
+  static uint32_t HWSeed() {
     static const uint32_t RevHWRNG = std::random_device{}();
     return RevHWRNG;
   }

--- a/include/RevSysCalls.h
+++ b/include/RevSysCalls.h
@@ -37,7 +37,7 @@ struct EcallState {
   std::string            path_string;
   size_t                 bytesRead = 0;
 
-  void                   clear() {
+  void clear() {
     string.clear();
     path_string.clear();
     bytesRead = 0;

--- a/include/RevThread.h
+++ b/include/RevThread.h
@@ -139,7 +139,7 @@ public:
   friend std::ostream& operator<<( std::ostream& os, const RevThread& Thread );
 
   ///< RevThread: Overload the to_string method
-  std::string          to_string() const {
+  std::string to_string() const {
     std::ostringstream oss;
     oss << *this;      // << operator is overloaded above
     return oss.str();  // Return the string
@@ -159,7 +159,7 @@ private:
   std::unordered_set< int > fildes = { 0, 1, 2 };  // Default file descriptors
 
   ///< RevThread: ID of the thread this thread is waiting to join
-  uint32_t                  WaitingToJoinTID = _INVALID_TID_;
+  uint32_t WaitingToJoinTID        = _INVALID_TID_;
 
 };  // class RevThread
 

--- a/include/RevTracer.h
+++ b/include/RevTracer.h
@@ -139,9 +139,9 @@ enum TraceKeyword_t {
 struct TraceRec_t {
   TraceKeyword_t key;
   // register        memory                  memh
-  uint64_t       a;  // reg             adr                     adr
-  uint64_t       b;  // value           len                     len
-  uint64_t       c;  // origin(TODO)    data (limited 8 bytes)  reg
+  uint64_t a;  // reg             adr                     adr
+  uint64_t b;  // value           len                     len
+  uint64_t c;  // origin(TODO)    data (limited 8 bytes)  reg
   TraceRec_t( TraceKeyword_t Key, uint64_t A, uint64_t B, uint64_t C = 0 ) :
     key( Key ), a( A ), b( B ), c( C ){};
 };
@@ -155,11 +155,11 @@ struct InstHeader_t {
   std::string& fallbackMnemonic = defaultMnem;
   bool         valid            = false;
 
-  void         set( size_t             _cycle,
-                    unsigned           _id,
-                    unsigned           _hart,
-                    unsigned           _tid,
-                    const std::string& _fallback ) {
+  void set( size_t             _cycle,
+            unsigned           _id,
+            unsigned           _hart,
+            unsigned           _tid,
+            const std::string& _fallback ) {
     cycle            = _cycle;
     id               = _id;
     hart             = _hart;
@@ -206,7 +206,7 @@ public:
   ~RevTracer();
 
   /// RevTracer: assign disassembler. Returns 0 if successful
-  int  SetDisassembler( std::string machine );
+  int SetDisassembler( std::string machine );
   /// RevTracer: assign trace symbol lookup map
   void SetTraceSymbols( std::map< uint64_t, std::string >* TraceSymbols );
   /// RevTracer: assign cycle where trace will start (user param)
@@ -252,62 +252,62 @@ public:
 
 private:
   /// RevTracer: clear instruction trace capture buffer and reset trace state
-  void        InstTraceReset();
+  void InstTraceReset();
 
   /// RevTracer: instance name
   std::string name;
 #ifdef REV_USE_SPIKE
   /// RevTracer: instruction parser used by disassembler
-  isa_parser_t*   isaParser;
+  isa_parser_t* isaParser;
   /// RevTracer: disassembler
   disassembler_t* diasm;
 #endif
   /// RevTracer: pointer to output stream
-  SST::Output*                       pOutput;
+  SST::Output* pOutput;
   /// RevTracer: control whether output is printed or not ( sampling continues )
-  bool                               outputEnabled = false;
+  bool outputEnabled = false;
   /// RevTracer: Instruction header captured at execution phase.
-  InstHeader_t                       instHeader;
+  InstHeader_t instHeader;
   /// RevTracer: Special affecting trace output
-  TraceEvents_t                      events;
+  TraceEvents_t events;
   /// RevTracer: buffer for captured states
-  std::vector< TraceRec_t >          traceRecs;
+  std::vector< TraceRec_t > traceRecs;
   /// RevTracer: Completion records
-  std::vector< CompletionRec_t >     completionRecs;
+  std::vector< CompletionRec_t > completionRecs;
   /// RevTracer: saved program counter
-  uint64_t                           pc           = 0;
+  uint64_t pc                                     = 0;
   /// RevTracer: previous program counter for branch determination
-  uint64_t                           lastPC       = 0;
+  uint64_t lastPC                                 = 0;
   /// RevTracer: saved instruction
-  uint32_t                           insn         = 0;
+  uint32_t insn                                   = 0;
   /// RevTracer: map of instruction addresses to symbols
   std::map< uint64_t, std::string >* traceSymbols = nullptr;
   /// RevTracer: Array of supported "NOP" instructions avaible for trace controls
-  uint32_t                           nops[NOP_COUNT];
+  uint32_t nops[NOP_COUNT];
   /// RevTracer: Check current state against user settings and update state
-  void                               CheckUserControls( uint64_t cycle );
+  void CheckUserControls( uint64_t cycle );
   /// RevTracer: determine if this buffer should be rendered
-  bool                               OutputOK();
+  bool OutputOK();
   /// RevTracer: format register address for rendering
-  std::string                        fmt_reg( uint8_t r );
+  std::string fmt_reg( uint8_t r );
   /// RevTracer: Format data associated with memory access
-  std::string                        fmt_data( unsigned len, uint64_t data );
+  std::string fmt_data( unsigned len, uint64_t data );
   /// RevTracer: Generate string from captured state
-  std::string         RenderExec( const std::string& fallbackMnemonic );
+  std::string RenderExec( const std::string& fallbackMnemonic );
   /// RevTracer: User setting: starting cycle of trace (overrides programmtic control)
-  uint64_t            startCycle = 0;
+  uint64_t startCycle = 0;
   /// RevTracer: User setting: maximum number of lines to print
-  uint64_t            cycleLimit = 0;
+  uint64_t cycleLimit = 0;
   /// RevTracer: support for trace control push/pop
   std::vector< bool > enableQ;
   /// RevTracer: current pointer into trace controls queue
-  unsigned            enableQindex;
+  unsigned enableQindex;
   /// RevTracer: wraparound limit for trace controls queue
-  const unsigned      MAX_ENABLE_Q = 100;
+  const unsigned MAX_ENABLE_Q = 100;
   /// RevTracer: count of lines rendered
-  uint64_t            traceCycles  = 0;
+  uint64_t traceCycles        = 0;
   /// RevTracer: Hard disable for output
-  bool                disabled     = 0;
+  bool disabled               = 0;
 
 };  // class RevTracer
 

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -260,8 +260,8 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) :
   uint64_t    StartAddr = 0x00ull;
   std::string StartSymbol;
 
-  bool        IsStartSymbolProvided = Opts->GetStartSymbol( id, StartSymbol );
-  bool        IsStartAddrProvided =
+  bool IsStartSymbolProvided = Opts->GetStartSymbol( id, StartSymbol );
+  bool IsStartAddrProvided =
     Opts->GetStartAddr( id, StartAddr ) && StartAddr != 0x00ull;
   uint64_t ResolvedStartSymbolAddr =
     ( IsStartSymbolProvided ) ? Loader->GetSymbolAddr( StartSymbol ) : 0x00ull;
@@ -772,7 +772,7 @@ void RevCPU::AssignThread( std::unique_ptr< RevThread >&& ThreadToAssign,
 // Checks if a thread with a given Thread ID can proceed (used for pthread_join).
 // it does this by seeing if a given thread's WaitingOnTID has completed
 bool RevCPU::ThreadCanProceed( const std::unique_ptr< RevThread >& Thread ) {
-  bool     rtn          = false;
+  bool rtn              = false;
 
   // Get the thread's waiting to join TID
   uint32_t WaitingOnTID = Thread->GetWaitingToJoinTID();

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -889,14 +889,14 @@ RevInst RevCore::DecodeCJInst( uint16_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
-  CompInst.cost            = InstTable[Entry].cost;
+  CompInst.cost   = InstTable[Entry].cost;
 
   // encodings
-  CompInst.opcode          = InstTable[Entry].opcode;
-  CompInst.funct3          = InstTable[Entry].funct3;
+  CompInst.opcode = InstTable[Entry].opcode;
+  CompInst.funct3 = InstTable[Entry].funct3;
 
   // registers
-  uint16_t          offset = ( ( Inst & 0b1111111111100 ) >> 2 );
+  uint16_t offset = ( ( Inst & 0b1111111111100 ) >> 2 );
 
   //swizzle bits offset[11|4|9:8|10|6|7|3:1|5]
   std::bitset< 16 > offsetBits( offset ), target;
@@ -1608,7 +1608,7 @@ void RevCore::HandleRegFault( unsigned width ) {
   RevRegFile* regFile = GetRegFile( HartToExecID );
 
   // select a register
-  unsigned    RegIdx  = RevRand( 0, _REV_NUM_REGS_ - 1 );
+  unsigned RegIdx     = RevRand( 0, _REV_NUM_REGS_ - 1 );
 
   if( !feature->HasF() || RevRand( 0, 1 ) ) {
     // X registers
@@ -2060,11 +2060,11 @@ std::unique_ptr< RevThread > RevCore::PopThreadFromHart( unsigned HartID ) {
 }
 
 void RevCore::PrintStatSummary() {
-  auto   memStatsTotal = mem->GetMemStatsTotal();
+  auto memStatsTotal = mem->GetMemStatsTotal();
 
-  double eff           = StatsTotal.totalCycles ?
-                           double( StatsTotal.cyclesBusy ) / StatsTotal.totalCycles :
-                           0;
+  double eff         = StatsTotal.totalCycles ?
+                         double( StatsTotal.cyclesBusy ) / StatsTotal.totalCycles :
+                         0;
   output->verbose( CALL_INFO,
                    2,
                    0,

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -603,7 +603,7 @@ bool RevLoader::LoadElf() {
   size_t FileSize = FileStats.st_size;
 
   // map the executable into memory
-  char*  membuf =
+  char* membuf =
     (char*) ( mmap( NULL, FileSize, PROT_READ, MAP_PRIVATE, fd, 0 ) );
   if( membuf == MAP_FAILED )
     output->fatal( CALL_INFO,

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -72,7 +72,7 @@ bool RevMem::outstandingRqsts() {
 
 void RevMem::HandleMemFault( unsigned width ) {
   // build up the fault payload
-  uint64_t  rval   = RevRand( 0, ( uint32_t{ 1 } << width ) - 1 );
+  uint64_t rval    = RevRand( 0, ( uint32_t{ 1 } << width ) - 1 );
 
   // find an address to fault
   unsigned  NBytes = RevRand( 0, memSize - 8 );
@@ -154,8 +154,8 @@ bool RevMem::LRBase( unsigned      Hart,
   // uint32_t adjPageNum = 0;
   // uint64_t adjPhysAddr = 0;
   // uint64_t endOfPage = (pageMap[pageNum].first << addrShift) + pageSize;
-  char*    BaseMem  = &physMem[physAddr];
-  char*    DataMem  = (char*) ( Target );
+  char* BaseMem     = &physMem[physAddr];
+  char* DataMem     = (char*) ( Target );
 
   if( ctrl ) {
     ctrl->sendREADLOCKRequest(
@@ -467,7 +467,7 @@ uint64_t RevMem::AllocMem( const uint64_t& SegSize ) {
   uint64_t NewSegBaseAddr = 0;
   // Check if there is a free segment that can fit the new data
   for( size_t i = 0; i < FreeMemSegs.size(); i++ ) {
-    auto     FreeSeg        = FreeMemSegs[i];
+    auto FreeSeg            = FreeMemSegs[i];
     // if the FreeSeg is bigger than the new data, we can shrink it so it starts
     // after the new segment (SegSize)
     uint64_t oldFreeSegSize = FreeSeg->getSize();

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -1379,7 +1379,7 @@ void RevBasicMemCtrl::performAMO(
   if( Tmp == nullptr ) {
     output->fatal( CALL_INFO, -1, "Error : AMOTable entry is null\n" );
   }
-  void*                  Target = Tmp->getTarget();
+  void* Target                  = Tmp->getTarget();
 
   RevFlag                flags  = Tmp->getFlags();
   std::vector< uint8_t > buffer = Tmp->getBuf();

--- a/src/RevNIC.cc
+++ b/src/RevNIC.cc
@@ -65,8 +65,8 @@ void RevNIC::init( unsigned int phase ) {
 
   if( iFace->isNetworkInitialized() ) {
     if( !initBroadcastSent ) {
-      initBroadcastSent                           = true;
-      nicEvent*                                ev = new nicEvent( getName() );
+      initBroadcastSent = true;
+      nicEvent* ev      = new nicEvent( getName() );
 
       SST::Interfaces::SimpleNetwork::Request* req =
         new SST::Interfaces::SimpleNetwork::Request();

--- a/src/RevRegFile.cc
+++ b/src/RevRegFile.cc
@@ -53,10 +53,10 @@ std::ostream& operator<<( std::ostream& os, const RevRegFile& regFile ) {
 
   // Loop over the registers
   for( size_t i = 0; i < _REV_NUM_REGS_; ++i ) {
-    uint64_t value    = regFile.GetX< uint64_t >( i );
+    uint64_t value = regFile.GetX< uint64_t >( i );
 
     // if scoreboard is not 0, there is a dependency
-    char     depValue = regFile.RV_Scoreboard[i] ? 'T' : 'F';
+    char depValue  = regFile.RV_Scoreboard[i] ? 'T' : 'F';
     os << "| " << std::setw( 4 ) << ( "x" + std::to_string( i ) );
     os << " | " << std::setw( 5 ) << aliases[i];
     std::ostringstream hs;

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -522,12 +522,12 @@ EcallStatus RevCore::ECALL_mknodat() {
 // TODO: 34, rev_mkdirat(int dfd, const char  * pathname, umode_t mode)
 EcallStatus RevCore::ECALL_mkdirat() {
   output->verbose( CALL_INFO, 2, 0, "ECALL: mkdirat called" );
-  EcallState& ECALL  = Harts.at( HartToExecID )->GetEcallState();
-  auto        dirfd  = RegFile->GetX< int >( RevReg::a0 );
-  auto        path   = RegFile->GetX< uint64_t >( RevReg::a1 );
-  auto        mode   = RegFile->GetX< unsigned short >( RevReg::a2 );
+  EcallState& ECALL = Harts.at( HartToExecID )->GetEcallState();
+  auto        dirfd = RegFile->GetX< int >( RevReg::a0 );
+  auto        path  = RegFile->GetX< uint64_t >( RevReg::a1 );
+  auto        mode  = RegFile->GetX< unsigned short >( RevReg::a2 );
 
-  auto        action = [&] {
+  auto action       = [&] {
     // Do the mkdirat on the host
     int rc = mkdirat( dirfd, ECALL.string.c_str(), mode );
     RegFile->SetX( RevReg::a0, rc );
@@ -937,9 +937,9 @@ EcallStatus RevCore::ECALL_read() {
                    "\n",
                    ActiveThreadID,
                    HartToExecID );
-  auto  fd           = RegFile->GetX< int >( RevReg::a0 );
-  auto  BufAddr      = RegFile->GetX< uint64_t >( RevReg::a1 );
-  auto  BufSize      = RegFile->GetX< uint64_t >( RevReg::a2 );
+  auto fd            = RegFile->GetX< int >( RevReg::a0 );
+  auto BufAddr       = RegFile->GetX< uint64_t >( RevReg::a1 );
+  auto BufSize       = RegFile->GetX< uint64_t >( RevReg::a2 );
 
   // Check if Current Ctx has access to the fd
   auto& ActiveThread = Harts.at( HartToExecID )->Thread;
@@ -962,7 +962,7 @@ EcallStatus RevCore::ECALL_read() {
   std::vector< char > TmpBuf( BufSize );
 
   // Do the read on the host
-  int                 rc = read( fd, &TmpBuf[0], BufSize );
+  int rc = read( fd, &TmpBuf[0], BufSize );
 
   // Write that data to the buffer inside of Rev
   mem->WriteMem( HartToExecID, BufAddr, BufSize, &TmpBuf[0] );
@@ -2865,7 +2865,7 @@ EcallStatus RevCore::ECALL_readahead() {
 
 // 214, rev_brk(unsigned long brk)
 EcallStatus RevCore::ECALL_brk() {
-  auto           Addr    = RegFile->GetX< uint64_t >( RevReg::a0 );
+  auto Addr              = RegFile->GetX< uint64_t >( RevReg::a0 );
 
   const uint64_t heapend = mem->GetHeapEnd();
   if( Addr > 0 && Addr > heapend ) {
@@ -2887,7 +2887,7 @@ EcallStatus RevCore::ECALL_munmap() {
   auto Addr = RegFile->GetX< uint64_t >( RevReg::a0 );
   auto Size = RegFile->GetX< uint64_t >( RevReg::a1 );
 
-  int  rc   = mem->DeallocMem( Addr, Size ) == uint64_t( -1 );
+  int rc    = mem->DeallocMem( Addr, Size ) == uint64_t( -1 );
   if( rc == -1 ) {
     output->fatal( CALL_INFO,
                    11,
@@ -4340,7 +4340,7 @@ EcallStatus RevCore::ECALL_pthread_create() {
                    " on hart %" PRIu32 "\n",
                    ActiveThreadID,
                    HartToExecID );
-  uint64_t          tidAddr     = RegFile->GetX< uint64_t >( RevReg::a0 );
+  uint64_t tidAddr              = RegFile->GetX< uint64_t >( RevReg::a0 );
   //uint64_t AttrPtr     = RegFile->GetX<uint64_t>(RevReg::a1);
   uint64_t          NewThreadPC = RegFile->GetX< uint64_t >( RevReg::a2 );
   uint64_t          ArgPtr      = RegFile->GetX< uint64_t >( RevReg::a3 );

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -312,7 +312,7 @@ std::string RevTracer::RenderExec( const std::string& fallbackMnemonic ) {
   // Until this is resolved, the trace supresses the extra register write when
   // we encounter a memhSendRead event.
   // TODO remove this if/when extra register write is removed.
-  bool              squashNextSetX = false;
+  bool squashNextSetX = false;
 
   std::stringstream ss_rw;
   for( TraceRec_t r : traceRecs ) {

--- a/test/amo/amoadd_c/amoadd_c.c
+++ b/test/amo/amoadd_c/amoadd_c.c
@@ -4,7 +4,7 @@
 uint64_t atom64 = 0;
 uint32_t atom32 = 0;
 
-int      main() {
+int main() {
   __atomic_fetch_add( &atom64, 2, __ATOMIC_RELAXED );
   __atomic_fetch_add( &atom64, 2, __ATOMIC_CONSUME );
   __atomic_fetch_add( &atom64, 2, __ATOMIC_ACQUIRE );

--- a/test/amo/amoswap_c/amoswap_c.c
+++ b/test/amo/amoswap_c/amoswap_c.c
@@ -17,7 +17,7 @@ uint32_t swap_dest32 = 0xfee1dead;
 uint32_t swap_src32  = ( ( (uint32_t) 0xdeadbeef ) << 16 );
 uint32_t swap_prev32 = 0;
 
-void     test_single_thread32() {
+void test_single_thread32() {
   // swap_prev should become swap_dest
   // swap_dest should become swap_src
   __atomic_exchange(

--- a/test/argc_bug/argc_bug.c
+++ b/test/argc_bug/argc_bug.c
@@ -18,7 +18,7 @@
 
 unsigned slow_accumulate( unsigned count, unsigned initial_value );
 
-int      main( int argc, char** argv ) {
+int main( int argc, char** argv ) {
 
   assert( argc == 5 );
   assert( argv[1][0] == '6' );

--- a/test/benchmarks/common/syscalls.c
+++ b/test/benchmarks/common/syscalls.c
@@ -37,7 +37,7 @@ static uintptr_t
 static uintptr_t counters[NUM_COUNTERS];
 static char*     counter_names[NUM_COUNTERS];
 
-void             setStats( int enable ) {
+void setStats( int enable ) {
   int i = 0;
 #define READ_CTR( name )              \
   do {                                \
@@ -107,7 +107,7 @@ void _init( int cid, int nc ) {
   thread_entry( cid, nc );
 
   // only single-threaded programs should ever get here.
-  int   ret = main( 0, 0 );
+  int ret = main( 0, 0 );
 
   char  buf[NUM_COUNTERS * 32] __attribute__( ( aligned( 64 ) ) );
   char* pbuf = buf;

--- a/test/benchmarks/qsort/qsort.c
+++ b/test/benchmarks/qsort/qsort.c
@@ -101,7 +101,7 @@ void sort( size_t n, type arr[] ) {
       type* j = ir;
 
       // Partitioning element.
-      type  a = l[0];
+      type a  = l[0];
 
       for( ;; ) {  // Beginning of innermost loop.
         while( *i++ < a )

--- a/test/benchmarks/towers/towers.c
+++ b/test/benchmarks/towers/towers.c
@@ -37,7 +37,7 @@ struct List {
 struct List g_nodeFreeList;
 struct Node g_nodePool[NUM_DISCS];
 
-int         list_getSize( struct List* list ) {
+int list_getSize( struct List* list ) {
   return list->size;
 }
 

--- a/test/big_loop/big_loop.c
+++ b/test/big_loop/big_loop.c
@@ -18,7 +18,7 @@ uint64_t A[1024];
 uint64_t B[1024];
 uint64_t R[1024];
 
-int      main( int argc, char** argv ) {
+int main( int argc, char** argv ) {
   uint64_t i = 0;
   uint64_t j = 0;
   int      r = 0;

--- a/test/cxx/stl/map/map.cc
+++ b/test/cxx/stl/map/map.cc
@@ -12,7 +12,7 @@
   }
 
 typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
-    revString;
+  revString;
 
 int main() {
 

--- a/test/cxx/stl/vector_obj/vector_obj.cc
+++ b/test/cxx/stl/vector_obj/vector_obj.cc
@@ -49,7 +49,7 @@ int main() {
 
   std::vector< TestObj, Allocator< TestObj > > v;
 
-  TestObj                                      c;
+  TestObj c;
   v.push_back( c );
   v[0].SetM1( 0xbeef );
   assert( v[0].GetM1() == 0xbeef )

--- a/test/dot_double/dot_double.c
+++ b/test/dot_double/dot_double.c
@@ -17,7 +17,7 @@
 double x[1024];
 double y[1024];
 
-int    main( int argc, char** argv ) {
+int main( int argc, char** argv ) {
   float result;
   int   inc_x = 1;
   int   inc_y = 1;

--- a/test/dot_single/dot_single.c
+++ b/test/dot_single/dot_single.c
@@ -17,7 +17,7 @@
 float x[1024];
 float y[1024];
 
-int   main( int argc, char** argv ) {
+int main( int argc, char** argv ) {
   float result;
   int   inc_x = 1;
   int   inc_y = 1;

--- a/test/fault/fault1.c
+++ b/test/fault/fault1.c
@@ -20,7 +20,7 @@ uint64_t VECT_A[WIDTH];
 uint64_t VECT_B[WIDTH];
 uint64_t RESULT[WIDTH];
 
-int      run_this() {
+int run_this() {
   uint64_t i = 0x00ull;
   uint64_t r = 0x00ull;
 

--- a/test/large_bss/large_bss.c
+++ b/test/large_bss/large_bss.c
@@ -15,6 +15,6 @@
 
 char t[1024 * 1024 * 12];
 
-int  main() {
+int main() {
   return 0;
 }

--- a/test/memset/memset.c
+++ b/test/memset/memset.c
@@ -9,7 +9,7 @@
 #define N ( 1024 )
 char mem[N];
 
-int  main() {
+int main() {
   memset( mem, 42, N );
   for( int i = 0; i < N; i++ ) {
     assert( mem[i] == 42 );

--- a/test/memset_2/memset_2.c
+++ b/test/memset_2/memset_2.c
@@ -42,7 +42,7 @@ hammer( u16 )
 
 /* Memory to test */
 #define SIZE 1000
-u8  mem[SIZE];
+u8 mem[SIZE];
 
 int main() {
   assert( !test_3( mem, SIZE ) );

--- a/test/minfft/ex1.c
+++ b/test/minfft/ex1.c
@@ -45,7 +45,7 @@ static const minfft_real pi_l = 3.141592653589793238462643383279502884L;
 static minfft_real       nsin_l( int, int );
 
 // cos(2*pi*n/N)
-static minfft_real       ncos_l( int n, int N ) {
+static minfft_real ncos_l( int n, int N ) {
   // reduce n to 0..N/8
   if( n < 0 )
     return ncos_l( -n, N );
@@ -87,11 +87,11 @@ static minfft_real nsin_l( int n, int N ) {
 }
 
 int main() {
-  minfft_cmpl  x[P], y[P];   // input and output buffers
-  minfft_cmpl  t[P], e2[P];  // input and output buffers
-                             //minfft_aux *a; // aux data
-                             // prepare aux data
-                             //a=minfft_mkaux_dft_1d(P);
+  minfft_cmpl x[P], y[P];   // input and output buffers
+  minfft_cmpl t[P], e2[P];  // input and output buffers
+                            //minfft_aux *a; // aux data
+                            // prepare aux data
+                            //a=minfft_mkaux_dft_1d(P);
   minfft_aux   a;
   minfft_real* e;
   a.N      = P;

--- a/test/minfft/minfft.c
+++ b/test/minfft/minfft.c
@@ -240,7 +240,7 @@ inline static void rs_dft_1d( int                N,
               *er = (minfft_real*) e;
   minfft_real *xi = xr + 1, *ti = tr + 1, *ei = er + 1;
   // prepare sub-transform inputs
-  int          loopCount = N / 4;
+  int loopCount = N / 4;
   for( n = 0; n < loopCount; n++ ) {
     // *rev = n + N;
     register minfft_real t0r, t1r, t2r, t3r;

--- a/test/pan_mbox_test1/pan_test.c
+++ b/test/pan_mbox_test1/pan_test.c
@@ -27,11 +27,11 @@ Command    revoke_cmd;
 Command    complete_cmd;
 MBoxEntry* Mailbox = (MBoxEntry*) ( _PAN_RDMA_MAILBOX_ );
 
-uint32_t   Token   = 0xfeedbeef;
-uint32_t   Tag     = 0x1;
-uint64_t   Input   = 0x1;
+uint32_t Token     = 0xfeedbeef;
+uint32_t Tag       = 0x1;
+uint64_t Input     = 0x1;
 
-void       cmd_wait() {
+void cmd_wait() {
   // this function blocks until the command is cleared from the mailbox
   volatile uint64_t value = Mailbox[0].Valid;
   while( value != _PAN_ENTRY_INJECTED_ ) {

--- a/test/syscalls/clock_gettime/clock_gettime.c
+++ b/test/syscalls/clock_gettime/clock_gettime.c
@@ -10,7 +10,7 @@ int main( int argc, char* argv[] ) {
   int                      sum = 0;
   struct __kernel_timespec s, e;
 
-  int                      ret = rev_clock_gettime( 0, &s );
+  int ret = rev_clock_gettime( 0, &s );
   assert( ret == 0 );
 
   /*

--- a/test/syscalls/file_io/file_io.c
+++ b/test/syscalls/file_io/file_io.c
@@ -13,19 +13,19 @@
   while( 0 )
 
 int main() {
-  char       buffer[BUF_SIZE];
+  char buffer[BUF_SIZE];
 
-  const char path[12]  = "test.txt";
+  const char path[12] = "test.txt";
 
   // Open the file "test.txt" under the current directory
   // rev_write(STDOUT_FILENO, OpenMsg, sizeof(OpenMsg));
-  int        fd        = rev_openat( AT_FDCWD, path, 0, O_RDONLY );
+  int fd              = rev_openat( AT_FDCWD, path, 0, O_RDONLY );
 
   // Read from the file
-  uint64_t   bytesRead = rev_read( fd, buffer, 29 );
+  uint64_t bytesRead  = rev_read( fd, buffer, 29 );
 
   // Null-terminate the buffer so we can use it as a string
-  buffer[bytesRead]    = '\0';
+  buffer[bytesRead]   = '\0';
 
   // Write to STDOUT
   rev_write( STDOUT_FILENO, buffer, bytesRead );

--- a/test/syscalls/printf/printf.h
+++ b/test/syscalls/printf/printf.h
@@ -20,7 +20,7 @@ extern volatile uint64_t fromhost;
 static uintptr_t counters[NUM_COUNTERS];
 static char*     counter_names[NUM_COUNTERS];
 
-void             printstr( const char* s ) {
+void printstr( const char* s ) {
   ssize_t bytes_written2 = rev_write( STDOUT_FILENO, s, strlen( s ) );
 }
 

--- a/test/threading/pthreads/permute/simple_pthreads.c
+++ b/test/threading/pthreads/permute/simple_pthreads.c
@@ -22,7 +22,7 @@ volatile unsigned thread1_counter = 0;
 volatile unsigned thread2_counter = 0;
 volatile unsigned thread3_counter = 0;
 
-void*             thread1() {
+void* thread1() {
   for( int i = 0; i < 10; i++ )
     thread1_counter++;
   return 0;

--- a/test/tls/basic-tls.c
+++ b/test/tls/basic-tls.c
@@ -2,7 +2,7 @@
 
 __thread int tls_var = 42;
 
-int          main() {
+int main() {
   rev_write( 0, &tls_var, sizeof( tls_var ) );
   return 0;
 }

--- a/test/tracer/tracer.c
+++ b/test/tracer/tracer.c
@@ -47,7 +47,7 @@ volatile int check_push_off( int r, int s ) {
 volatile unsigned thread1_counter = 0;
 volatile unsigned thread2_counter = 0;
 
-void*             thread1() {
+void* thread1() {
   TRACE_PUSH_ON
   for( int i = 0; i < 10; i++ )
     thread1_counter++;


### PR DESCRIPTION
This changes the `clang-format` to not align declarations across blank lines.

Previously, something like this could occur:
```
extern std::vector< void ( * )() > fenv_tests;
unsigned                           failures;

int                                main() {
}
```
`main()` should not be indented like that. This change changes the `.clang-format` so that declarations are not lined up if there is a blank line between them. A few files are affected with only whitespace changes.
