### PR TITLE
Add two more syscall structs

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -254,6 +254,8 @@ struct __kernel_itimerspec;
 struct sigevent;
 struct sigaction;
 struct siginfo;
+struct sigset_t;
+struct fd_set;
 
 typedef uint32_t      rwf_t;
 typedef unsigned long aio_context_t;


### PR DESCRIPTION
Two more missing `struct` declarations were discovered in C++20 mode.
