### PR TITLE
Add struct declaration to avoid warnings

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -253,6 +253,7 @@ struct old_timespec32;
 struct __kernel_itimerspec;
 struct sigevent;
 struct sigaction;
+struct siginfo;
 
 typedef uint32_t      rwf_t;
 typedef unsigned long aio_context_t;


### PR DESCRIPTION
Another `struct` was missed and I saw the warning.
