### PR TITLE
Add support for extension versions

### DIFF
--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -35,10 +35,10 @@ enum RevFeatureType : uint32_t {
   RV_P        = 1 << 9,   ///< RevFeatureType: P-Extension
   RV_V        = 1 << 10,  ///< RevFeatureType: V-extension
   RV_H        = 1 << 11,  ///< RevFeatureType: H-extension
-  RV_ZICSR    = 1 << 12,  ///< RevFEatureType: Zicsr-extension
-  RV_ZIFENCEI = 1 << 13,  ///< RevFeatureType: Zifencei-extension
-  RV_ZFA      = 1 << 14,  ///< RevFeatureType: Zfa-extension
-  RV_ZICBOM   = 1 << 15,  ///< RevFeatureType: Zicbom-extension
+  RV_ZICBOM   = 1 << 12,  ///< RevFeatureType: Zicbom-extension
+  RV_ZICSR    = 1 << 13,  ///< RevFEatureType: Zicsr-extension
+  RV_ZIFENCEI = 1 << 14,  ///< RevFeatureType: Zifencei-extension
+  RV_ZFA      = 1 << 15,  ///< RevFeatureType: Zfa-extension
   RV_ZFH      = 1 << 16,  ///< RevFeatureType: H-extension
   RV_ZFHMIN   = 1 << 17,  ///< RevFeatureRtpe: Zfhmin extension
   RV_ZTSO     = 1 << 18,  ///< RevFeatureType: Ztso-extension

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -23,22 +23,25 @@ namespace SST::RevCPU {
 /// ORed to indicate multiple extensions being present.
 enum RevFeatureType : uint32_t {
   RV_UNKNOWN  = 0,        ///< RevFeatureType: unknown feature
-  RV_E        = 1 << 0,   ///< RevFeatureType: E-extension
-  RV_I        = 1 << 1,   ///< RevFeatureType: I-extension
+  RV_I        = 1 << 0,   ///< RevFeatureType: I-extension
+  RV_E        = 1 << 1,   ///< RevFeatureType: E-extension
   RV_M        = 1 << 2,   ///< RevFeatureType: M-extension
   RV_A        = 1 << 3,   ///< RevFeatureType: A-extension
   RV_F        = 1 << 4,   ///< RevFeatureType: F-extension
   RV_D        = 1 << 5,   ///< RevFeatureType: D-extension
   RV_Q        = 1 << 6,   ///< RevFeatureType: Q-extension
   RV_C        = 1 << 7,   ///< RevFeatureType: C-extension
-  RV_P        = 1 << 8,   ///< RevFeatureType: P-Extension
-  RV_V        = 1 << 9,   ///< RevFeatureType: V-extension
-  RV_H        = 1 << 10,  ///< RevFeatureType: H-extension
-  RV_ZICSR    = 1 << 11,  ///< RevFEatureType: Zicsr-extension
-  RV_ZIFENCEI = 1 << 12,  ///< RevFeatureType: Zifencei-extension
-  RV_ZTSO     = 1 << 13,  ///< RevFeatureType: Ztso-extension
+  RV_B        = 1 << 8,   ///< RevFeatureType: C-extension
+  RV_P        = 1 << 9,   ///< RevFeatureType: P-Extension
+  RV_V        = 1 << 10,  ///< RevFeatureType: V-extension
+  RV_H        = 1 << 11,  ///< RevFeatureType: H-extension
+  RV_ZICSR    = 1 << 12,  ///< RevFEatureType: Zicsr-extension
+  RV_ZIFENCEI = 1 << 13,  ///< RevFeatureType: Zifencei-extension
   RV_ZFA      = 1 << 14,  ///< RevFeatureType: Zfa-extension
   RV_ZICBOM   = 1 << 15,  ///< RevFeatureType: Zicbom-extension
+  RV_ZFH      = 1 << 16,  ///< RevFeatureType: H-extension
+  RV_ZFHMIN   = 1 << 17,  ///< RevFeatureRtpe: Zfhmin extension
+  RV_ZTSO     = 1 << 18,  ///< RevFeatureType: Ztso-extension
 };
 
 class RevFeature {

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -68,12 +68,12 @@ bool RevFeature::ParseMachineModel() {
     { "P",          0, 2, -1, 0, RV_P                                                      }, // Unsupported
     { "V",          1, 0, -1, 0, RV_V | RV_D | RV_F | RV_ZICSR                             },
     { "H",          1, 0, -1, 0, RV_H                                                      }, // Unsupported
+    { "Zicbom",     1, 0,  1, 1, RV_ZICBOM                                                 },
     { "Zicsr",      2, 0,  2, 2, RV_ZICSR                                                  },
     { "Zifencei",   2, 0,  2, 2, RV_ZIFENCEI                                               },
-    { "Zfa",        1, 0,  1, 1, RV_ZFA | RV_F | RV_ZICSR                                  },
-    { "Zicbom",     1, 0,  1, 1, RV_ZICBOM                                                 },
-    { "Zfhmin",     1, 0, -1, 0, RV_ZFHMIN | RV_F | RV_ZICSR                               }, // Unsupported
+    { "Zfa",        1, 0, -1, 0, RV_ZFA | RV_F | RV_ZICSR                                  }, // Unsupported
     { "Zfh",        1, 0, -1, 0, RV_ZFH | RV_ZFHMIN | RV_F | RV_ZICSR                      }, // Unsupported
+    { "Zfhmin",     1, 0, -1, 0, RV_ZFHMIN | RV_F | RV_ZICSR                               }, // Unsupported
     { "Ztso",       1, 0, -1, 0, RV_ZTSO                                                   }, // Unsupported
   };
   // clang-format on

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -40,6 +40,7 @@ bool RevFeature::ParseMachineModel() {
   output->verbose( CALL_INFO, 6, 0, "Core %u ; Setting XLEN to %u\n", ProcID, xlen );
   output->verbose( CALL_INFO, 6, 0, "Core %u ; Architecture string=%s\n", ProcID, mac );
 
+  // clang-format off
   ///< List of architecture extensions. These must listed in canonical order
   ///< as shown in Table 27.11, Chapter 27, of the RISC-V Unprivileged Spec
   ///< (Table 74 of Chapter 36 in the 2024 version).
@@ -48,34 +49,39 @@ bool RevFeature::ParseMachineModel() {
   ///< in linear time complexity of the table and the string. Some of the
   ///< extensions imply other extensions, so the extension flags are ORed.
   ///<
-  ///< The second and third values are the major version range that Rev supports.
+  ///< The second and third values are the major and minor default version.
+  ///< The fourth and fifth values are the major version range that Rev supports.
+  ///< Values of -1, 0 for the fourth and fifth values indicates no Rev support yet.
   ///<
-  // clang-format off
-  static constexpr std::tuple<std::string_view, uint32_t, uint32_t, uint32_t> table[] = {
-    { "I",          1, -1, RV_I                                                      },
-    { "E",          1, -1, RV_E                                                      },
-    { "M",          1, -1, RV_M                                                      },
-    { "A",          1, -1, RV_A                                                      },
-    { "F",          1, -1, RV_F | RV_ZICSR                                           },
-    { "D",          1, -1, RV_D | RV_F | RV_ZICSR                                    },
-    { "G",          1, -1, RV_I | RV_M | RV_A | RV_F | RV_D | RV_ZICSR | RV_ZIFENCEI },
-    { "Q",          1, -1, RV_Q | RV_D | RV_F | RV_ZICSR                             },
-    { "C",          1, -1, RV_C                                                      },
-    { "P",          1, -1, RV_P                                                      },
-    { "V",          1, -1, RV_V | RV_D | RV_F | RV_ZICSR                             },
-    { "H",          1, -1, RV_H                                                      },
-    { "Zicsr",      1, -1, RV_ZICSR                                                  },
-    { "Zifencei",   1, -1, RV_ZIFENCEI                                               },
-    { "Ztso",       1, -1, RV_ZTSO                                                   },
-    { "Zfa",        1, -1, RV_ZFA | RV_F | RV_ZICSR                                  },
-    { "Zicbom",     1, -1, RV_ZICBOM                                                 },
+  ///< ExtensionName DefaultMajor DefaultMinor MinSupportedVersion MaxSupportedVersion Flags
+  static constexpr std::tuple<std::string_view, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> table[] = {
+    { "I",          2, 1,  2, 2, RV_I                                                      },
+    { "E",          2, 0, -1, 0, RV_E                                                      }, // Unsupported
+    { "M",          2, 0,  2, 2, RV_M                                                      },
+    { "A",          2, 1,  2, 2, RV_A                                                      },
+    { "F",          2, 2,  2, 2, RV_F | RV_ZICSR                                           },
+    { "D",          2, 2,  2, 2, RV_D | RV_F | RV_ZICSR                                    },
+    { "G",          2, 0,  2, 2, RV_I | RV_M | RV_A | RV_F | RV_D | RV_ZICSR | RV_ZIFENCEI },
+    { "Q",          2, 2, -1, 0, RV_Q | RV_D | RV_F | RV_ZICSR                             }, // Unsupported
+    { "C",          2, 0,  2, 2, RV_C                                                      },
+    { "B",          1, 0, -1, 0, RV_B                                                      }, // Unsupported
+    { "P",          0, 2, -1, 0, RV_P                                                      }, // Unsupported
+    { "V",          1, 0, -1, 0, RV_V | RV_D | RV_F | RV_ZICSR                             },
+    { "H",          1, 0, -1, 0, RV_H                                                      }, // Unsupported
+    { "Zicsr",      2, 0,  2, 2, RV_ZICSR                                                  },
+    { "Zifencei",   2, 0,  2, 2, RV_ZIFENCEI                                               },
+    { "Zfa",        1, 0,  1, 1, RV_ZFA | RV_F | RV_ZICSR                                  },
+    { "Zicbom",     1, 0,  1, 1, RV_ZICBOM                                                 },
+    { "Zfhmin",     1, 0, -1, 0, RV_ZFHMIN | RV_F | RV_ZICSR                               }, // Unsupported
+    { "Zfh",        1, 0, -1, 0, RV_ZFH | RV_ZFHMIN | RV_F | RV_ZICSR                      }, // Unsupported
+    { "Ztso",       1, 0, -1, 0, RV_ZTSO                                                   }, // Unsupported
   };
   // clang-format on
 
   // -- step 2: parse all the features
   // Note: Extension strings, if present, must appear in the order listed in the table above.
   if( *mac ) {
-    for( const auto& [ext, minimumVersion, maximumVersion, flags] : table ) {
+    for( auto [ext, majorVersion, minorVersion, minimumVersion, maximumVersion, flags] : table ) {
       // Look for an architecture string matching the current extension
       if( !strncasecmp( mac, ext.data(), ext.size() ) ) {
 
@@ -86,7 +92,6 @@ bool RevFeature::ParseMachineModel() {
         mac += ext.size();
 
         // Optional version string follows extension
-        unsigned long majorVersion = 2, minorVersion = 0;
         if( isdigit( *mac ) ) {
           majorVersion = strtoul( mac, const_cast<char**>( &mac ), 10 );
           if( tolower( *mac ) == 'p' && isdigit( *++mac ) )
@@ -95,7 +100,12 @@ bool RevFeature::ParseMachineModel() {
 
         if( majorVersion < minimumVersion || majorVersion > maximumVersion ) {
           output->fatal(
-            CALL_INFO, -1, "Error: Version %lu.%lu of %s extension is not supported\n", majorVersion, minorVersion, ext.data()
+            CALL_INFO,
+            -1,
+            "Error: Version %" PRIu32 ".%" PRIu32 " of %s extension is not supported\n",
+            majorVersion,
+            minorVersion,
+            ext.data()
           );
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,6 +204,7 @@ endif()
 endmacro()
 
 # add_rev_test(test_name test_dir timeout labels)
+add_rev_test(EXT_VERSION ext_version 20 "rv64")
 add_rev_test(EX1 ex1 30 "memh;rv32")
 add_rev_test(EX2 ex2 30 "memh;rv64")
 add_rev_test(EX3 ex3 30 "memh;rv32")

--- a/test/ext_version/Makefile
+++ b/test/ext_version/Makefile
@@ -1,0 +1,25 @@
+#
+# Makefile
+#
+# makefile: ext_version
+#
+# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+.PHONY: src
+
+EXAMPLE=ext_version
+CC=${RVCC}
+ARCH=rv64imafdc
+
+all: $(EXAMPLE).exe
+$(EXAMPLE).exe: $(EXAMPLE).c
+	$(CC) -march=$(ARCH) -O3 -static -o $(EXAMPLE).exe $(EXAMPLE).c
+clean:
+	rm -Rf $(EXAMPLE).exe
+
+#-- EOF

--- a/test/ext_version/ext_version.c
+++ b/test/ext_version/ext_version.c
@@ -1,0 +1,3 @@
+int main( void ) {
+  return 0;
+}

--- a/test/ext_version/run_ext_version.sh
+++ b/test/ext_version/run_ext_version.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+make clean
+make
+
+# Unknown extension
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:RV64XGC]" 2>&1 | grep -q 'Error: failed to parse the machine model: RV64XGC'
+
+# Out of order extension
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:RV64GVC]" 2>&1 | grep -q 'Error: failed to parse the machine model: RV64GVC'
+
+# Incomplete version string
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:RV64XGC2P]" 2>&1 | grep -q 'Error: failed to parse the machine model: RV64XGC2P'
+
+# Unsupported version
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:RV64GCV0p7]" 2>&1 | grep -q 'Error: Version 0.7 of V extension is not supported'
+
+# Supported version
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:rv64i2p0m2a2p0fd2p0c]" 2>&1 | grep -q 'Simulation is complete'
+
+# Supported version
+sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "ext_version.exe" --args "one" --enableMemH=0 --machine="[CORES:rv64i2p0m2a2p0fd2p0c2_p]" 2>&1 | grep -q 'Simulation is complete'
+
+echo 'Simulation is complete'


### PR DESCRIPTION
In [V2.0 of the RISC-V Specification](https://github.com/riscv/riscv-isa-manual/releases/tag/20240411), optional version strings after extension names were added (see **Chapter 39**).

The optional version strings are of the form: `nnn` [ `p` `nnn` ] with major and minor version numbers. Two versions of an extension ISA are considered compatible if their major version numbers are the same.

If the minor version is omitted, it is assumed to be `0`.

If the version string is omitted, it is assumed to be  the version of the extension when this version string feature was added.

If the `P` extension must follow another extension with a major but not minor version number, an underscore character must separate the version number and `P`.

This PR improves the `RevFeature` parser to support optional version strings in the architecture string, and to specify a range of versions which Rev supports.

Right now for supported extensions, the range is `[n,n]` where `n` is the default major version number. For unsupported extensions, the range is `[-1,0]`. There is a test case which validates that `V0p7` is not supported, so that if Vector support is ever added, Rev will display an error message if the `0.7` version of the Vector spec is requested (because once supported, the lower bound for `V` would be `1`).

Right now version numbers are only parsed and checked for support; they are not stored anywhere so that we could support multiple versions of an extension, but that could be added later.