### PR TITLE
fixing doxygen builds; update for Issue273

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_DOCUMENTATION)
     message(FATAL_ERROR "Doxygen is required to build the documentation.")
   endif()
 
-  set(doxyfile ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/RevCPU.conf)
+  set(doxyfile ${CMAKE_CURRENT_SOURCE_DIR}/doxygen/Rev.conf)
 
   add_custom_target(doc
     COMMAND ${DOXYGEN_EXECUTABLE} ${doxyfile}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Building the Rev SST component from source using CMake (>= 3.19) can be performe
 
 Additional build options include:
     * -DBUILD_ASM_TESTING=ON
+    * -DBUILD_DOCUMENTATION=ON  : enables Doxygen source code generation (use `make doc`)
 
 After a successful build you can test your install with:
 

--- a/scripts/cleanmanpages.sh
+++ b/scripts/cleanmanpages.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# -- cleans the unnecessary directory reference manpages _*.3
+
+BASE=$1
+
+rm -Rf $BASE/_*.3


### PR DESCRIPTION
this fixes the documentation bug (Issue #273) by adding the appropriate scripts, fixing the name of the doxygen config file and updating the README documentation