### PR TITLE
Only print 4 hex digits for compressed instructions in verbose mode

### DIFF
--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -1303,12 +1303,13 @@ RevInst RevCore::FetchAndDecodeInst() {
       CALL_INFO,
       6,
       0,
-      "Core %" PRIu32 "; Hart %" PRIu32 "; Thread %" PRIu32 "; PC:InstPayload = 0x%" PRIx64 ":0x%" PRIx32 "\n",
+      ~Inst & 3 ? "Core %" PRIu32 "; Hart %" PRIu32 "; Thread %" PRIu32 "; PC:InstPayload = 0x%" PRIx64 ":0x%04" PRIx32 "\n" :
+                  "Core %" PRIu32 "; Hart %" PRIu32 "; Thread %" PRIu32 "; PC:InstPayload = 0x%" PRIx64 ":0x%08" PRIx32 "\n",
       id,
       HartToDecodeID,
       ActiveThreadID,
       PC,
-      Inst
+      ~Inst & 3 ? Inst & 0xffff : Inst
     );
   } else {
     output->fatal(


### PR DESCRIPTION
Similar to https://github.com/tactcomplabs/rev/pull/277 for tracer, output only 4 hex digits for compressed instructions in verbose mode.

```
RevCPU[cpu:FetchAndDecodeInst:39500]: Core 0; Hart 0; Thread 1; PC:InstPayload = 0x3a49c:0xb34ff0ef
RevCPU[cpu:FetchAndDecodeInst:40500]: Core 0; Hart 0; Thread 1; PC:InstPayload = 0x397d0:0x619c
RevCPU[cpu:FetchAndDecodeInst:41000]: Core 0; Hart 0; Thread 1; PC:InstPayload = 0x397d2:0x1101
RevCPU[cpu:FetchAndDecodeInst:41500]: Core 0; Hart 0; Thread 1; PC:InstPayload = 0x397d4:0xe822
RevCPU[cpu:FetchAndDecodeInst:42000]: Core 0; Hart 0; Thread 1; PC:InstPayload = 0x397d6:0xfe87b783
                                                                                         ^^^^^^^^^^
```