### PR TITLE
Make feature pointers pointers to const RevFeature

### DIFF
--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -76,20 +76,20 @@ public:
   // --------------------
 
   /// RevCoProc: Instruction interface to RevCore
-  virtual bool IssueInst( RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst ) = 0;
+  virtual bool IssueInst( const RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst ) = 0;
 
   /// ReCoProc: Reset - called on startup
-  virtual bool Reset()                                                             = 0;
+  virtual bool Reset()                                                                   = 0;
 
   /// RevCoProc: Teardown - called when associated RevCore completes
-  virtual bool Teardown()                                                          = 0;
+  virtual bool Teardown()                                                                = 0;
 
   /// RevCoProc: Clock - can be called by SST or by overriding RevCPU
-  virtual bool ClockTick( SST::Cycle_t cycle )                                     = 0;
+  virtual bool ClockTick( SST::Cycle_t cycle )                                           = 0;
 
   /// RevCoProc: Returns true when co-processor has completed execution
   ///            - used for proper exiting of associated RevCore
-  virtual bool IsDone()                                                            = 0;
+  virtual bool IsDone()                                                                  = 0;
 
 protected:
   SST::Output*   output{};  ///< RevCoProc: sst output object
@@ -150,7 +150,7 @@ public:
   void registerStats();
 
   /// RevSimpleCoProc: Enqueue Inst into the InstQ and return
-  virtual bool IssueInst( RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst );
+  virtual bool IssueInst( const RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst );
 
   /// RevSimpleCoProc: Reset the co-processor by emmptying the InstQ
   virtual bool Reset();
@@ -165,12 +165,13 @@ public:
 
 private:
   struct RevCoProcInst {
-    RevCoProcInst( uint32_t inst, RevFeature* F, RevRegFile* R, RevMem* M ) : Inst( inst ), Feature( F ), RegFile( R ), Mem( M ) {}
+    RevCoProcInst( uint32_t inst, const RevFeature* F, RevRegFile* R, RevMem* M )
+      : Inst( inst ), Feature( F ), RegFile( R ), Mem( M ) {}
 
-    uint32_t const    Inst;
-    RevFeature* const Feature;
-    RevRegFile* const RegFile;
-    RevMem* const     Mem;
+    uint32_t const          Inst;
+    const RevFeature* const Feature;
+    RevRegFile* const       RegFile;
+    RevMem* const           Mem;
   };
 
   /// RevSimpleCoProc: Total number of instructions retired

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -183,6 +183,12 @@ public:
   ///< RevCore: Add a co-processor to the RevCore
   void SetCoProc( RevCoProc* coproc );
 
+  /// GetHartToExecID: Retrieve the current executing Hart
+  unsigned GetHartToExecID() const { return HartToExecID; }
+
+  /// SetHartToExecID: Set the current executing Hart
+  void SetHartToExecID( unsigned hart ) { HartToExecID = hart; }
+
   //--------------- External Interface for use with Co-Processor -------------------------
   ///< RevCore: Allow a co-processor to query the bits in scoreboard. Note the RevCorePassKey may only
   ///  be created by a RevCoProc (or a class derived from RevCoProc) so this function may not be called from even within
@@ -303,12 +309,13 @@ private:
   std::vector<std::unique_ptr<RevThread>>
     ThreadsThatChangedState{};  ///< RevCore: used to signal to RevCPU that the thread assigned to HART has changed state
 
-  SST::Output* const             output;       ///< RevCore: output handler
-  std::unique_ptr<RevFeature>    featureUP{};  ///< RevCore: feature handler
-  RevFeature*                    feature{};
-  RevCoreStats                   Stats{};       ///< RevCore: collection of performance stats
-  RevCoreStats                   StatsTotal{};  ///< RevCore: collection of total performance stats
-  std::unique_ptr<RevPrefetcher> sfetch{};      ///< RevCore: stream instruction prefetcher
+  SST::Output* const                output;                       ///< RevCore: output handler
+  std::unique_ptr<RevFeature>       CreateFeature();              ///< RevCore: Create a RevFeature object
+  std::unique_ptr<RevFeature> const featureUP = CreateFeature();  ///< RevCore: feature handler
+  RevFeature* const                 feature   = featureUP.get();  ///< RevCore: raw feature pointer
+  RevCoreStats                      Stats{};                      ///< RevCore: collection of performance stats
+  RevCoreStats                      StatsTotal{};                 ///< RevCore: collection of total performance stats
+  std::unique_ptr<RevPrefetcher>    sfetch{};                     ///< RevCore: stream instruction prefetcher
 
   std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>>
     LSQueue{};  ///< RevCore: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.

--- a/include/RevExt.h
+++ b/include/RevExt.h
@@ -55,13 +55,13 @@ struct RevExt {
   std::string_view GetName() const { return name; }
 
   /// RevExt: baseline execution function
-  bool Execute( unsigned Inst, const RevInst& Payload, uint16_t HartID, RevRegFile* regFile );
+  bool Execute( unsigned Inst, const RevInst& Payload, uint16_t HartID, RevRegFile* regFile ) const;
 
   /// RevExt: retrieves the extension's instruction table
-  const std::vector<RevInstEntry>& GetTable() { return table; }
+  const std::vector<RevInstEntry>& GetTable() const { return table; }
 
   /// RevExt: retrieves the extension's compressed instruction table
-  const std::vector<RevInstEntry>& GetCTable() { return ctable; }
+  const std::vector<RevInstEntry>& GetCTable() const { return ctable; }
 
 private:
   std::string_view const    name;      ///< RevExt: extension name

--- a/include/RevExt.h
+++ b/include/RevExt.h
@@ -31,7 +31,7 @@ namespace SST::RevCPU {
 
 struct RevExt {
   /// RevExt: standard constructor
-  RevExt( std::string_view name, RevFeature* feature, RevMem* mem, SST::Output* output )
+  RevExt( std::string_view name, const RevFeature* feature, RevMem* mem, SST::Output* output )
     : name( name ), feature( feature ), mem( mem ), output( output ) {}
 
   /// RevExt: standard destructor. virtual so that Extensions[i] can be deleted
@@ -65,7 +65,7 @@ struct RevExt {
 
 private:
   std::string_view const    name;      ///< RevExt: extension name
-  RevFeature* const         feature;   ///< RevExt: feature object
+  const RevFeature* const   feature;   ///< RevExt: feature object
   RevMem* const             mem;       ///< RevExt: memory object
   SST::Output* const        output;    ///< RevExt: output handler
   std::vector<RevInstEntry> table{};   ///< RevExt: instruction table

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -46,8 +46,7 @@ enum RevFeatureType : uint32_t {
   RV_ZTSO     = 1 << 20,  ///< RevFeatureType: Ztso-extension
 };
 
-class RevFeature {
-public:
+struct RevFeature {
   /// RevFeature: standard constructor
   RevFeature( std::string Machine, SST::Output* Output, unsigned Min, unsigned Max, unsigned Id );
 
@@ -100,14 +99,14 @@ public:
   void SetHartToExecID( unsigned hart ) { HartToExecID = hart; }
 
 private:
-  std::string    machine{};       ///< RevFeature: feature string
-  SST::Output*   output{};        ///< RevFeature: output handler
-  unsigned       MinCost{};       ///< RevFeature: min memory cost
-  unsigned       MaxCost{};       ///< RevFeature: max memory cost
-  unsigned       ProcID{};        ///< RevFeature: RISC-V Proc ID
-  unsigned       HartToExecID{};  ///< RevFeature: The current executing Hart on RevCore
-  RevFeatureType features{};      ///< RevFeature: feature elements
-  unsigned       xlen{};          ///< RevFeature: RISC-V Xlen
+  const std::string  machine;                 ///< RevFeature: feature string
+  SST::Output* const output;                  ///< RevFeature: output handler
+  const unsigned     MinCost;                 ///< RevFeature: min memory cost
+  const unsigned     MaxCost;                 ///< RevFeature: max memory cost
+  const unsigned     ProcID;                  ///< RevFeature: RISC-V Proc ID
+  unsigned           HartToExecID{};          ///< RevFeature: The current executing Hart on RevCore
+  RevFeatureType     features{ RV_UNKNOWN };  ///< RevFeature: feature elements
+  unsigned           xlen{};                  ///< RevFeature: RISC-V Xlen
 
   /// ParseMachineModel: parse the machine model string
   bool ParseMachineModel();

--- a/include/RevInstHelpers.h
+++ b/include/RevInstHelpers.h
@@ -66,7 +66,7 @@ inline constexpr double fpmin<double, uint64_t> = 0x0p+0;
 /// FP values outside the range of the target integer type are clipped
 /// at the integer type's numerical limits, whether signed or unsigned.
 template<typename INT, typename FP>
-bool fcvtif( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fcvtif( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   // Read the FP register. Round to integer according to current rounding mode.
   FP fp = std::rint( R->GetFP<FP>( Inst.rs1 ) );
 
@@ -132,7 +132,7 @@ uint32_t fclass( T val ) {
 
 /// Load template
 template<typename T>
-bool load( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   if( sizeof( T ) < sizeof( int64_t ) && !R->IsRV64 ) {
     static constexpr RevFlag flags =
       sizeof( T ) < sizeof( int32_t ) ? std::is_signed_v<T> ? RevFlag::F_SEXT32 : RevFlag::F_ZEXT32 : RevFlag::F_NONE;
@@ -175,7 +175,7 @@ bool load( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Store template
 template<typename T>
-bool store( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool store( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ), R->GetX<T>( Inst.rs2 ) );
   R->AdvancePC( Inst );
   return true;
@@ -183,7 +183,7 @@ bool store( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Floating-point load template
 template<typename T>
-bool fload( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   if( std::is_same_v<T, double> || F->HasD() ) {
     static constexpr RevFlag flags = sizeof( T ) < sizeof( double ) ? RevFlag::F_BOXNAN : RevFlag::F_NONE;
     uint64_t                 rs1   = R->GetX<uint64_t>( Inst.rs1 );
@@ -220,7 +220,7 @@ bool fload( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Floating-point store template
 template<typename T>
-bool fstore( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fstore( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   T val = R->GetFP<T, true>( Inst.rs2 );
   M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ), val );
   R->AdvancePC( Inst );
@@ -229,7 +229,7 @@ bool fstore( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Floating-point operation template
 template<typename T, template<class> class OP>
-bool foper( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool foper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, OP()( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -267,7 +267,7 @@ struct FMax {
 
 /// Floating-point conditional operation template
 template<typename T, template<class> class OP>
-bool fcondop( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fcondop( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   bool res = OP()( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ) );
   R->SetX( Inst.rd, res );
   R->AdvancePC( Inst );
@@ -283,7 +283,7 @@ enum class OpKind { Imm, Reg };
 // The third parameter is std::make_unsigned_t or std::make_signed_t (default)
 // The optional fourth parameter indicates W mode (32-bit on XLEN == 64)
 template<template<class> class OP, OpKind KIND, template<class> class SIGN = std::make_signed_t, bool W_MODE = false>
-bool oper( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool oper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   if( !W_MODE && !R->IsRV64 ) {
     using T = SIGN<int32_t>;
     T rs1   = R->GetX<T>( Inst.rs1 );
@@ -322,7 +322,7 @@ struct ShiftRight {
 
 // Computes the UPPER half of multiplication, based on signedness
 template<bool rs1_is_signed, bool rs2_is_signed>
-bool uppermul( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool uppermul( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   if( R->IsRV64 ) {
     uint64_t rs1 = R->GetX<uint64_t>( Inst.rs1 );
     uint64_t rs2 = R->GetX<uint64_t>( Inst.rs2 );
@@ -353,7 +353,7 @@ enum class DivRem { Div, Rem };
 // The second parameter is std::make_signed_t or std::make_unsigned_t
 // The optional third parameter indicates W mode (32-bit on XLEN == 64)
 template<DivRem DIVREM, template<class> class SIGN, bool W_MODE = false>
-bool divrem( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool divrem( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   if( !W_MODE && !R->IsRV64 ) {
     using T = SIGN<int32_t>;
     T rs1   = R->GetX<T>( Inst.rs1 );
@@ -386,7 +386,7 @@ bool divrem( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 // The first template parameter is the comparison functor
 // The second template parameter is std::make_signed_t or std::make_unsigned_t
 template<template<class> class OP, template<class> class SIGN = std::make_unsigned_t>
-bool bcond( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool bcond( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   bool cond;
   if( R->IsRV64 ) {
     cond = OP()( R->GetX<SIGN<int64_t>>( Inst.rs1 ), R->GetX<SIGN<int64_t>>( Inst.rs2 ) );
@@ -419,7 +419,7 @@ inline auto revFMA( T x, T y, T z ) {
 
 /// Fused Multiply+Add
 template<typename T>
-bool fmadd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fmadd( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, revFMA( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ), R->GetFP<T>( Inst.rs3 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -427,7 +427,7 @@ bool fmadd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Fused Multiply-Subtract
 template<typename T>
-bool fmsub( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fmsub( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, revFMA( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ), negate( R->GetFP<T>( Inst.rs3 ) ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -435,7 +435,7 @@ bool fmsub( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Fused Negated (Multiply-Subtract)
 template<typename T>
-bool fnmsub( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fnmsub( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, revFMA( negate( R->GetFP<T>( Inst.rs1 ) ), R->GetFP<T>( Inst.rs2 ), R->GetFP<T>( Inst.rs3 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -443,7 +443,7 @@ bool fnmsub( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 /// Fused Negated (Multiply+Add)
 template<typename T>
-bool fnmadd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+bool fnmadd( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, negate( revFMA( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ), R->GetFP<T>( Inst.rs3 ) ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -451,7 +451,7 @@ bool fnmadd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
 // Square root
 template<typename T>
-static bool fsqrt( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fsqrt( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, std::sqrt( R->GetFP<T>( Inst.rs1 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -459,7 +459,7 @@ static bool fsqrt( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst 
 
 // Transfer sign bit
 template<typename T>
-static bool fsgnj( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fsgnj( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, std::copysign( R->GetFP<T>( Inst.rs1 ), R->GetFP<T>( Inst.rs2 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -467,7 +467,7 @@ static bool fsgnj( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst 
 
 // Negated transfer sign bit
 template<typename T>
-static bool fsgnjn( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fsgnjn( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, std::copysign( R->GetFP<T>( Inst.rs1 ), negate( R->GetFP<T>( Inst.rs2 ) ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -475,7 +475,7 @@ static bool fsgnjn( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst
 
 // Xor transfer sign bit
 template<typename T>
-static bool fsgnjx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fsgnjx( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   T rs1 = R->GetFP<T>( Inst.rs1 ), rs2 = R->GetFP<T>( Inst.rs2 );
   R->SetFP( Inst.rd, std::copysign( rs1, std::signbit( rs1 ) ? negate( rs2 ) : rs2 ) );
   R->AdvancePC( Inst );
@@ -484,7 +484,7 @@ static bool fsgnjx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst
 
 // Move floating-point register to integer register
 template<typename T>
-static bool fmvif( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fmvif( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   std::make_signed_t<uint_type_t<T>> i;
   T                                  fp = R->GetFP<T, true>( Inst.rs1 );  // The FP value
   static_assert( sizeof( i ) == sizeof( fp ) );
@@ -496,7 +496,7 @@ static bool fmvif( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst 
 
 // Move integer register to floating-point register
 template<typename T>
-static bool fmvfi( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fmvfi( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   T    fp;
   auto i = R->GetX<uint_type_t<T>>( Inst.rs1 );  // The X register
   static_assert( sizeof( i ) == sizeof( fp ) );
@@ -508,7 +508,7 @@ static bool fmvfi( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst 
 
 // Floating-point classify
 template<typename T>
-static bool fclassify( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fclassify( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetX( Inst.rd, fclass( R->GetFP<T>( Inst.rs1 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -516,7 +516,7 @@ static bool fclassify( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& I
 
 // Convert integer to floating point
 template<typename FP, typename INT>
-static bool fcvtfi( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fcvtfi( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, static_cast<FP>( R->GetX<INT>( Inst.rs1 ) ) );
   R->AdvancePC( Inst );
   return true;
@@ -524,7 +524,7 @@ static bool fcvtfi( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst
 
 // Convert floating point to floating point
 template<typename FP2, typename FP1>
-static bool fcvtff( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+static bool fcvtff( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   R->SetFP( Inst.rd, static_cast<FP2>( R->GetFP<FP1>( Inst.rs1 ) ) );
   R->AdvancePC( Inst );
   return true;

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -149,7 +149,7 @@ struct RevInstEntry {
   bool     raisefpe    = false;    ///<RevInstEntry: Whether FP exceptions are raised
 
   /// Instruction implementation function
-  bool ( *func )( RevFeature*, RevRegFile*, RevMem*, const RevInst& ){};
+  bool ( *func )( const RevFeature*, RevRegFile*, RevMem*, const RevInst& ){};
 
   /// Predicate for enabling table entries for only certain encodings
   bool ( *predicate )( uint32_t Inst ) = []( uint32_t ) { return true; };
@@ -176,7 +176,7 @@ struct RevInstEntry {
   auto& SetCompressed(bool c)        { this->compressed = c;     return *this; }
   auto& Setrs2fcvtOp(uint8_t op)     { this->rs2fcvtOp  = op;    return *this; }
   auto& SetRaiseFPE(bool c)          { this->raisefpe   = c;     return *this; }
-  auto& SetImplFunc( bool func( RevFeature *, RevRegFile *, RevMem *, const RevInst& ) )
+  auto& SetImplFunc( bool func( const RevFeature *, RevRegFile *, RevMem *, const RevInst& ) )
                                      { this->func       = func;  return *this; }
   auto& SetPredicate( bool pred( uint32_t ) )
                                      { this->predicate  = pred;  return *this; }

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -848,25 +848,25 @@ public:
 
   // Friend functions and classes to access internal register state
   template<typename INT, typename FP>
-  friend bool fcvtif( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool fcvtif( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T>
-  friend bool load( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T>
-  friend bool store( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool store( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T>
-  friend bool fload( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T>
-  friend bool fstore( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool fstore( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T, template<class> class OP>
-  friend bool foper( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool foper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   template<typename T, template<class> class OP>
-  friend bool fcondop( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
+  friend bool fcondop( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst );
 
   friend std::ostream& operator<<( std::ostream& os, const RevRegFile& regFile );
 

--- a/include/insns/RV32D.h
+++ b/include/insns/RV32D.h
@@ -132,7 +132,7 @@ class RV32D : public RevExt {
 
 public:
   /// RV32D: standard constructor
-  RV32D( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32D", Feature, RevMem, Output ) {
+  RV32D( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32D", Feature, RevMem, Output ) {
     SetTable( std::move( RV32DTable ) );
     SetCTable( std::move( RV32DCTable ) );
   }

--- a/include/insns/RV32F.h
+++ b/include/insns/RV32F.h
@@ -135,7 +135,7 @@ class RV32F : public RevExt {
 
 public:
   /// RV32F: standard constructor
-  RV32F( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32F", Feature, RevMem, Output ) {
+  RV32F( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32F", Feature, RevMem, Output ) {
     SetTable( std::move( RV32FTable ) );
     if( !Feature->IsRV64() && !Feature->HasD() ) {
       // RV32FC-only instructions

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -22,31 +22,31 @@ namespace SST::RevCPU {
 
 class RV32I : public RevExt {
   // Standard instructions
-  static bool nop( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool nop( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->AdvancePC( Inst );
     return true;
   }
 
-  static bool lui( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool lui( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, static_cast<int32_t>( Inst.imm << 12 ) );
     R->AdvancePC( Inst );
     return true;
   }
 
-  static bool auipc( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool auipc( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     auto ui = static_cast<int32_t>( Inst.imm << 12 );
     R->SetX( Inst.rd, ui + R->GetPC() );
     R->AdvancePC( Inst );
     return true;
   }
 
-  static bool jal( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool jal( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, R->GetPC() + Inst.instSize );
     R->SetPC( R->GetPC() + Inst.ImmSignExt( 21 ) );
     return true;
   }
 
-  static bool jalr( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool jalr( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     auto ret = R->GetPC() + Inst.instSize;
     R->SetPC( ( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) & -2 );
     R->SetX( Inst.rd, ret );
@@ -98,13 +98,13 @@ class RV32I : public RevExt {
   static constexpr auto& srl   = oper<ShiftRight, OpKind::Reg, std::make_unsigned_t>;
   static constexpr auto& sra   = oper<ShiftRight, OpKind::Reg>;
 
-  static bool fence( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fence( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     M->FenceMem( F->GetHartToExecID() );
     R->AdvancePC( Inst );
     return true;  // temporarily disabled
   }
 
-  static bool ecall( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool ecall( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     /*
      * In reality this should be getting/setting a LOT of bits inside the
      * CSRs however because we are only concerned with ecall right now it's
@@ -265,7 +265,7 @@ class RV32I : public RevExt {
 
 public:
   /// RV32I: standard constructor
-  RV32I( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32I", Feature, RevMem, Output ) {
+  RV32I( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32I", Feature, RevMem, Output ) {
     if( !Feature->IsRV64() ) {
       // RV32C-Only instruction
       RV32ICTable.push_back( RevCInstDefaults()

--- a/include/insns/RV32M.h
+++ b/include/insns/RV32M.h
@@ -69,7 +69,7 @@ class RV32M : public RevExt {
 
 public:
   /// RV32M: standard constructor
-  RV32M( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32M", Feature, RevMem, Output ) {
+  RV32M( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV32M", Feature, RevMem, Output ) {
     if( Feature->IsModeEnabled( RV_M ) ) {
       RV32MTable.insert( RV32MTable.end(), RV32DivTable.begin(), RV32DivTable.end() );
     }

--- a/include/insns/RV64D.h
+++ b/include/insns/RV64D.h
@@ -58,7 +58,7 @@ class RV64D : public RevExt {
 
 public:
   /// RV364D: standard constructor
-  RV64D( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64D", Feature, RevMem, Output ) {
+  RV64D( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64D", Feature, RevMem, Output ) {
     SetTable( std::move( RV64DTable ) );
   }
 };  // end class RV32I

--- a/include/insns/RV64F.h
+++ b/include/insns/RV64F.h
@@ -49,7 +49,7 @@ class RV64F : public RevExt {
 
 public:
   /// RV364F: standard constructor
-  RV64F( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64F", Feature, RevMem, Output ) {
+  RV64F( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64F", Feature, RevMem, Output ) {
     SetTable( std::move( RV64FTable ) );
   }
 };  // end class RV64F

--- a/include/insns/RV64I.h
+++ b/include/insns/RV64I.h
@@ -85,7 +85,7 @@ class RV64I : public RevExt {
 
 public:
   /// RV64I: standard constructor
-  RV64I( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64I", Feature, RevMem, Output ) {
+  RV64I( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64I", Feature, RevMem, Output ) {
     SetTable( std::move( RV64ITable ) );
     SetCTable( std::move( RV64ICTable ) );
   }

--- a/include/insns/RV64M.h
+++ b/include/insns/RV64M.h
@@ -58,7 +58,7 @@ class RV64M : public RevExt {
 
 public:
   /// RV64M: standard constructor
-  RV64M( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64M", Feature, RevMem, Output ) {
+  RV64M( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64M", Feature, RevMem, Output ) {
     if( Feature->IsModeEnabled( RV_M ) ) {
       RV64MTable.insert( RV64MTable.end(), RV64DivTable.begin(), RV64DivTable.end() );
     }

--- a/include/insns/RV64P.h
+++ b/include/insns/RV64P.h
@@ -19,19 +19,19 @@ namespace SST::RevCPU {
 
 class RV64P : public RevExt {
 
-  static bool future( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool future( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, !!M->SetFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
     // R->AdvancePC(Inst);
     return true;
   }
 
-  static bool rfuture( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool rfuture( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, !!M->RevokeFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
     // R->AdvancePC(Inst);
     return true;
   }
 
-  static bool sfuture( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool sfuture( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, !!M->StatusFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
     // R->AdvancePC(Inst);
     return true;
@@ -61,7 +61,7 @@ class RV64P : public RevExt {
 
 public:
   /// RV64P: standard constructor
-  RV64P( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64P", Feature, RevMem, Output ) {
+  RV64P( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "RV64P", Feature, RevMem, Output ) {
     SetTable( std::move( RV64PTable ) );
   }
 };  // end class RV64I

--- a/include/insns/Zaamo.h
+++ b/include/insns/Zaamo.h
@@ -18,7 +18,7 @@ namespace SST::RevCPU {
 
 class Zaamo : public RevExt {
   template<typename XLEN, RevFlag F_AMO>
-  static bool amooper( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool amooper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     static_assert( std::is_unsigned_v<XLEN>, "XLEN must be unsigned integral type" );
 
     RevFlag flags{ F_AMO };
@@ -115,7 +115,7 @@ class Zaamo : public RevExt {
 
 public:
   /// Zaamo: standard constructor
-  Zaamo( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zaamo", Feature, RevMem, Output ) {
+  Zaamo( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zaamo", Feature, RevMem, Output ) {
     if( Feature->IsRV64() ) {
       auto Table{ RV64Table() };
       ZaamoTable.insert( ZaamoTable.end(), std::move_iterator( Table.begin() ), std::move_iterator( Table.end() ) );

--- a/include/insns/Zalrsc.h
+++ b/include/insns/Zalrsc.h
@@ -20,7 +20,7 @@ class Zalrsc : public RevExt {
 
   // Load Reserved instruction
   template<typename TYPE>
-  static bool lr( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool lr( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     static_assert( std::is_unsigned_v<TYPE>, "TYPE must be unsigned integral type" );
     auto addr = R->GetX<uint64_t>( Inst.rs1 );
 
@@ -54,7 +54,7 @@ class Zalrsc : public RevExt {
 
   // Store Conditional instruction
   template<typename TYPE>
-  static bool sc( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool sc( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     static_assert( std::is_unsigned_v<TYPE>, "TYPE must be unsigned integral type" );
     auto addr     = R->GetX<uint64_t>( Inst.rs1 );
     auto val      = R->GetX<TYPE>( Inst.rs2 );
@@ -105,7 +105,7 @@ class Zalrsc : public RevExt {
 
 public:
   /// Zalrsc: standard constructor
-  Zalrsc( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zalrsc", Feature, RevMem, Output ) {
+  Zalrsc( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zalrsc", Feature, RevMem, Output ) {
     if( Feature->IsRV64() ) {
       auto Table{ RV64ZalrscTable() };
       ZalrscTable.insert( ZalrscTable.end(), std::move_iterator( Table.begin() ), std::move_iterator( Table.end() ) );

--- a/include/insns/Zfa.h
+++ b/include/insns/Zfa.h
@@ -20,7 +20,7 @@ class Zfa : public RevExt {
 
   // Round to integer without inexact exceptions
   template<typename T>
-  static bool fround( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fround( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetFP( Inst.rd, std::nearbyint( R->GetFP<T>( Inst.rs1 ) ) );
     R->AdvancePC( Inst );
     return true;
@@ -28,7 +28,7 @@ class Zfa : public RevExt {
 
   // Round to integer with inexact exceptions
   template<typename T>
-  static bool froundnx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool froundnx( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetFP( Inst.rd, std::rint( R->GetFP<T>( Inst.rs1 ) ) );
     R->AdvancePC( Inst );
     return true;
@@ -57,7 +57,7 @@ class Zfa : public RevExt {
   /// Floating-point minimum/maximum
   /// If either argument is NaN, the result is NaN
   template<typename T, template<class> class MINMAX>
-  static bool fminmaxm( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fminmaxm( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     T x   = R->GetFP<T>( Inst.rs1 );
     T y   = R->GetFP<T>( Inst.rs2 );
     T res = MINMAX()( x, y );
@@ -70,7 +70,7 @@ class Zfa : public RevExt {
   }
 
   // Move the high 32 bits of floating-point double to a XLEN==32 register
-  static bool fmvhxd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fmvhxd( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     double   fp = R->GetFP<double>( Inst.rs1 );
     uint64_t ifp;
     memcpy( &ifp, &fp, sizeof( ifp ) );
@@ -81,7 +81,7 @@ class Zfa : public RevExt {
   }
 
   // Move a pair of XLEN==32 registers to a floating-point double
-  static bool fmvpdx( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fmvpdx( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     uint64_t ifp = R->GetX<uint64_t>( Inst.rs1 ) | R->GetX<uint64_t>( Inst.rs2 ) << 32;
     double   fp;
     memcpy( &fp, &ifp, sizeof( fp ) );
@@ -94,7 +94,7 @@ class Zfa : public RevExt {
   // Convert double precision floating point to 32-bit signed integer modulo 2^32
   // Always truncates (rounds toward 0) regardless of rounding mode
   // Raises the same exceptions as fcvt.w.d but the result is always modulo 2^32
-  static bool fcvtmodwd( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fcvtmodwd( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
 
     double   fp = R->GetFP<double>( Inst.rs1 );
     uint64_t ifp;
@@ -284,7 +284,7 @@ class Zfa : public RevExt {
 
 public:
   /// Zfa: standard constructor
-  Zfa( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zfa", Feature, RevMem, Output ) {
+  Zfa( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zfa", Feature, RevMem, Output ) {
     if( Feature->HasD() ) {
       if( !Feature->IsRV64() ) {
         // clang-format off

--- a/include/insns/Zicbom.h
+++ b/include/insns/Zicbom.h
@@ -24,7 +24,7 @@ namespace SST::RevCPU {
 
 class Zicbom : public RevExt {
 
-  static bool cmo( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool cmo( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     switch( Inst.imm ) {
     case CBO_INVAL_IMM:
       // CBO.INVAL
@@ -65,7 +65,7 @@ class Zicbom : public RevExt {
   // clang-format on
 
 public:
-  Zicbom( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zicbom", Feature, RevMem, Output ) {
+  Zicbom( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zicbom", Feature, RevMem, Output ) {
     SetTable( std::move( ZicbomTable ) );
   }
 };  // end class Zicbom

--- a/include/insns/Zicsr.h
+++ b/include/insns/Zicsr.h
@@ -66,7 +66,7 @@ class Zicsr : public RevExt {
   /// Modify a CSR Register according to CSRRW, CSRRS, or CSRRC
   // This calls the 32/64-bit ModCSR depending on the current XLEN
   template<OpKind OPKIND, CSROp OP>
-  static bool ModCSR( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool ModCSR( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     return R->IsRV64 ? ModCSRImpl<uint64_t, OPKIND, OP>( R, Inst ) : ModCSRImpl<uint32_t, OPKIND, OP>( R, Inst );
   }
 
@@ -129,7 +129,7 @@ class Zicsr : public RevExt {
 
 public:
   /// Zicsr: standard constructor
-  Zicsr( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zicsr", Feature, RevMem, Output ) {
+  Zicsr( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zicsr", Feature, RevMem, Output ) {
     SetTable( std::move( ZicsrTable ) );
   }
 

--- a/include/insns/Zifencei.h
+++ b/include/insns/Zifencei.h
@@ -18,7 +18,7 @@ namespace SST::RevCPU {
 
 class Zifencei : public RevExt {
 
-  static bool fencei( RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
+  static bool fencei( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     M->FenceMem( F->GetHartToExecID() );
     R->AdvancePC( Inst );
     return true;
@@ -31,7 +31,7 @@ class Zifencei : public RevExt {
   // clang-format on
 
 public:
-  Zifencei( RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zifencei", Feature, RevMem, Output ) {
+  Zifencei( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zifencei", Feature, RevMem, Output ) {
     SetTable( std::move( ZifenceiTable ) );
   }
 

--- a/src/RevCoProc.cc
+++ b/src/RevCoProc.cc
@@ -43,7 +43,7 @@ RevSimpleCoProc::RevSimpleCoProc( ComponentId_t id, Params& params, RevCore* par
     output->output("Registering subcomponent RevSimpleCoProc with frequency=%s\n", ClockFreq.c_str());*/
 }
 
-bool RevSimpleCoProc::IssueInst( RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst ) {
+bool RevSimpleCoProc::IssueInst( const RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst ) {
   RevCoProcInst inst = RevCoProcInst( Inst, F, R, M );
   std::cout << "CoProc instruction issued: " << std::hex << Inst << std::dec << std::endl;
   //parent->ExternalDepSet(CreatePasskey(), F->GetHartToExecID(), 7, false);

--- a/src/RevExt.cc
+++ b/src/RevExt.cc
@@ -13,7 +13,7 @@
 namespace SST::RevCPU {
 
 /// Execute an instruction
-bool RevExt::Execute( unsigned Inst, const RevInst& payload, uint16_t HartID, RevRegFile* regFile ) {
+bool RevExt::Execute( unsigned Inst, const RevInst& payload, uint16_t HartID, RevRegFile* regFile ) const {
   bool ( *func )( const RevFeature*, RevRegFile*, RevMem*, const RevInst& );
 
   if( payload.compressed ) {

--- a/src/RevExt.cc
+++ b/src/RevExt.cc
@@ -14,7 +14,7 @@ namespace SST::RevCPU {
 
 /// Execute an instruction
 bool RevExt::Execute( unsigned Inst, const RevInst& payload, uint16_t HartID, RevRegFile* regFile ) {
-  bool ( *func )( RevFeature*, RevRegFile*, RevMem*, const RevInst& );
+  bool ( *func )( const RevFeature*, RevRegFile*, RevMem*, const RevInst& );
 
   if( payload.compressed ) {
     // this is a compressed instruction, grab the compressed trampoline function

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -17,8 +17,7 @@
 namespace SST::RevCPU {
 
 RevFeature::RevFeature( std::string Machine, SST::Output* Output, unsigned Min, unsigned Max, unsigned Id )
-  : machine( std::move( Machine ) ), output( Output ), MinCost( Min ), MaxCost( Max ), ProcID( Id ), HartToExecID( 0 ),
-    features( RV_UNKNOWN ), xlen( 0 ) {
+  : machine( std::move( Machine ) ), output( Output ), MinCost( Min ), MaxCost( Max ), ProcID( Id ) {
   output->verbose( CALL_INFO, 6, 0, "Core %u ; Initializing feature set from machine string=%s\n", ProcID, machine.c_str() );
   if( !ParseMachineModel() )
     output->fatal( CALL_INFO, -1, "Error: failed to parse the machine model: %s\n", machine.c_str() );


### PR DESCRIPTION
This makes the `RevFeature* Feature` pointers into `const RevFeature* Feature` since the feature data is read-only, and we don't want functions to modify `RevFeature`.

(The `const` does not apply to the function-local variable pointer `Feature`, but to _what it points to_.)
