### PR TITLE
Format tracer output to be more readable and handle compressed instructions

### DIFF
--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -264,13 +264,18 @@ std::string RevTracer::RenderExec( const std::string& fallbackMnemonic ) {
             ss_disasm << "?" << "\n";
 #else
     // show mnemonic and field format strings.
-    ss_disasm << fallbackMnemonic << "\t";
+    ss_disasm << std::left << std::setw( 20 ) << fallbackMnemonic << std::right << "\t";
 #endif
   }
 
   // Initial rendering
   std::stringstream os;
-  os << "0x" << std::hex << pc << ":" << std::setfill( '0' ) << std::setw( 8 ) << insn;
+  os << "0x" << std::hex << pc << ":" << std::setfill( '0' );
+  if( ~insn & 3 ) {
+    os << std::setw( 4 ) << ( insn & 0xffff ) << "    ";
+  } else {
+    os << std::setw( 8 ) << insn;
+  }
   os << " " << std::setfill( ' ' ) << std::setw( 2 ) << ss_events.str() << " " << ss_disasm.str();
 
   // register and memory read/write events preserving code ordering


### PR DESCRIPTION
Make tracer output handle compressed instructions, by only outputting 4 hex digits plus 4 spaces when a compressed instruction is encountered (currently it always outputs 8 hex digits even if only the lower 4 are significant because it's a compressed instruction, and then it repeats the higher bits again in the next instruction).

Pad mnemonic field at 20 characters so that when Spike isn't used, the tracer output after the mnemonic is lined up.

Makes output look like this (16-bit compressed instructions only show 4 hex digits after `:`; register transfer information is lined up after mnemonics):
```
RevCPU[cpu:Render:15449500]: Core 0; Hart 0; Thread 1; *I 0x10650:00101013  + slli %rd, %rs1, $imm       0x0<-x0 x0<-0x0
RevCPU[cpu:Render:15450000]: Core 0; Hart 0; Thread 1; *I 0x10654:4781        c.li %rd, $imm             0x0<-x0 x15<-0x0
RevCPU[cpu:Render:15450500]: Core 0; Hart 0; Thread 1; *I 0x10656:577d        c.li %rd, $imm             0x0<-x0 x14<-0xffffffffffffffff
RevCPU[cpu:Render:15451000]: Core 0; Hart 0; Thread 1; *I 0x10658:02200693    addi %rd, %rs1, $imm       0x0<-x0 x13<-0x22
RevCPU[cpu:Render:15451500]: Core 0; Hart 0; Thread 1; *I 0x1065c:461d        c.li %rd, $imm             0x0<-x0 x12<-0x7
RevCPU[cpu:Render:15452000]: Core 0; Hart 0; Thread 1; *I 0x1065e:45c1        c.li %rd, $imm             0x0<-x0 x11<-0x10
RevCPU[cpu:Render:15452500]: Core 0; Hart 0; Thread 1; *I 0x10660:4501        c.li %rd, $imm             0x0<-x0 x10<-0x0
RevCPU[cpu:Render:15453000]: Core 0; Hart 0; Thread 1; *I 0x10662:bd7ff0ef    jal %rd, $imm              x1<-0x10666 pc<-0x10238 <rev_mmap>
RevCPU[cpu:Render:15453500]: Core 0; Hart 0; Thread 1; *I 0x10238:0de00893    addi %rd, %rs1, $imm       0x0<-x0 x17<-0xde
RevCPU[cpu:Render:15454000]: Core 0; Hart 0; Thread 1; *I 0x1023c:00000073    ecall
RevCPU[cpu:ECALL_mmap:15454500]: ECALL: mmap called
RevCPU[cpu:Render:15455000]: Core 0; Hart 0; Thread 1; *I 0x10240:8082        ret                        0xde<-x17 0x0<-x10 0x10<-x1
```