### PR TITLE
Updates for sst 14.0.0 support

### DIFF
--- a/src/RevNIC.cc
+++ b/src/RevNIC.cc
@@ -63,11 +63,13 @@ void RevNIC::init( unsigned int phase ) {
       req->dest                                    = SST::Interfaces::SimpleNetwork::INIT_BROADCAST_ADDR;
       req->src                                     = iFace->getEndpointID();
       req->givePayload( ev );
-      iFace->sendInitData( req );
+
+      //iFace->sendInitData( req );  // removed for SST 14.0.0
+      iFace->sendUntimedData( req );
     }
   }
-
-  while( SST::Interfaces::SimpleNetwork::Request* req = iFace->recvInitData() ) {
+  //while( SST::Interfaces::SimpleNetwork::Request* req = iFace->recvInitData() ) {
+  while( SST::Interfaces::SimpleNetwork::Request* req = iFace->recvUntimedData() ) {  // SST 14.0.0
     nicEvent* ev = static_cast<nicEvent*>( req->takePayload() );
     numDest++;
     output->verbose( CALL_INFO, 1, 0, "%s received init message from %s\n", getName().c_str(), ev->getSource().c_str() );


### PR DESCRIPTION
This PR is to track changes related to updating REV to support the latest SST release v14.0.0.  The current release notes identify deprecated functions that may affect REV.

Removed previously deprecated functions: Link::sendInitData(), Link::recvInitData(), SimpleNetwork::sendInitData(), SimpleNetwork::recvInitData() and BaseComponent::getSimulation() have been removed.

The SST_ELI_REGISTER_SUBCOMPONENT_DERIVED and SST_ELI_REGISTER_MODULE_DERIVED macros are removed

The SimpleMem interface is removed. Use the StandardMem interface instead.

The Event::Handler and Clock::Handler handler types are deprecated in favor of Event::Handler2 and Clock::Handler2. The new types support checkpoint/restart. 

The release notes are located here:
https://sst-simulator.org/SSTPages/SSTmicroRelease_V14dot0dot0/ ) 
