### PR TITLE
Refactor the performance counters code

### DIFF
--- a/include/insns/Zicsr.h
+++ b/include/insns/Zicsr.h
@@ -23,21 +23,7 @@ class Zicsr : public RevExt {
   /// Modify a CSR Register according to CSRRW, CSRRS, or CSRRC
   // Because CSR has a 32/64-bit width, this function is templatized
   template<typename XLEN, OpKind OPKIND, CSROp OP>
-  static bool ModCSRImpl( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-
-    // Alternative forms of rdcycle[h], rdtime[h], rdinstret[h] which use an immediate 0 or csrrc
-    // Canonical forms of rdcycle[h], rdtime[h], rdinstret[h] use csrrs with register x0
-    if( OP != CSROp::Write && Inst.rs1 == 0 ) {
-      switch( Inst.imm ) {
-      case 0xc00: return rdcycle( F, R, M, Inst );
-      case 0xc80: return rdcycleh( F, R, M, Inst );
-      case 0xc01: return rdtime( F, R, M, Inst );
-      case 0xc81: return rdtimeh( F, R, M, Inst );
-      case 0xc02: return rdinstret( F, R, M, Inst );
-      case 0xc82: return rdinstreth( F, R, M, Inst );
-      }
-    }
-
+  static bool ModCSRImpl( RevRegFile* R, const RevInst& Inst ) {
     XLEN old = 0;
 
     // CSRRW with rd == zero does not read CSR
@@ -81,7 +67,7 @@ class Zicsr : public RevExt {
   // This calls the 32/64-bit ModCSR depending on the current XLEN
   template<OpKind OPKIND, CSROp OP>
   static bool ModCSR( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    return R->IsRV32 ? ModCSRImpl<uint32_t, OPKIND, OP>( F, R, M, Inst ) : ModCSRImpl<uint64_t, OPKIND, OP>( F, R, M, Inst );
+    return R->IsRV32 ? ModCSRImpl<uint32_t, OPKIND, OP>( R, Inst ) : ModCSRImpl<uint64_t, OPKIND, OP>( R, Inst );
   }
 
   static constexpr auto& csrrw  = ModCSR<OpKind::Reg, CSROp::Write>;
@@ -90,53 +76,6 @@ class Zicsr : public RevExt {
   static constexpr auto& csrrwi = ModCSR<OpKind::Imm, CSROp::Write>;
   static constexpr auto& csrrsi = ModCSR<OpKind::Imm, CSROp::Set>;
   static constexpr auto& csrrci = ModCSR<OpKind::Imm, CSROp::Clear>;
-
-  // Performance counters
-  // TODO: These should be moved to a separate Zicntr extension, but right now the
-  // spec is unclear on what order Zicntr should appear in an architecture string
-
-  // template is used to break circular dependencies and allow for an incomplete RevCore type now
-  template<typename T, typename = std::enable_if_t<std::is_same_v<T, RevRegFile>>>
-  static uint64_t rdcycleImpl( RevFeature* F, T* R, RevMem* M, const RevInst& Inst ) {
-    return R->Core->GetCycles();
-  }
-
-  template<typename T, typename = std::enable_if_t<std::is_same_v<T, RevRegFile>>>
-  static uint64_t rdtimeImpl( RevFeature* F, T* R, RevMem* M, const RevInst& Inst ) {
-    return R->Core->GetCurrentSimCycle();
-  }
-
-  static uint64_t rdinstretImpl( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) { return R->GetInstRet(); }
-
-  enum Half { Lo, Hi };
-
-  /// Performance Counter template
-  // Passed a function which gets the 64-bit value of a performance counter
-  template<Half HALF, uint64_t COUNTER( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )>
-  static bool perfCounter( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    if( R->IsRV32 ) {
-      if constexpr( HALF == Lo ) {
-        R->SetX( Inst.rd, static_cast<uint32_t>( COUNTER( F, R, M, Inst ) & 0xffffffff ) );
-      } else {
-        R->SetX( Inst.rd, static_cast<uint32_t>( COUNTER( F, R, M, Inst ) >> 32 ) );
-      }
-    } else {
-      if constexpr( HALF == Lo ) {
-        R->SetX( Inst.rd, COUNTER( F, R, M, Inst ) );
-      } else {
-        return false;  // Hi half is not available on RV64
-      }
-    }
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static constexpr auto& rdcycle    = perfCounter<Lo, rdcycleImpl>;
-  static constexpr auto& rdcycleh   = perfCounter<Hi, rdcycleImpl>;
-  static constexpr auto& rdtime     = perfCounter<Lo, rdtimeImpl>;
-  static constexpr auto& rdtimeh    = perfCounter<Hi, rdtimeImpl>;
-  static constexpr auto& rdinstret  = perfCounter<Lo, rdinstretImpl>;
-  static constexpr auto& rdinstreth = perfCounter<Hi, rdinstretImpl>;
 
   // ----------------------------------------------------------------------
   //
@@ -178,12 +117,12 @@ class Zicsr : public RevExt {
     { RevZicsrInstDefaults().SetMnemonic( "csrrci %rd, %csr, $imm" ).SetFunct3( 0b111 ).SetImplFunc( csrrci     ).SetPredicate( []( uint32_t Inst ){ return DECODE_RD( Inst ) != 0; } ) },
     { RevZicsrInstDefaults().SetMnemonic( "csrci %csr, $imm"       ).SetFunct3( 0b111 ).SetImplFunc( csrrci     ).SetPredicate( []( uint32_t Inst ){ return DECODE_RD( Inst ) == 0; } ) },
 
-    { RevZicsrInstDefaults().SetMnemonic( "rdcycle %rd"            ).SetFunct3( 0b010 ).SetImplFunc( rdcycle    ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc00; } ) },
-    { RevZicsrInstDefaults().SetMnemonic( "rdcycleh %rd"           ).SetFunct3( 0b010 ).SetImplFunc( rdcycleh   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc80; } ) },
-    { RevZicsrInstDefaults().SetMnemonic( "rdtime %rd"             ).SetFunct3( 0b010 ).SetImplFunc( rdtime     ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc01; } ) },
-    { RevZicsrInstDefaults().SetMnemonic( "rdtimeh %rd"            ).SetFunct3( 0b010 ).SetImplFunc( rdtimeh    ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc81; } ) },
-    { RevZicsrInstDefaults().SetMnemonic( "rdinstret %rd"          ).SetFunct3( 0b010 ).SetImplFunc( rdinstret  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc02; } ) },
-    { RevZicsrInstDefaults().SetMnemonic( "rdinstreth %rd"         ).SetFunct3( 0b010 ).SetImplFunc( rdinstreth ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc82; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdcycle %rd"            ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc00; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdcycleh %rd"           ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc80; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdtime %rd"             ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc01; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdtimeh %rd"            ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc81; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdinstret %rd"          ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc02; } ) },
+    { RevZicsrInstDefaults().SetMnemonic( "rdinstreth %rd"         ).SetFunct3( 0b010 ).SetImplFunc( csrrs      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 0 && DECODE_IMM12( Inst ) == 0xc82; } ) },
   };
   // clang-format on
 


### PR DESCRIPTION
Refactor the performance counters code so that the operation of reading a performance counter is separate and orthogonal to the `CSRRW`, `CSRRS`, and `CSRRC` instructions.

This cuts down on the code needed, since the `CSRRW`, `CSRRS`, and `CSRRC `instructions operate the same for all CSR registers, and the `RevRegFile` handles CSRs with special meanings through its `GetCSR()` and `SetCSR()` functions.
