### PR TITLE
Fully templatize floating-point helper functions

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -34,6 +34,8 @@
 
 namespace SST::RevCPU {
 
+using float16 = _Float16;
+
 /// Zero-extend value of bits size
 template<typename T>
 constexpr auto ZeroExt( T val, size_t bits ) {

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -44,69 +44,33 @@ class RV32D : public RevExt {
   static constexpr auto& fled    = fcondop<double, std::less_equal>;
 
   // FP to Integer Conversion instructions
-  static constexpr auto& fcvtwd  = CvtFpToInt<double, int32_t>;
-  static constexpr auto& fcvtwud = CvtFpToInt<double, uint32_t>;
+  static constexpr auto& fcvtwd  = fcvtif<int32_t, double>;
+  static constexpr auto& fcvtwud = fcvtif<uint32_t, double>;
 
-  static bool fsqrtd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::sqrt( R->GetFP<double>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Square root
+  static constexpr auto& fsqrtd  = fsqrt<double>;
 
-  static bool fsgnjd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::copysign( R->GetFP<double>( Inst.rs1 ), R->GetFP<double>( Inst.rs2 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Sign transfer
+  static constexpr auto& fsgnjd  = fsgnj<double>;
+  static constexpr auto& fsgnjnd = fsgnjn<double>;
+  static constexpr auto& fsgnjxd = fsgnjx<double>;
 
-  static bool fsgnjnd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::copysign( R->GetFP<double>( Inst.rs1 ), -R->GetFP<double>( Inst.rs2 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Conversions between single and double precision FP
+  static constexpr auto& fcvtsd  = fcvtff<float, double>;
+  static constexpr auto& fcvtds  = fcvtff<double, float>;
 
-  static bool fsgnjxd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    double rs1 = R->GetFP<double>( Inst.rs1 ), rs2 = R->GetFP<double>( Inst.rs2 );
-    R->SetFP( Inst.rd, std::copysign( rs1, std::signbit( rs1 ) ? -rs2 : rs2 ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // FP Classify
+  static constexpr auto& fclassd = fclassify<double>;
 
-  static bool fcvtsd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<float>( R->GetFP<double>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtds( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<double>( R->GetFP<float>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fclassd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetX( Inst.rd, fclass( R->GetFP<double>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtdw( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<double>( R->GetX<int32_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtdwu( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<double>( R->GetX<uint32_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Conversion from integer to double
+  static constexpr auto& fcvtdw  = fcvtfi<double, int32_t>;
+  static constexpr auto& fcvtdwu = fcvtfi<double, uint32_t>;
 
   // Compressed instructions
-  static constexpr auto& cfldsp = fld;
-  static constexpr auto& cfsdsp = fsd;
-  static constexpr auto& cfld   = fld;
-  static constexpr auto& cfsd   = fsd;
+  static constexpr auto& cfldsp  = fld;
+  static constexpr auto& cfsdsp  = fsd;
+  static constexpr auto& cfld    = fld;
+  static constexpr auto& cfsd    = fsd;
 
   // ----------------------------------------------------------------------
   //

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -44,77 +44,33 @@ class RV32F : public RevExt {
   static constexpr auto& fles    = fcondop<float, std::less_equal>;
 
   // FP to Integer Conversion instructions
-  static constexpr auto& fcvtws  = CvtFpToInt<float, int32_t>;
-  static constexpr auto& fcvtwus = CvtFpToInt<float, uint32_t>;
+  static constexpr auto& fcvtws  = fcvtif<int32_t, float>;
+  static constexpr auto& fcvtwus = fcvtif<uint32_t, float>;
 
-  static bool fsqrts( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::sqrt( R->GetFP<float>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Square root
+  static constexpr auto& fsqrts  = fsqrt<float>;
 
-  static bool fsgnjs( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::copysign( R->GetFP<float>( Inst.rs1 ), R->GetFP<float>( Inst.rs2 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Sign transfer
+  static constexpr auto& fsgnjs  = fsgnj<float>;
+  static constexpr auto& fsgnjns = fsgnjn<float>;
+  static constexpr auto& fsgnjxs = fsgnjx<float>;
 
-  static bool fsgnjns( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, std::copysign( R->GetFP<float>( Inst.rs1 ), -R->GetFP<float>( Inst.rs2 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Transfers between integer and FP registers
+  static constexpr auto& fmvxw   = fmvif<float>;
+  static constexpr auto& fmvwx   = fmvfi<float>;
 
-  static bool fsgnjxs( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    float rs1 = R->GetFP<float>( Inst.rs1 ), rs2 = R->GetFP<float>( Inst.rs2 );
-    R->SetFP( Inst.rd, std::copysign( rs1, std::signbit( rs1 ) ? -rs2 : rs2 ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // FP classification
+  static constexpr auto& fclasss = fclassify<float>;
 
-  static bool fmvxw( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    int32_t i32;
-    float   fp32 = R->GetFP<float, true>( Inst.rs1 );  // The FP32 value
-    static_assert( sizeof( i32 ) == sizeof( fp32 ) );
-    memcpy( &i32, &fp32, sizeof( i32 ) );  // Reinterpreted as int32_t
-    R->SetX( Inst.rd, i32 );               // Copied to the destination register
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fmvwx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    float fp32;
-    auto  i32 = R->GetX<int32_t>( Inst.rs1 );  // The X register as a 32-bit value
-    static_assert( sizeof( i32 ) == sizeof( fp32 ) );
-    memcpy( &fp32, &i32, sizeof( fp32 ) );  // Reinterpreted as float
-    R->SetFP( Inst.rd, fp32 );              // Copied to the destination register
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fclasss( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetX( Inst.rd, fclass( R->GetFP<float>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtsw( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<float>( R->GetX<int32_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtswu( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<float>( R->GetX<uint32_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Conversion from integer to float
+  static constexpr auto& fcvtsw  = fcvtfi<float, int32_t>;
+  static constexpr auto& fcvtswu = fcvtfi<float, uint32_t>;
 
   // Compressed instructions
-  static constexpr auto& cflwsp = flw;
-  static constexpr auto& cfswsp = fsw;
-  static constexpr auto& cflw   = flw;
-  static constexpr auto& cfsw   = fsw;
+  static constexpr auto& cflwsp  = flw;
+  static constexpr auto& cfswsp  = fsw;
+  static constexpr auto& cflw    = flw;
+  static constexpr auto& cfsw    = fsw;
 
   // ----------------------------------------------------------------------
   //

--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -20,38 +20,17 @@
 namespace SST::RevCPU {
 
 class RV64D : public RevExt {
-  static constexpr auto& fcvtld  = CvtFpToInt<double, int64_t>;
-  static constexpr auto& fcvtlud = CvtFpToInt<double, uint64_t>;
+  // Conversion from double to integer
+  static constexpr auto& fcvtld  = fcvtif<int64_t, double>;
+  static constexpr auto& fcvtlud = fcvtif<uint64_t, double>;
 
-  static bool fcvtdl( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<double>( R->GetX<int64_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Conversion from integer to double
+  static constexpr auto& fcvtdl  = fcvtfi<double, int64_t>;
+  static constexpr auto& fcvtdlu = fcvtfi<double, uint64_t>;
 
-  static bool fcvtdlu( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<double>( R->GetX<uint64_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fmvxd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    uint64_t u64;
-    double   fp = R->GetFP<double, true>( Inst.rs1 );
-    memcpy( &u64, &fp, sizeof( u64 ) );
-    R->SetX( Inst.rd, u64 );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fmvdx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    uint64_t u64 = R->GetX<uint64_t>( Inst.rs1 );
-    double   fp;
-    memcpy( &fp, &u64, sizeof( fp ) );
-    R->SetFP( Inst.rd, fp );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  // Moves between FP and integer registers
+  static constexpr auto& fmvxd   = fmvif<double>;
+  static constexpr auto& fmvdx   = fmvfi<double>;
 
   // ----------------------------------------------------------------------
   //

--- a/include/insns/RV64F.h
+++ b/include/insns/RV64F.h
@@ -20,20 +20,10 @@
 namespace SST::RevCPU {
 
 class RV64F : public RevExt {
-  static constexpr auto& fcvtls  = CvtFpToInt<float, int64_t>;
-  static constexpr auto& fcvtlus = CvtFpToInt<float, uint64_t>;
-
-  static bool fcvtsl( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<float>( R->GetX<int64_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
-
-  static bool fcvtslu( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetFP( Inst.rd, static_cast<float>( R->GetX<uint64_t>( Inst.rs1 ) ) );
-    R->AdvancePC( Inst );
-    return true;
-  }
+  static constexpr auto& fcvtls  = fcvtif<int64_t, float>;
+  static constexpr auto& fcvtlus = fcvtif<uint64_t, float>;
+  static constexpr auto& fcvtsl  = fcvtfi<float, int64_t>;
+  static constexpr auto& fcvtslu = fcvtfi<float, uint64_t>;
 
   // ----------------------------------------------------------------------
   //


### PR DESCRIPTION
This fully templatizes the floating-point helper functions. Previously, the short ones were written explicitly in `include/insns/*.h`. Now all of them are instantiations of floating-point helper template functions, in preparation for `float16` and `bfloat16`  support. This also improves test coverage by making `float` and `double` instructions use the same code.

`UnBoxNaN` performs the opposite of the existing `BoxNaN`, so that the `GetFP()` function is much simpler. It is also fully templatized so that it can support `float16` and `bfloat16` in the future.

`CvtFpToInt` was renamed to `fcvtif` to resemble the naming scheme for instructions, where the destination type and register (integer) is listed first, and the source type and register (float) is listed second. The template parameters indicating the source and destination types are listed in the same order.