### PR TITLE
Backport STL tests from Forza repo

### DIFF
--- a/test/cxx/CMakeLists.txt
+++ b/test/cxx/CMakeLists.txt
@@ -1,2 +1,11 @@
+# RevCPU test/cxx/CMakeLists.txt
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
 add_rev_test(SIMPLE_STRUCT simple_struct 30 "all;rv64;memh;c++")
 add_subdirectory(stl)

--- a/test/cxx/simple_struct/Makefile
+++ b/test/cxx/simple_struct/Makefile
@@ -15,7 +15,7 @@
 EXAMPLE=simple_struct
 CC=riscv64-unknown-elf-g++
 #ARCH=rv64g
-ARCH=rv64imafd
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/simple_struct/simple_struct.cc
+++ b/test/cxx/simple_struct/simple_struct.cc
@@ -1,3 +1,11 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
 #include "syscalls.h"
 #include <memory>
 #define assert( x )               \
@@ -42,7 +50,7 @@ public:
 };
 
 int main() {
-  rec testrec( 1, 2 );
+  static rec testrec( 1, 2 );
   assert( testrec.c == 3 );
 
 #if 1

--- a/test/cxx/simple_struct/simple_struct.cc
+++ b/test/cxx/simple_struct/simple_struct.cc
@@ -50,7 +50,7 @@ public:
 };
 
 int main() {
-  static rec testrec( 1, 2 );
+  rec testrec( 1, 2 );
   assert( testrec.c == 3 );
 
 #if 1

--- a/test/cxx/stl/CMakeLists.txt
+++ b/test/cxx/stl/CMakeLists.txt
@@ -1,4 +1,23 @@
-add_rev_test(MAP map 30 "all;rv64;memh;c++")
-add_rev_test(VECTOR vector 30 "all;rv64;memh;c++")
-add_rev_test(VECTOR_OBJ vector_obj 30 "all;rv64;memh;c++")
+# RevCPU test/cxx/stl CMakeLists.txt
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+#add_rev_test(array array 30 "all;memh;rv64;c++" SCRIPT "run_array.sh")
+add_rev_test(map map 30 "all;memh;rv64;c++" SCRIPT "run_map.sh")
+add_rev_test(map_obj map_obj 30 "all;memh;rv64;c++" SCRIPT "run_map_obj.sh")
+add_rev_test(multimap multimap 30 "all;memh;rv64;c++" SCRIPT "run_multimap.sh")
+add_rev_test(multimap_obj multimap_obj 30 "all;memh;rv64;c++" SCRIPT "run_multimap_obj.sh")
+add_rev_test(vector vector 30 "all;memh;rv64;c++" SCRIPT "run_vector.sh")
+#add_rev_test(vector_edge vector_edge 30 "all;memh;rv64;c++" SCRIPT "run_vector_edge.sh")
+#add_rev_test(vector_int64_t vector_int64_t 30 "all;memh;rv64;c++" SCRIPT "run_vector_int64_t.sh")
+add_rev_test(vector_obj vector_obj 30 "all;memh;rv64;c++" SCRIPT "run_vector_obj.sh")
+add_rev_test(vector_pair vector_pair 30 "all;memh;rv64;c++" SCRIPT "run_vector_pair.sh")
+#add_rev_test(vector_vector_int64_t vector_vector_int64_t 30 "all;memh;rv64;c++" SCRIPT "run_vector_vector_int64_t.sh")
+add_rev_test(unordered_map unordered_map 30 "all;memh;rv64;c++" SCRIPT "run_unordered_map.sh")
+add_rev_test(unordered_map_obj unordered_map_obj 30 "all;memh;rv64;c++" SCRIPT "run_unordered_map_obj.sh")
 

--- a/test/cxx/stl/array/Makefile
+++ b/test/cxx/stl/array/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=array
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/array/Makefile
+++ b/test/cxx/stl/array/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=array
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/array/array.cc
+++ b/test/cxx/stl/array/array.cc
@@ -1,0 +1,66 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include <array>
+#include <stdexcept>
+
+#include "rev-macros.h"
+#include "revalloc.h"
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+#define DIM 450  // Large array test
+#define N   10
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+void testAlloc() {
+  std::array< int, DIM > arr;
+
+  for( int i = 0; i < DIM; i++ ) {
+    arr[i] = i;
+  }
+
+  int expected_sum = DIM * ( DIM - 1 ) / 2;
+  int sum          = 0;
+  for( int i = 0; i < DIM; i++ ) {
+    sum += arr[i];
+  }
+
+  assert( sum == expected_sum );
+}
+
+void testBoundsCheck() {
+  std::array< int, DIM > arr;
+
+  try {
+    arr.at( DIM ) = DIM;  // accessing DIM using at should throw an exception
+    assert( false );
+  } catch( const std::out_of_range& e ) {
+    // success
+  }
+}
+
+int main() {
+
+  //When constructing the map the correct method is to use the default constructor and then
+  //  insert each element as shown (using std::pair
+  std::array< float, DIM > arr;
+
+  testAlloc();
+  testBoundsCheck();
+
+  return 0;
+}

--- a/test/cxx/stl/array/rev-test.py
+++ b/test/cxx/stl/array/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "array.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/array/rev-test.py
+++ b/test/cxx/stl/array/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "array.exe",  # Target executable

--- a/test/cxx/stl/array/run_array.sh
+++ b/test/cxx/stl/array/run_array.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x array.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX array.c: array.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/map/Makefile
+++ b/test/cxx/stl/map/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=map
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/map/map.cc
+++ b/test/cxx/stl/map/map.cc
@@ -1,3 +1,11 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
 #include "rev-macros.h"
 #include "revalloc.h"
 #include <map>

--- a/test/cxx/stl/map/rev-test.py
+++ b/test/cxx/stl/map/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "map.exe",  # Target executable

--- a/test/cxx/stl/map/run_map.sh
+++ b/test/cxx/stl/map/run_map.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x map.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX map: map.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/map_obj/Makefile
+++ b/test/cxx/stl/map_obj/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=map_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/map_obj/Makefile
+++ b/test/cxx/stl/map_obj/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=map_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/map_obj/map_obj.cc
+++ b/test/cxx/stl/map_obj/map_obj.cc
@@ -1,0 +1,115 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include <array>
+#include <map>
+#include <string>
+
+#include "rev-macros.h"
+#include "revalloc.h"
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+#define DIM 450
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+class EntityEmbedding {
+public:
+  uint64_t                 id;
+  std::array< float, DIM > vals;
+
+  EntityEmbedding( uint64_t id ) : id( id ) {
+  }
+
+  EntityEmbedding() {
+  }
+};
+
+using TestMap =
+  std::map< uint64_t,
+            EntityEmbedding,
+            std::less< uint64_t >,
+            Allocator< std::pair< const uint64_t, EntityEmbedding > > >;
+
+void testInsertion() {
+  TestMap m;
+
+  m.insert( { 0, EntityEmbedding( 0 ) } );
+  m.insert( { 1, EntityEmbedding( 1 ) } );
+  m.insert( { 0, EntityEmbedding( 2 ) } );
+
+  assert( m.size() == 2 );  // make sure that only two entries exist here
+  assert( m[0].id == 0 );   // the original value (0) should be returned
+}
+
+void testFind() {
+  TestMap m;
+
+  m.insert( { 0, EntityEmbedding( 0 ) } );
+  m.insert( { 1, EntityEmbedding( 1 ) } );
+  m.insert( { 0, EntityEmbedding( 2 ) } );
+  m.insert( { 2, EntityEmbedding( 3 ) } );
+
+  assert( m.size() == 3 );
+
+  auto it1 = m.find( 1 );  // find key1
+  assert( it1 != m.end() && it1->second.id == 1 );
+
+  auto it2 = m.find( 4 );  // find key that does not exist
+  assert( it2 == m.end() );
+}
+
+void testIteration() {
+  TestMap m;
+
+  m.insert( { 1, EntityEmbedding( 0 ) } );
+  m.insert( { 2, EntityEmbedding( 1 ) } );
+  m.insert( { 3, EntityEmbedding( 2 ) } );
+  m.insert( { 4, EntityEmbedding( 3 ) } );
+
+  assert( m.size() == 4 );
+
+  // ensure that the map is iterated in the intended order
+  int num = 1;
+  for( auto it = m.begin(); it != m.end(); it++ ) {
+    assert( it->first == num );
+    num++;
+  }
+}
+
+void testDeletion() {
+  TestMap m;
+
+  m.insert( { 1, EntityEmbedding( 0 ) } );
+  m.insert( { 2, EntityEmbedding( 1 ) } );
+  m.insert( { 3, EntityEmbedding( 2 ) } );
+  m.insert( { 4, EntityEmbedding( 3 ) } );
+
+  assert( m.size() == 4 );
+
+  auto check = m.extract( 1 );  // remove key 1
+  assert( check.key() == 1 );
+  assert( m.size() == 3 );
+}
+
+int main() {
+
+  testInsertion();
+  testFind();
+  testIteration();
+  testDeletion();
+
+  return 0;
+}

--- a/test/cxx/stl/map_obj/rev-test.py
+++ b/test/cxx/stl/map_obj/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "map_obj.exe",  # Target executable

--- a/test/cxx/stl/map_obj/rev-test.py
+++ b/test/cxx/stl/map_obj/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "map_obj.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/map_obj/run_map_obj.sh
+++ b/test/cxx/stl/map_obj/run_map_obj.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x map_obj.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX map_pbj: map_obj.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/multimap/Makefile
+++ b/test/cxx/stl/multimap/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=multimap
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/multimap/Makefile
+++ b/test/cxx/stl/multimap/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=multimap
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/multimap/multimap.cc
+++ b/test/cxx/stl/multimap/multimap.cc
@@ -1,0 +1,122 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "rev-macros.h"
+#include "revalloc.h"
+#include <map>
+#include <string>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+using TestMultiMap =
+  std::multimap< uint64_t,                      // key
+                 std::pair< uint64_t, float >,  // value
+                 std::less< uint64_t >,         // sorting method
+                 Allocator< std::pair<
+                   const uint64_t,
+                   std::pair< uint64_t, float > > > >;  // revalloc Allocator
+
+void testInsertion() {
+  TestMultiMap m;
+
+  m.insert( {
+    1, {2, 3.0f}
+  } );
+  m.insert( {
+    2, {3, 4.0f}
+  } );
+  assert( m.size() == 2 );
+
+  m.insert( {
+    1, {4, 5.0f}
+  } );
+  m.insert( {
+    1, {6, 7.0f}
+  } );
+  assert( m.size() == 4 );
+}
+
+void testDuplicateKeyInsertion() {
+  TestMultiMap m;
+  m.insert( {
+    1, {2, 3.0f}
+  } );
+  m.insert( {
+    1, {4, 5.0f}
+  } );
+  m.insert( {
+    1, {6, 7.0f}
+  } );
+
+  assert( m.size() == 3 );
+
+  auto range = m.equal_range( 1 );  // all values for key 1
+  int  count = 0;
+  for( auto it = range.first; it != range.second; it++ ) {
+    count++;
+  }
+  assert( count == 3 );  // should be able to count 3 values for key 1
+}
+
+void testOrderPreservation() {
+  TestMultiMap m;
+  m.insert( {
+    1, {2, 3.0f}
+  } );
+  m.insert( {
+    1, {4, 5.0f}
+  } );
+  m.insert( {
+    1, {6, 7.0f}
+  } );
+
+  auto it = m.begin();
+  assert( it->second.first == 2 );
+  it++;
+  assert( it->second.first == 4 );
+}
+
+void testDeletion() {
+  TestMultiMap m;
+  m.insert( {
+    1, {2, 3.0f}
+  } );
+  m.insert( {
+    1, {4, 5.0f}
+  } );
+  m.insert( {
+    1, {6, 7.0f}
+  } );
+  m.insert( {
+    2, {7, 8.0f}
+  } );
+
+  assert( m.size() == 4 );
+
+  // delete all entries with key 2
+  m.extract( 2 );
+
+  assert( m.size() == 3 );
+}
+
+int main() {
+  testInsertion();
+  testDuplicateKeyInsertion();
+  testOrderPreservation();
+  testDeletion();
+  return 0;
+}

--- a/test/cxx/stl/multimap/rev-test.py
+++ b/test/cxx/stl/multimap/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "multimap.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/multimap/rev-test.py
+++ b/test/cxx/stl/multimap/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "multimap.exe",  # Target executable

--- a/test/cxx/stl/multimap/run_multimap.sh
+++ b/test/cxx/stl/multimap/run_multimap.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x multimap.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX multimap: multimap.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/multimap_obj/Makefile
+++ b/test/cxx/stl/multimap_obj/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=multimap_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/multimap_obj/Makefile
+++ b/test/cxx/stl/multimap_obj/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=multimap_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/multimap_obj/multimap_obj.cc
+++ b/test/cxx/stl/multimap_obj/multimap_obj.cc
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "rev-macros.h"
+#include "revalloc.h"
+#include <map>
+#include <string>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+class WikiDataEdge {
+public:
+  uint64_t src;
+  uint64_t dst;
+  uint64_t type;
+
+  WikiDataEdge( uint64_t s, uint64_t d, uint64_t t ) :
+    src( s ), dst( d ), type( t ) {
+  }
+
+  WikiDataEdge() {
+  }
+};
+
+using TestMultiMap = std::multimap<
+  uint64_t,               // key
+  WikiDataEdge,           // value
+  std::less< uint64_t >,  // sorting method
+  Allocator<
+    std::pair< const uint64_t, WikiDataEdge > > >;  // revalloc Allocator
+
+void testInsertion() {
+  TestMultiMap m;
+
+  m.insert( { 0, WikiDataEdge( 1, 2, 0 ) } );
+  m.insert( { 1, WikiDataEdge( 1, 4, 1 ) } );
+  m.insert( { 0, WikiDataEdge( 2, 1, 0 ) } );
+
+  assert( m.size() == 3 );
+}
+
+void testDuplicateKeyInsertion() {
+  TestMultiMap m;
+  m.insert( { 0, WikiDataEdge( 1, 2, 0 ) } );
+  m.insert( { 1, WikiDataEdge( 1, 4, 1 ) } );
+  m.insert( { 0, WikiDataEdge( 2, 1, 0 ) } );
+
+  assert( m.size() == 3 );
+
+  auto range = m.equal_range( 0 );  // all values for key 0
+  int  count = 0;
+  for( auto it = range.first; it != range.second; it++ ) {
+    count++;
+  }
+  assert( count == 2 );  // should be able to count 3 values for key 1
+}
+
+void testOrderPreservation() {
+  TestMultiMap m;
+  m.insert( { 0, WikiDataEdge( 1, 2, 0 ) } );
+  m.insert( { 0, WikiDataEdge( 1, 4, 1 ) } );
+  m.insert( { 0, WikiDataEdge( 2, 1, 0 ) } );
+
+  // note the order of insertion and checks is not the same
+  auto it = m.begin();
+  assert( it->second.src == 1 && it->second.dst == 2 );
+  it++;
+  assert( it->second.src == 1 && it->second.dst == 4 );
+  it++;
+  assert( it->second.src == 2 && it->second.dst == 1 );
+}
+
+void testDeletion() {
+  TestMultiMap m;
+  m.insert( { 0, WikiDataEdge( 1, 2, 0 ) } );
+  m.insert( { 1, WikiDataEdge( 1, 4, 1 ) } );
+  m.insert( { 0, WikiDataEdge( 2, 1, 0 ) } );
+
+  assert( m.size() == 3 );
+
+  // delete all entries with key 1
+  m.extract( 1 );
+
+  assert( m.size() == 2 );
+}
+
+int main() {
+  testInsertion();
+  testDuplicateKeyInsertion();
+  testOrderPreservation();
+  testDeletion();
+  return 0;
+}

--- a/test/cxx/stl/multimap_obj/rev-test.py
+++ b/test/cxx/stl/multimap_obj/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "multimap_obj.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/multimap_obj/rev-test.py
+++ b/test/cxx/stl/multimap_obj/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "multimap_obj.exe",  # Target executable

--- a/test/cxx/stl/multimap_obj/run_multimap_obj.sh
+++ b/test/cxx/stl/multimap_obj/run_multimap_obj.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x multimap_obj.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX multimap_obj: multimap_obj.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/unordered_map/Makefile
+++ b/test/cxx/stl/unordered_map/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=unordered_map
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/unordered_map/Makefile
+++ b/test/cxx/stl/unordered_map/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=unordered_map
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/unordered_map/rev-test.py
+++ b/test/cxx/stl/unordered_map/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "unordered_map.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/unordered_map/rev-test.py
+++ b/test/cxx/stl/unordered_map/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "unordered_map.exe",  # Target executable

--- a/test/cxx/stl/unordered_map/run_unordered_map.sh
+++ b/test/cxx/stl/unordered_map/run_unordered_map.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x unordered_map.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX unordered_map: unordered_map.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/unordered_map/unordered_map.cc
+++ b/test/cxx/stl/unordered_map/unordered_map.cc
@@ -1,0 +1,95 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "rev-macros.h"
+#include "revalloc.h"
+#include <string>
+#include <unordered_map>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+using TestMap =
+  std::unordered_map< uint64_t,
+                      long,
+                      std::hash< uint64_t >,
+                      std::equal_to< uint64_t >,
+                      Allocator< std::pair< const uint64_t, long > > >;
+
+// using TestMap = std::unordered_map<uint64_t, long, std::less<uint64_t>, Allocator<std::pair<const uint64_t, long>> >;
+
+
+void testInsertion() {
+  TestMap m;
+
+  m.insert( { 0, 1 } );
+  m.insert( { 1, 2 } );
+  m.insert( { 2, 3 } );
+  assert( m.size() == 3 );
+
+  m.insert( { 0, 2 } );
+  assert( m[0] == 1 );  // the orignal value of key 0 = 1 should be returned
+}
+
+void testElementAccess() {
+  TestMap m;
+  m.insert( { 0, 1 } );
+  m.insert( { 1, 2 } );
+  m.insert( { 2, 3 } );
+
+  assert( m.find( 0 ) != m.end() && m[0] == 1 );
+
+  // key 4 should not exist in the map
+  assert( m.find( 4 ) == m.end() );
+}
+
+void testDeletion() {
+  TestMap m;
+  m.insert( { 0, 1 } );
+  m.insert( { 1, 2 } );
+  m.insert( { 2, 3 } );
+
+  assert( m.size() == 3 );
+
+  auto check = m.extract( 0 );
+
+  // removed element 0, check size, removed key and make sure key=0 does not exist in map
+  assert( m.find( 0 ) == m.end() && m.size() == 2 && check.key() == 0 );
+}
+
+void testIteration() {
+  TestMap m;
+  m.insert( { 0, 1 } );
+  m.insert( { 1, 2 } );
+  m.insert( { 2, 3 } );
+
+  // assert( m.begin()->first == 0 );
+
+  for( auto it = m.begin(); it != m.end(); it++ ) {
+    assert( it->first >= 0 && it->first <= 2 && it->second >= 1 &&
+            it->second <= 3 );
+  }
+}
+
+int main() {
+
+  testInsertion();
+  testElementAccess();
+  testDeletion();
+  testIteration();
+
+  return 0;
+}

--- a/test/cxx/stl/unordered_map_obj/Makefile
+++ b/test/cxx/stl/unordered_map_obj/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=unordered_map_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/unordered_map_obj/Makefile
+++ b/test/cxx/stl/unordered_map_obj/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=unordered_map_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/unordered_map_obj/rev-test.py
+++ b/test/cxx/stl/unordered_map_obj/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "unordered_map_obj.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/unordered_map_obj/rev-test.py
+++ b/test/cxx/stl/unordered_map_obj/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "unordered_map_obj.exe",  # Target executable

--- a/test/cxx/stl/unordered_map_obj/run_unordered_map_obj.sh
+++ b/test/cxx/stl/unordered_map_obj/run_unordered_map_obj.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x unordered_map_obj.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX unordered_map_obj: unordered_map_obj.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/unordered_map_obj/unordered_map_obj.cc
+++ b/test/cxx/stl/unordered_map_obj/unordered_map_obj.cc
@@ -1,0 +1,130 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include <array>
+#include <string>
+#include <unordered_map>
+
+#include "rev-macros.h"
+#include "revalloc.h"
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+#define DIM 450
+
+typedef std::basic_string< char, std::char_traits< char >, Allocator< char > >
+  revString;
+
+class ContigSet {
+public:
+  uint64_t id;
+  uint8_t  val1;
+  uint64_t val2;
+  int      val3;
+
+  ContigSet() {
+  }
+
+  ContigSet( uint64_t id ) : id( id ) {
+  }
+
+  ContigSet( uint64_t id, uint8_t v1, uint64_t v2, uint64_t v3 ) :
+    id( id ), val1( v1 ), val2( v2 ), val3( v3 ) {
+  }
+};
+
+using TestMap =
+  std::unordered_map< uint64_t,
+                      ContigSet,
+                      std::hash< uint64_t >,
+                      std::equal_to< uint64_t >,
+                      Allocator< std::pair< const uint64_t, ContigSet > > >;
+
+void testInsertion() {
+  TestMap m;
+
+  m.insert( { 0, ContigSet( 0 ) } );
+  m.insert( { 1, ContigSet( 1 ) } );
+  m.insert( { 0, ContigSet( 2 ) } );
+
+  assert( m.size() == 2 );  // make sure that only two entries exist here
+  assert( m[0].id == 0 );   // the original value (0) should be returned
+
+  // check for value update
+  m[0].id = 42;
+  assert( m[0].id == 42 );
+}
+
+void testFind() {
+  TestMap m;
+
+  m.insert( { 0, ContigSet( 0 ) } );
+  m.insert( { 1, ContigSet( 1 ) } );
+  m.insert( { 0, ContigSet( 2 ) } );
+  m.insert( { 2, ContigSet( 3 ) } );
+
+  assert( m.size() == 3 );
+
+  auto it1 = m.find( 1 );  // find key1
+  assert( it1 != m.end() && it1->second.id == 1 );
+
+  auto it2 = m.find( 4 );  // find key that does not exist
+  assert( it2 == m.end() );
+}
+
+void testIteration() {
+  TestMap m;
+
+  m.insert( { 1, ContigSet( 0 ) } );
+  m.insert( { 2, ContigSet( 1 ) } );
+  m.insert( { 3, ContigSet( 2 ) } );
+  m.insert( { 4, ContigSet( 3 ) } );
+
+  assert( m.size() == 4 );
+
+  int count = 0;
+
+  // ensure all objects are iterated over with range check on expected values
+  for( auto it = m.begin(); it != m.end(); it++ ) {
+    assert( it->first >= 1 && it->first <= 4 && it->second.id >= 0 &&
+            it->second.id <= 3 );
+    count++;
+  }
+
+  assert( count == m.size() );
+}
+
+void testDeletion() {
+  TestMap m;
+
+  m.insert( { 1, ContigSet( 0 ) } );
+  m.insert( { 2, ContigSet( 1 ) } );
+  m.insert( { 3, ContigSet( 2 ) } );
+  m.insert( { 4, ContigSet( 3 ) } );
+
+  assert( m.size() == 4 );
+
+  auto check = m.extract( 1 );  // remove key 1
+  assert( check.key() == 1 );
+  assert( m.size() == 3 );
+}
+
+int main() {
+
+  testInsertion();
+  testFind();
+  testIteration();
+  testDeletion();
+
+  return 0;
+}

--- a/test/cxx/stl/vector/Makefile
+++ b/test/cxx/stl/vector/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector/rev-test.py
+++ b/test/cxx/stl/vector/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector.exe",  # Target executable

--- a/test/cxx/stl/vector/run_vector.sh
+++ b/test/cxx/stl/vector/run_vector.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector: vector.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector/vector.cc
+++ b/test/cxx/stl/vector/vector.cc
@@ -1,3 +1,11 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
 #include "rev-macros.h"
 #include "revalloc.h"
 #include <vector>

--- a/test/cxx/stl/vector_edge/Makefile
+++ b/test/cxx/stl/vector_edge/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector_edge
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector_edge/Makefile
+++ b/test/cxx/stl/vector_edge/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=vector_edge
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/vector_edge/rev-test.py
+++ b/test/cxx/stl/vector_edge/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "vector_edge.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/vector_edge/rev-test.py
+++ b/test/cxx/stl/vector_edge/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector_edge.exe",  # Target executable

--- a/test/cxx/stl/vector_edge/run_vector_edge.sh
+++ b/test/cxx/stl/vector_edge/run_vector_edge.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector_edge.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector_edge: vector_edge.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector_edge/vector_edge.cc
+++ b/test/cxx/stl/vector_edge/vector_edge.cc
@@ -1,0 +1,199 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "revalloc.h"
+#include <vector>
+
+#include "rev-macros.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+#define N 10
+#define M 20
+
+typedef struct {
+  int src;
+  int dst;
+} edge_t;
+
+class Edge {
+public:
+  int src;
+  int dst;
+
+  Edge() {
+  }
+
+  Edge( int src, int dst ) : src( src ), dst( dst ) {
+  }
+
+  Edge( const Edge& e ) : src( e.src ), dst( e.dst ) {
+  }
+};
+
+void test_struct_edge_push_back() {
+  std::vector< edge_t, Allocator< edge_t > > v;
+  v.push_back( { 1, 1 } );
+  v.push_back( { 2, 2 } );
+  assert( v.size() == 2 && v[0].src == 1 && v[0].dst == 1 && v[1].src == 2 &&
+          v[1].dst == 2 );
+}
+
+void test_struct_edge_reserve() {
+  std::vector< edge_t, Allocator< edge_t > > v;
+  v.reserve( N );
+
+  auto initial_address = v.data();
+  bool reserve_failed  = false;
+
+  // add N elements, the vector should not resize
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( { i, i } );
+    if( initial_address != v.data() ) {
+      reserve_failed = true;
+      break;
+    }
+  }
+
+  assert( !reserve_failed && v.size() == N );
+}
+
+void test_struct_edge_resize() {
+  // assert(false);
+  std::vector< edge_t, Allocator< edge_t > > v;
+  v.resize( N );
+  assert( v.size() == N );
+
+  // fill using the access operator
+  for( int i = 0; i < N; i++ ) {
+    v[i] = { i, i };
+  }
+
+  assert( v.size() == N && v[0].src == 0 && v[0].dst == 0 &&
+          ( v[N / 2].src = N / 2 ) && ( v[N / 2].dst = N / 2 ) );
+}
+
+void test_struct_edge_begin_and_end() {
+  std::vector< edge_t, Allocator< edge_t > > v;
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( { i, i } );
+  }
+
+  // use an iterator to check if the vector contains the correct edges
+  int i = 0;
+  for( auto it = v.begin(); it != v.end(); it++, i++ ) {
+    assert( it->src == i && it->dst == i );
+  }
+}
+
+void test_struct_edge_at() {
+  std::vector< edge_t, Allocator< edge_t > > v;
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( { i, i } );
+  }
+
+  for( int i = 0; i < N; i++ ) {
+    assert( v.at( i ).src == i && v.at( i ).dst == i );
+  }
+
+  try {
+    edge_t check = v.at( N + 1 );
+    assert( false );  // this should never run
+  } catch( const std::out_of_range& e ) {
+  }
+}
+
+void test_class_edge_reserve() {
+  std::vector< Edge, Allocator< Edge > > v;
+  v.reserve( N );
+
+  auto initial_address = v.data();
+  bool reserve_failed  = false;
+
+  // add N elements, the vector should not resize
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( Edge( i, i ) );
+    if( initial_address != v.data() ) {
+      reserve_failed = true;
+      break;
+    }
+  }
+
+  assert( !reserve_failed && v.size() == N );
+}
+
+void test_class_edge_resize() {
+  std::vector< Edge, Allocator< Edge > > v;
+  v.resize( N );
+  assert( v.size() == N );
+
+  // fill using the access operator
+  for( int i = 0; i < N; i++ ) {
+    v[i] = Edge( i, i );
+  }
+
+  assert( v.size() == N && v[0].src == 0 && v[0].dst == 0 &&
+          ( v[N / 2].src = N / 2 ) && ( v[N / 2].dst = N / 2 ) );
+}
+
+void test_class_edge_begin_and_end() {
+  std::vector< Edge, Allocator< Edge > > v;
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( Edge( i, i ) );
+  }
+
+  // use an iterator to check if the vector contains the correct edges
+  int i = 0;
+  for( auto it = v.begin(); it != v.end(); it++, i++ ) {
+    assert( it->src == i && it->dst == i );
+  }
+}
+
+void test_class_edge_at() {
+  std::vector< Edge, Allocator< Edge > > v;
+  for( int i = 0; i < N; i++ ) {
+    v.push_back( Edge( i, i ) );
+  }
+
+  for( int i = 0; i < N; i++ ) {
+    assert( v.at( i ).src == i && v.at( i ).dst == i );
+  }
+
+  try {
+    Edge check = v.at( N + 1 );
+    assert( false );  // this should never execute
+  } catch( const std::out_of_range& e ) {
+  }
+}
+
+int main() {
+  // edge struct tests
+  test_struct_edge_push_back();
+  test_struct_edge_reserve();
+  test_struct_edge_resize();
+  test_struct_edge_begin_and_end();
+  test_struct_edge_at();
+
+  // edge class tests
+  test_class_edge_reserve();
+  test_class_edge_resize();
+  test_class_edge_begin_and_end();
+  test_class_edge_at();
+
+  return 0;
+}

--- a/test/cxx/stl/vector_int64_t/Makefile
+++ b/test/cxx/stl/vector_int64_t/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=vector_int64_t
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -I ../../../syscalls -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/vector_int64_t/Makefile
+++ b/test/cxx/stl/vector_int64_t/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector_int64_t
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector_int64_t/rev-test.py
+++ b/test/cxx/stl/vector_int64_t/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "vector_int64_t.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/vector_int64_t/rev-test.py
+++ b/test/cxx/stl/vector_int64_t/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector_int64_t.exe",  # Target executable

--- a/test/cxx/stl/vector_int64_t/run_vector_int64_t.sh
+++ b/test/cxx/stl/vector_int64_t/run_vector_int64_t.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector_int64_t.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector_int64_t: vector_int64_t.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector_int64_t/vector_int64_t.cc
+++ b/test/cxx/stl/vector_int64_t/vector_int64_t.cc
@@ -1,0 +1,140 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "revalloc.h"
+#include <vector>
+
+#include "rev-macros.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+#define N 10
+#define M 20
+
+// fill in pre-sized std vector -- tests out the [] access operator
+static inline void fill_vector( std::vector< int64_t, Allocator< int64_t > >& v,
+                                int start_pos,
+                                int count ) {
+  int end_pos = start_pos + count;
+  for( int i = start_pos; i < end_pos; i++ ) {
+    v[i] = i;
+  }
+}
+
+// fill a vector using push_back
+static inline void fill_push_back_vector(
+  std::vector< int64_t, Allocator< int64_t > >& v, int start_num, int count ) {
+  int end_num = start_num + count;
+  for( int i = start_num; i < end_num; i++ ) {
+    v.push_back( i );
+  }
+}
+
+void test_reserve() {
+  std::vector< int64_t, Allocator< int64_t > > v;
+  v.reserve( N );
+
+  assert( v.capacity() == N );
+  assert( v.size() == 0 );
+
+  auto initial_address = v.data();
+  bool reserve_failed  = false;
+  for( int64_t i = 0; i < N; i++ ) {
+    v.push_back( i );
+    if( v.data() != initial_address ) {
+      reserve_failed = true;
+      break;
+    }
+  }
+  assert( v.size() == N && !reserve_failed && ( v[N / 2] == N / 2 ) )
+
+    // Now check if the reallocation works when the vector grows larger than capacity
+    v.push_back( N );
+  assert( v.data() != initial_address && v.size() == ( N + 1 ) &&
+          v.capacity() >= ( N + 1 ) );
+}
+
+void test_resize() {
+  std::vector< int64_t, Allocator< int64_t > > v;
+  v.resize( N );
+
+  assert( v.size() == N );
+  fill_vector( v, 0, N );
+  assert( v.size() == N );  // ensure that vector::size has not increased
+
+  fill_push_back_vector( v, N, N );
+  assert( v.size() == ( 2 * N ) );  // ensure that vector::size is now 2*N
+
+  // Resize to 4*N and check
+  v.resize( 4 * N );
+  assert( v.size() == 4 * N );
+  fill_vector( v, 2 * N, 2 * N );
+
+  assert( v.size() == 4 * N );
+}
+
+void test_begin_and_end() {
+  std::vector< int64_t, Allocator< int64_t > > v;
+  fill_push_back_vector( v, 0, N );
+
+  int64_t i = 0;
+  for( auto iter = v.begin(); iter < v.end(); iter++, i++ ) {
+    assert( *iter == i );
+  }
+}
+
+void test_erase() {
+  std::vector< int64_t, Allocator< int64_t > > v;
+  fill_push_back_vector( v, 0, N );
+  assert( v.size() == N );
+
+  // erase the first N / 2 elements one at a time
+  for( int i = 0; i < ( N / 2 ); i++ ) {
+    v.erase( v.begin() );
+  }
+  assert( v.size() == ( N / 2 ) );
+  assert( v[0] == ( N / 2 ) );
+
+  // test erase via iterator range
+  v.erase( v.begin(), v.end() );
+  assert( v.size() == 0 );
+}
+
+void test_at() {
+  std::vector< int64_t, Allocator< int64_t > > v;
+  fill_push_back_vector( v, 0, N );
+
+  int check = -1;
+  try {
+    v.at( N + 1 ) = N + 1;
+    check         = 0;  // this should not run
+  } catch( const std::out_of_range& e ) {
+    assert( check == -1 );
+  }
+}
+
+int main() {
+
+  test_reserve();
+  test_resize();
+  test_begin_and_end();
+  test_erase();
+  test_at();
+
+  return 0;
+}

--- a/test/cxx/stl/vector_obj/Makefile
+++ b/test/cxx/stl/vector_obj/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector_obj
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector_obj/rev-test.py
+++ b/test/cxx/stl/vector_obj/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector_obj.exe",  # Target executable

--- a/test/cxx/stl/vector_obj/run_vector_obj.sh
+++ b/test/cxx/stl/vector_obj/run_vector_obj.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector_obj.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector_obj: vector_obj.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector_obj/vector_obj.cc
+++ b/test/cxx/stl/vector_obj/vector_obj.cc
@@ -1,3 +1,11 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
 #include "rev-macros.h"
 #include "revalloc.h"
 #include <vector>

--- a/test/cxx/stl/vector_pair/Makefile
+++ b/test/cxx/stl/vector_pair/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector_pair
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector_pair/Makefile
+++ b/test/cxx/stl/vector_pair/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=vector_pair
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/vector_pair/rev-test.py
+++ b/test/cxx/stl/vector_pair/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "vector_pair.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/vector_pair/rev-test.py
+++ b/test/cxx/stl/vector_pair/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector_pair.exe",  # Target executable

--- a/test/cxx/stl/vector_pair/run_vector_pair.sh
+++ b/test/cxx/stl/vector_pair/run_vector_pair.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector_pair.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector_pair: vector_pair.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector_pair/vector_pair.cc
+++ b/test/cxx/stl/vector_pair/vector_pair.cc
@@ -1,0 +1,120 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "rev-macros.h"
+#include "revalloc.h"
+#include <vector>
+
+#include <cstdint>
+#include <utility>  // For std::pair
+
+#include <cstdio>
+#include <stdexcept>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+#define N 10
+#define M 20
+
+bool testSize() {
+  std::vector< std::pair< int64_t, int64_t >,
+               Allocator< std::pair< int64_t, int64_t > > >
+    vec = {
+      {1, 2},
+      {3, 4}
+  };
+  if( vec.size() != 2 )
+    return false;
+
+  vec.push_back( { 5, 6 } );
+  return vec.size() == 3;
+}
+
+bool testReserve() {
+  std::vector< std::pair< int64_t, int64_t >,
+               Allocator< std::pair< int64_t, int64_t > > >
+    vec;
+  vec.reserve( N );
+  if( vec.capacity() != N ) {
+    return false;
+  }
+
+  auto initial_address = vec.data();
+  bool reserve_failed  = false;
+  for( int i = 0; i < N; i++ ) {
+    vec.push_back( std::pair< int64_t, int64_t >( i, i ) );
+
+    // the vector backing store address should not change
+    if( vec.data() != initial_address ) {
+      reserve_failed = true;
+      break;
+    }
+  }
+
+  return !reserve_failed && ( vec.size() == N );
+}
+
+bool testResize() {
+  std::vector< std::pair< int64_t, int64_t >,
+               Allocator< std::pair< int64_t, int64_t > > >
+    vec( 2 );
+  vec.resize( 4 );
+  if( vec.size() != 4 )
+    return false;
+
+  // Newly added pairs should be initialized to (0, 0)
+  return vec[2].first == 0 && vec[2].second == 0 && vec[3].first == 0 &&
+         vec[3].second == 0;
+}
+
+bool testPushBack() {
+  std::vector< std::pair< int64_t, int64_t >,
+               Allocator< std::pair< int64_t, int64_t > > >
+    vec;
+  vec.push_back( { 1, 2 } );
+  vec.push_back( { 3, 4 } );
+
+  return vec.size() == 2 && vec[1].first == 3 && vec[1].second == 4;
+}
+
+bool testBeginEnd() {
+  std::vector< std::pair< int64_t, int64_t >,
+               Allocator< std::pair< int64_t, int64_t > > >
+    vec = {
+      {1, 1},
+      {2, 2},
+      {3, 3}
+  };
+  auto it = vec.begin();
+  if( it == vec.end() || it->first != 1 || it->second != 1 )
+    return false;
+
+  int64_t sumFirst = 0, sumSecond = 0;
+  for( auto it = vec.begin(); it != vec.end(); ++it ) {
+    sumFirst += it->first;
+    sumSecond += it->second;
+  }
+  return sumFirst == 6 && sumSecond == 6;
+}
+
+int main() {
+
+  assert( testSize() );
+  assert( testPushBack() );
+  assert( testReserve() );
+  assert( testResize() );
+  assert( testBeginEnd() );
+
+  return 0;
+}

--- a/test/cxx/stl/vector_vector_int64_t/Makefile
+++ b/test/cxx/stl/vector_vector_int64_t/Makefile
@@ -16,7 +16,7 @@ EXAMPLE=vector_vector_int64_t
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
-ARCH=rv64imafdc
+ARCH=rv64gc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc

--- a/test/cxx/stl/vector_vector_int64_t/Makefile
+++ b/test/cxx/stl/vector_vector_int64_t/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -12,7 +12,7 @@
 
 .PHONY: src
 
-EXAMPLE=vector
+EXAMPLE=vector_vector_int64_t
 CC=riscv64-unknown-elf-g++
 #CC="${RVCC}"
 #ARCH=rv64g
@@ -20,7 +20,7 @@ ARCH=rv64imafdc
 
 all: $(EXAMPLE).exe
 $(EXAMPLE).exe: $(EXAMPLE).cc
-	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
+	$(CC) -march=$(ARCH) -O0 -I../../../../common/include -I../../../../common/syscalls -I../../../include -o $(EXAMPLE).exe $(EXAMPLE).cc -static
 clean:
 	rm -Rf $(EXAMPLE).exe
 

--- a/test/cxx/stl/vector_vector_int64_t/rev-test.py
+++ b/test/cxx/stl/vector_vector_int64_t/rev-test.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+# rev-test.py
+#
+
+import os
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(8)
+
+max_addr_gb = 1
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "revcpu.RevCPU")
+comp_cpu.addParams({
+        "verbose" : 20,                                # Verbosity
+        "numCores" : 1,                               # Number of cores
+        "clock" : "1.0GHz",                           # Clock
+        "memSize" : 1024*1024*1024,                   # Memory size in bytes
+        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "startAddr" : "[0:0x00000000]",               # Starting address for core 0
+        "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
+        "program" : "vector_vector_int64_t.exe",  # Target executable
+        "splash" : 1                                  # Display the splash message
+})
+
+# sst.setStatisticOutput("sst.statOutputCSV")
+sst.enableAllStatisticsForAllComponents()
+
+# EOF

--- a/test/cxx/stl/vector_vector_int64_t/rev-test.py
+++ b/test/cxx/stl/vector_vector_int64_t/rev-test.py
@@ -26,7 +26,7 @@ comp_cpu.addParams({
         "numCores" : 1,                               # Number of cores
         "clock" : "1.0GHz",                           # Clock
         "memSize" : 1024*1024*1024,                   # Memory size in bytes
-        "machine" : "[0:RV64IMAFDC]",                      # Core:Config; RV64I for core 0
+        "machine" : "[0:RV64GC]",                     # Core:Config; RV64I for core 0
         "startAddr" : "[0:0x00000000]",               # Starting address for core 0
         "memCost" : "[0:1:10]",                       # Memory loads required 1-10 cycles
         "program" : "vector_vector_int64_t.exe",  # Target executable

--- a/test/cxx/stl/vector_vector_int64_t/run_vector_vector_int64_t.sh
+++ b/test/cxx/stl/vector_vector_int64_t/run_vector_vector_int64_t.sh
@@ -11,9 +11,9 @@
 make clean && make
 
 # Check that the exec was built...
-if [[ -x simple_struct.exe ]]; then
-	sst --add-lib-path=../../../build/src/ ./rev-test-simple-struct.py
+if [[ -x vector_vector_int64_t.exe ]]; then
+  sst --add-lib-path=../../../../build/src/ ./rev-test.py
 else
-	echo "Test SIMPLE_STRUCT: simple_struct.exe not Found - likely build failed"
-	exit 1
+  echo "Test STL CXX vector_vector_int64_t: vector_vector_int64_t.exe not Found - likely build failed"
+  exit 1
 fi

--- a/test/cxx/stl/vector_vector_int64_t/vector_vector_int64_t.cc
+++ b/test/cxx/stl/vector_vector_int64_t/vector_vector_int64_t.cc
@@ -1,0 +1,131 @@
+//
+// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "rev-macros.h"
+#include "revalloc.h"
+#include <vector>
+
+#include <cstdint>
+#include <utility>  // For std::pair
+
+#include <cstdio>
+#include <stdexcept>
+
+#define assert( x )      \
+  if( !( x ) ) {         \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+    asm( ".byte 0x00" ); \
+  }
+
+#define N 20
+#define M 40
+
+bool testSize() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+    vec = {
+      {1, 2},
+      {3, 4}
+  };
+  if( vec.size() != 2 )
+    return false;
+
+  vec.push_back( { 5, 6, 7 } );
+  return vec.size() == 3;
+}
+
+bool testResize() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+    vec( 2 );
+  vec.resize( 3 );
+  if( vec.size() != 3 )
+    return false;
+
+  vec[2].resize( 2, 42 );
+  return vec[2].size() == 2 && vec[2][1] == 42;
+}
+
+bool testReserve() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+    vec;
+  vec.reserve( N );
+  assert( vec.capacity() == N );
+
+  auto initial_address = vec.data();
+  bool reserve_failed  = false;
+  bool realloc_failed  = false;
+  for( int i = 0; i < N; i++ ) {
+    vec.push_back( std::vector< int64_t, Allocator< int64_t > >{ i, i } );
+    if( vec.data() !=
+        initial_address ) {  // the data address must not change for N pushes
+      reserve_failed = true;
+      break;
+    }
+  }
+
+  return !reserve_failed && ( vec.size() == N );
+}
+
+bool testPushBack() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+    vec;
+  vec.push_back( { 1, 2 } );
+  vec.push_back( { 3 } );
+
+  return vec.size() == 2 && vec[1].size() == 1 && vec[1][0] == 3;
+}
+
+bool testBeginEnd() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+       vec = { { 1 }, { 2 }, { 3 } };
+  auto it  = vec.begin();
+  if( it == vec.end() || ( *it )[0] != 1 )
+    return false;
+
+  int sum = 0;
+  for( auto it = vec.begin(); it != vec.end(); ++it ) {
+    sum += ( *it )[0];
+  }
+  return sum == 6;
+}
+
+bool testAt() {
+  std::vector< std::vector< int64_t, Allocator< int64_t > >,
+               Allocator< std::vector< int64_t, Allocator< int64_t > > > >
+    vec = { { 1 }, { 2 }, { 3 }, { 4 } };
+  if( vec.at( 0 )[0] != 1 && vec.at( 3 )[0] != 4 ) {
+    return false;
+  }
+
+  try {
+    auto check = vec.at( 5 );
+    return false;  // this line should never execute
+  } catch( std::out_of_range& e ) {
+    return true;
+  }
+
+  // return false;
+}
+
+int main() {
+
+  assert( testReserve() );
+  assert( testSize() );
+  assert( testResize() );
+  assert( testPushBack() );
+  assert( testBeginEnd() );
+  assert( testAt() );
+
+  return 0;
+}


### PR DESCRIPTION
This backports the STL tests from the Forza repo to the main Rev repo.

Four of the tests fail because of the error:
```
RevCPU[cpu:FetchAndDecodeInst:414020FATAL: RevCPU[cpu:ECALL_brk:41405000]: Out of memory / Unable to expand system break (brk) to Addr = 0x0
```
Those tests are currently commented out in `CMakeLists.txt`.
