### PR TITLE
Fix stack and thread local storage allocation

### DIFF
--- a/include/RevCPU.h
+++ b/include/RevCPU.h
@@ -235,9 +235,6 @@ private:
   // - Handles updating LSQueue & MarkLoadComplete function pointers
   void AssignThread( std::unique_ptr<RevThread>&& ThreadToAssign, unsigned ProcID );
 
-  // Sets up arguments for a thread with a given ID and feature set.
-  void SetupArgs( const std::unique_ptr<RevRegFile>& RegFile );
-
   // Checks the status of ALL threads that are currently blocked.
   void CheckBlockedThreads();
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -45,6 +45,7 @@ inline void BoxNaN( double* dest, const float* value ) {
 enum class RevReg : uint16_t {
   zero =  0, ra  =  1, sp   =  2, gp   =  3, tp  =  4, t0  =  5, t1   =  6, t2   =  7,
   s0   =  8, s1  =  9, a0   = 10, a1   = 11, a2  = 12, a3  = 13, a4   = 14, a5   = 15,
+  fp   =  8,
   a6   = 16, a7  = 17, s2   = 18, s3   = 19, s4  = 20, s5  = 21, s6   = 22, s7   = 23,
   s8   = 24, s9  = 25, s10  = 26, s11  = 27, t3  = 28, t4  = 29, t5   = 30, t6   = 31,
   ft0  =  0, ft1 =  1, ft2  =  2, ft3  =  3, ft4 =  4, ft5 =  5, ft6  =  6, ft7  =  7,

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -478,8 +478,8 @@ bool RevLoader::LoadProgramArgs( const std::string& exe, const std::vector<std::
   //
   // Each string that argv[i] points to starts at an address which is a multiple of XLEN.
   //
-  // Finally, in RevCPU::SetupArgs(), we initialize the a0 register to the value of argc
-  // and the a1 register to the base pointer to argv.
+  // Finally, in RevCPU::InitMainThread(), we initialize the a0 register to the value of
+  // argc and the a1 register to the base pointer to argv.
   // -------------- END MEMORY LAYOUT NOTES
 
   // Allocate sizeof(XLEN) bytes for each of the argv[] pointers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -230,6 +230,7 @@ add_rev_test(ARGC_SHORT argc_short 30 "test_level=2;memh;rv64;loader;" SCRIPT "r
 add_rev_test(ARGV argv 30 "test_level=2;memh;rv64;loader;c++" SCRIPT "run_argv.sh")
 add_rev_test(ARGV_layout argv_layout 30 "test_level=2;memh;rv32;loader;" SCRIPT "run_argv_layout.sh")
 add_rev_test(ARGV_limit argv_limit 75 "test_level=2;memh;rv32;loader;" SCRIPT "run_argv_limit.sh")
+add_rev_test(ARGV_stack argv_stack 10 "memh;rv64")
 add_rev_test(COPROC_EX coproc_ex 30 "memh;rv64;coproc" SCRIPT "run_coproc_ex.sh")
 
 if(TEST_LEVEL GREATER_EQUAL 2)

--- a/test/argv_stack/Makefile
+++ b/test/argv_stack/Makefile
@@ -1,0 +1,25 @@
+#
+# Makefile
+#
+# makefile: argv_stack
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+.PHONY: src
+
+EXAMPLE=argv_stack
+CC=${RVCC}
+ARCH=rv64imafdc
+
+all: $(EXAMPLE).exe
+$(EXAMPLE).exe: $(EXAMPLE).c
+	$(CC) -march=$(ARCH) -O3 -static -o $(EXAMPLE).exe $(EXAMPLE).c
+clean:
+	rm -Rf $(EXAMPLE).exe
+
+#-- EOF

--- a/test/argv_stack/argv_stack.c
+++ b/test/argv_stack/argv_stack.c
@@ -1,0 +1,17 @@
+/*
+ * argv_stack.c
+ *
+ * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+ * All Rights Reserved
+ * contact@tactcomplabs.com
+ *
+ * See LICENSE in the top level directory for licensing details
+ *
+ */
+
+int main( int argc, char** argv ) {
+  char a[1024];
+  if( a + sizeof( a ) > (char*) argv )
+    asm( ".word 0" );
+  return 0;
+}


### PR DESCRIPTION
The current code computes the stack pointer `sp` incorrectly. It does not guarantee it's on a 16-byte boundary, and it does not calculate the size correctly, using `Mem->GetThreadMemSegs().front()->getTopAddr()` instead of `Mem->GetStackTop()`.

The stack pointer `sp` grows downward. The thread local storage is accessed with nonnegative offsets from `tp`.

We compute the `StackTop - TLSSize` and round it down to a multiple of 16 bytes. `sp` and `tp` are both set to this address.
