### PR TITLE
Fix copyright date handling

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -171,7 +171,7 @@ reformat_files() {
             detect_change "$file" "$temp" "%s: Converting non-ASCII characters to ASCII equivalents"
 
             # Change the copyright date at the top of any text files
-            if perl -pe 'INIT { exit 1 if !-f $ARGV[0] || -B $ARGV[0]; $year = (localtime)[5] + 1900 } s/^([*\/#\/"*[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?(?=\s+Tactical Computing)/qq($1Copyright (C) $2@{[$year != $2 ? "-$year" : ""]})/ie if $. < 10' < "$file" > "$temp"; then
+            if perl -pe 'INIT { exit 1 if !-f $ARGV[0] || -B $ARGV[0]; $year = (localtime)[5] + 1900 } s/^([*\/#\/"*[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?(?=\s+Tactical Computing)/qq($1Copyright (C) $2@{[$year != $2 ? "-$year" : ""]})/ie if $. < 10' "$file" > "$temp"; then
                 detect_change "$file" "$temp" "%s: Changing copyright date"
             fi
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Tactical Computing Laboratories LLC
+Copyright (C) 2023-2024 Tactical Computing Laboratories LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,6 +1,6 @@
 # include/CoreGen/StoneCutter/Intrinsics CMakeLists.txt
 #
-# Copyright (C) 2017-2022 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/slurm/build-gcc11-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc11-sst13.1.0.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/build-gcc11-sst13.1.0.sh
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/slurm/build-gcc11.sh
+++ b/scripts/slurm/build-gcc11.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/build-gcc11.sh
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/slurm/build-llvm12-sst13.1.0.sh
+++ b/scripts/slurm/build-llvm12-sst13.1.0.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/build-llvm12-sst13.1.0.sh
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/slurm/build-llvm12.sh
+++ b/scripts/slurm/build-llvm12.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/build-llvm12.sh
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/scripts/slurm/exec_build.sh
+++ b/scripts/slurm/exec_build.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/exec_build.sh
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # RevCPU src CMakeLists.txt
-# Copyright (C) 2017-2022 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/src/pyrevcpu.py
+++ b/src/pyrevcpu.py
@@ -2,7 +2,7 @@
 #
 # Rev Python Infrastructure
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # RevCPU test/CMakeLists.txt
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/amo/amoadd_c/Makefile
+++ b/test/amo/amoadd_c/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: amoadd_c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/amo/amoadd_cxx/Makefile
+++ b/test/amo/amoadd_cxx/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: strlen_c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/amo/amoswap_c/Makefile
+++ b/test/amo/amoswap_c/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: amoswap_c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/argc/Makefile
+++ b/test/argc/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/argc/argc.c
+++ b/test/argc/argc.c
@@ -1,7 +1,7 @@
 /*
  * argc.c
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/argc_bug/Makefile
+++ b/test/argc_bug/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: argc bug
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/argc_bug/argc_bug.c
+++ b/test/argc_bug/argc_bug.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64G
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/argc_bug/rev-test-basim.py
+++ b/test/argc_bug/rev-test-basim.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/argc_short/Makefile
+++ b/test/argc_short/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/argc_short/argc.c
+++ b/test/argc_short/argc.c
@@ -1,7 +1,7 @@
 /*
  * argc.c
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/backingstore/Makefile
+++ b/test/backingstore/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: backingstore
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/backingstore/backingstore.c
+++ b/test/backingstore/backingstore.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/backingstore/rev-backingstore.py
+++ b/test/backingstore/rev-backingstore.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/benchmarks/memcpy/Makefile
+++ b/test/benchmarks/memcpy/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: big_loop.c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/benchmarks/qsort/Makefile
+++ b/test/benchmarks/qsort/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: big_loop.c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/benchmarks/towers/Makefile
+++ b/test/benchmarks/towers/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: big_loop.c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/bge_ble/Makefile
+++ b/test/bge_ble/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: bge_ble
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/bge_ble/rev-bge-ble.py
+++ b/test/bge_ble/rev-bge-ble.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/big_loop/Makefile
+++ b/test/big_loop/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: big_loop.c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/big_loop/big_loop.c
+++ b/test/big_loop/big_loop.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/cache_1/Makefile
+++ b/test/cache_1/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: large_bss
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cache_1/cache_1.c
+++ b/test/cache_1/cache_1.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/cache_1/rev-test-cache1.py
+++ b/test/cache_1/rev-test-cache1.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cache_2/Makefile
+++ b/test/cache_2/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: cache_test2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cache_2/cache_2.c
+++ b/test/cache_2/cache_2.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/cache_2/rev-test-cache2.py
+++ b/test/cache_2/rev-test-cache2.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/coproc_ex/Makefile
+++ b/test/coproc_ex/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/coproc_ex/coproc_ex.c
+++ b/test/coproc_ex/coproc_ex.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/coproc_ex/rev-test-coproc_ex.py
+++ b/test/coproc_ex/rev-test-coproc_ex.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/simple_struct/Makefile
+++ b/test/cxx/simple_struct/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: simple_struct
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/simple_struct/rev-test-simple-struct.py
+++ b/test/cxx/simple_struct/rev-test-simple-struct.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/map/Makefile
+++ b/test/cxx/stl/map/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/map/rev-test.py
+++ b/test/cxx/stl/map/rev-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/vector/Makefile
+++ b/test/cxx/stl/vector/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/vector/rev-test.py
+++ b/test/cxx/stl/vector/rev-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/vector_obj/Makefile
+++ b/test/cxx/stl/vector_obj/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/cxx/stl/vector_obj/rev-test.py
+++ b/test/cxx/stl/vector_obj/rev-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dcmp/Makefile
+++ b/test/dcmp/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: dcmp
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dcmp/rev-dcmp.py
+++ b/test/dcmp/rev-dcmp.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dep_check/Makefile
+++ b/test/dep_check/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dep_check/dep_check.c
+++ b/test/dep_check/dep_check.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/divw/Makefile
+++ b/test/divw/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: divw
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/divw2/Makefile
+++ b/test/divw2/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: divw2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dot_double/Makefile
+++ b/test/dot_double/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: dot_double
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dot_double/dot_double.c
+++ b/test/dot_double/dot_double.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64IMAFDC
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/dot_double/rev-test-do_double.py
+++ b/test/dot_double/rev-test-do_double.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dot_single/Makefile
+++ b/test/dot_single/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: dot_single
 #
-# Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/dot_single/dot_single.c
+++ b/test/dot_single/dot_single.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64IMAFDC
  *
- * Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/dot_single/rev-test-do_single.py
+++ b/test/dot_single/rev-test-do_single.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex1/Makefile
+++ b/test/ex1/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex1/ex1.c
+++ b/test/ex1/ex1.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex2/Makefile
+++ b/test/ex2/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex2/ex2.c
+++ b/test/ex2/ex2.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex3/Makefile
+++ b/test/ex3/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex3
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex3/ex3.c
+++ b/test/ex3/ex3.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex4/Makefile
+++ b/test/ex4/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex4
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex4/ex4.c
+++ b/test/ex4/ex4.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex5/Makefile
+++ b/test/ex5/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex5
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex5/ex5.c
+++ b/test/ex5/ex5.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex6/Makefile
+++ b/test/ex6/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex6
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex6/ex6.c
+++ b/test/ex6/ex6.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64IMAFDC
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/ex7/Makefile
+++ b/test/ex7/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex7
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/ex7/ex7.c
+++ b/test/ex7/ex7.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/fault/Makefile
+++ b/test/fault/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: fault1
 #
-# Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-1.py
+++ b/test/fault/fault-test-1.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-2.py
+++ b/test/fault/fault-test-2.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-3.py
+++ b/test/fault/fault-test-3.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-4.py
+++ b/test/fault/fault-test-4.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-5.py
+++ b/test/fault/fault-test-5.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-6.py
+++ b/test/fault/fault-test-6.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-7.py
+++ b/test/fault/fault-test-7.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-8.py
+++ b/test/fault/fault-test-8.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault-test-9.py
+++ b/test/fault/fault-test-9.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/fault/fault1.c
+++ b/test/fault/fault1.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/CMakeLists.txt
+++ b/test/isa/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/isa/Makefile
+++ b/test/isa/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/isa/add.c
+++ b/test/isa/add.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/addi.c
+++ b/test/isa/addi.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/addiw.c
+++ b/test/isa/addiw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/addw.c
+++ b/test/isa/addw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/and.c
+++ b/test/isa/and.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/andi.c
+++ b/test/isa/andi.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/div.c
+++ b/test/isa/div.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/divu.c
+++ b/test/isa/divu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/divuw.c
+++ b/test/isa/divuw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/divw.c
+++ b/test/isa/divw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/f_ldst.c
+++ b/test/isa/f_ldst.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fadd.c
+++ b/test/isa/fadd.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fclass.c
+++ b/test/isa/fclass.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fcmp.c
+++ b/test/isa/fcmp.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fcvt_sd.c
+++ b/test/isa/fcvt_sd.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32F, RV32D, RV64F, RV64D
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fcvt_sw.c
+++ b/test/isa/fcvt_sw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32F, RV32D, RV64F, RV64D
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fcvt_w.c
+++ b/test/isa/fcvt_w.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fdiv.c
+++ b/test/isa/fdiv.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fmadd.c
+++ b/test/isa/fmadd.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fmin.c
+++ b/test/isa/fmin.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/fmove.c
+++ b/test/isa/fmove.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/jal.c
+++ b/test/isa/jal.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/jalr.c
+++ b/test/isa/jalr.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lb.c
+++ b/test/isa/lb.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lbu.c
+++ b/test/isa/lbu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/ld.c
+++ b/test/isa/ld.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lh.c
+++ b/test/isa/lh.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lhu.c
+++ b/test/isa/lhu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lw.c
+++ b/test/isa/lw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/lwu.c
+++ b/test/isa/lwu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/mul.c
+++ b/test/isa/mul.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/mulh.c
+++ b/test/isa/mulh.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/mulhsu.c
+++ b/test/isa/mulhsu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/mulhu.c
+++ b/test/isa/mulhu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/mulw.c
+++ b/test/isa/mulw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/or.c
+++ b/test/isa/or.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/ori.c
+++ b/test/isa/ori.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/rem.c
+++ b/test/isa/rem.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/remu.c
+++ b/test/isa/remu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/remuw.c
+++ b/test/isa/remuw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/remw.c
+++ b/test/isa/remw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/rev-isa-test.py
+++ b/test/isa/rev-isa-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/isa/sb.c
+++ b/test/isa/sb.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sd.c
+++ b/test/isa/sd.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sh.c
+++ b/test/isa/sh.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sll.c
+++ b/test/isa/sll.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/slli.c
+++ b/test/isa/slli.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/slliw.c
+++ b/test/isa/slliw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sllw.c
+++ b/test/isa/sllw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/slt.c
+++ b/test/isa/slt.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/slti.c
+++ b/test/isa/slti.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sltiu.c
+++ b/test/isa/sltiu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sltu.c
+++ b/test/isa/sltu.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sra.c
+++ b/test/isa/sra.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/srai.c
+++ b/test/isa/srai.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sraiw.c
+++ b/test/isa/sraiw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sraw.c
+++ b/test/isa/sraw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/srli.c
+++ b/test/isa/srli.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/srliw.c
+++ b/test/isa/srliw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/srlw.c
+++ b/test/isa/srlw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sub.c
+++ b/test/isa/sub.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/subw.c
+++ b/test/isa/subw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/sw.c
+++ b/test/isa/sw.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/xor.c
+++ b/test/isa/xor.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/isa/xori.c
+++ b/test/isa/xori.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/large_bss/Makefile
+++ b/test/large_bss/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: large_bss
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/large_bss/large_bss.c
+++ b/test/large_bss/large_bss.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64G
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/many_core/Makefile
+++ b/test/many_core/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/many_core/many_core.c
+++ b/test/many_core/many_core.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/many_core/rev-many-core.py
+++ b/test/many_core/rev-many-core.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/memset/Makefile
+++ b/test/memset/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/memset/memset.py
+++ b/test/memset/memset.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/memset_2/Makefile
+++ b/test/memset_2/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: memset_2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/minfft/Makefile
+++ b/test/minfft/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex1
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/minfft/rev-test-minfft.py
+++ b/test/minfft/rev-test-minfft.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_mbox_test1/Makefile
+++ b/test/pan_mbox_test1/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: pan_test
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_mbox_test1/pan_spin.c
+++ b/test/pan_mbox_test1/pan_spin.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/pan_mbox_test1/pan_test.c
+++ b/test/pan_mbox_test1/pan_test.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/pan_mbox_test1/rev-pan-test.py
+++ b/test/pan_mbox_test1/rev-pan-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_test1/Makefile
+++ b/test/pan_test1/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: pan_test
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_test1/pan_test.c
+++ b/test/pan_test1/pan_test.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/pan_test1/rev-pan-test.py
+++ b/test/pan_test1/rev-pan-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_test2/Makefile
+++ b/test/pan_test2/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: pan_test
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/pan_test2/pan_test.c
+++ b/test/pan_test2/pan_test.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/pan_test2/rev-pan-test.py
+++ b/test/pan_test2/rev-pan-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/rev-model-options-config.py
+++ b/test/rev-model-options-config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strlen_c/Makefile
+++ b/test/strlen_c/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: strlen_c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strlen_c/strlen_c.py
+++ b/test/strlen_c/strlen_c.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strlen_cxx/Makefile
+++ b/test/strlen_cxx/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: strlen_c
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strlen_cxx/strlen_cxx.py
+++ b/test/strlen_cxx/strlen_cxx.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strstr/Makefile
+++ b/test/strstr/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: strstr
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/strstr/rev-strstr.py
+++ b/test/strstr/rev-strstr.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/chdir/Makefile
+++ b/test/syscalls/chdir/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/clock_gettime/Makefile
+++ b/test/syscalls/clock_gettime/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/file_io/Makefile
+++ b/test/syscalls/file_io/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/getcwd/Makefile
+++ b/test/syscalls/getcwd/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/munmap/Makefile
+++ b/test/syscalls/munmap/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: munmap
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/printf/Makefile
+++ b/test/syscalls/printf/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/vector/Makefile
+++ b/test/syscalls/vector/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: vector
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/vector/rev-test.py
+++ b/test/syscalls/vector/rev-test.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/syscalls/write/Makefile
+++ b/test/syscalls/write/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex2
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/threading/pthreads/permute/Makefile
+++ b/test/threading/pthreads/permute/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: simple_pthreads
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/threading/pthreads/permute/rev-test-pthread.py
+++ b/test/threading/pthreads/permute/rev-test-pthread.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/threading/pthreads/permute/simple_pthreads.c
+++ b/test/threading/pthreads/permute/simple_pthreads.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I, RV64G
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/threading/pthreads/pthread_arg_passing/Makefile
+++ b/test/threading/pthreads/pthread_arg_passing/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: pthread_arg_passing
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/threading/pthreads/pthread_basic/Makefile
+++ b/test/threading/pthreads/pthread_basic/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: pthread_basic
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/tls/Makefile
+++ b/test/tls/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: basic-tls
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/tracer/Makefile
+++ b/test/tracer/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: tracer
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/tracer/rev-test-tracer-memh.py
+++ b/test/tracer/rev-test-tracer-memh.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/tracer/rev-test-tracer.py
+++ b/test/tracer/rev-test-tracer.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/tracer/tracer.c
+++ b/test/tracer/tracer.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/x0/Makefile
+++ b/test/x0/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: ex5
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/x0/rev-test-x0.py
+++ b/test/x0/rev-test-x0.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/x0/x0.c
+++ b/test/x0/x0.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64IMAFDC
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *

--- a/test/zicbom/Makefile
+++ b/test/zicbom/Makefile
@@ -3,7 +3,7 @@
 #
 # makefile: zicbom
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/zicbom/rev-test-zicbom.py
+++ b/test/zicbom/rev-test-zicbom.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #

--- a/test/zicbom/zicbom.c
+++ b/test/zicbom/zicbom.c
@@ -3,7 +3,7 @@
  *
  * RISC-V ISA: RV64I_Zicbom
  *
- * Copyright (C) 2017-2023 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *


### PR DESCRIPTION
A 1-character bug in `.githooks/pre-commit` prevented copyright dates from being modified correctly.

This fixes `.githooks/pre-commit` and runs it on the entire tree, fixing some copyright dates.
