### PR TITLE
Fast print utility

### DIFF
--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -673,7 +673,7 @@ REV_SYSCALL( 9006, void dump_thread_mem( ) );
 REV_SYSCALL( 9007, void dump_thread_mem_to_file( const char* outputFile ) );
 
 // ==================== REV PRINT UTILITIES
-REV_SYSCALL( 9110, int rev_fast_printf(const char* format, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a4=0, uint64_t a6=0) );
+REV_SYSCALL( 9110, int rev_fast_printf(const char* format, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a5=0, uint64_t a6=0) );
 
 // clang-format on
 

--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -671,6 +671,10 @@ REV_SYSCALL( 9004, void dump_valid_mem( ) );
 REV_SYSCALL( 9005, void dump_valid_mem_to_file( const char* outputFile ) );
 REV_SYSCALL( 9006, void dump_thread_mem( ) );
 REV_SYSCALL( 9007, void dump_thread_mem_to_file( const char* outputFile ) );
+
+// ==================== REV PRINT UTILITIES
+REV_SYSCALL( 9110, int rev_fast_printf(const char* format, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a4=0, uint64_t a6=0) );
+
 // clang-format on
 
 #endif  //SYSCALL_TYPES_ONLY

--- a/common/syscalls/syscalls.h
+++ b/common/syscalls/syscalls.h
@@ -673,7 +673,9 @@ REV_SYSCALL( 9006, void dump_thread_mem( ) );
 REV_SYSCALL( 9007, void dump_thread_mem_to_file( const char* outputFile ) );
 
 // ==================== REV PRINT UTILITIES
+#ifdef __cplusplus
 REV_SYSCALL( 9110, int rev_fast_printf(const char* format, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a5=0, uint64_t a6=0) );
+#endif
 
 // clang-format on
 

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -306,8 +306,8 @@ private:
   std::function<uint32_t()> const GetNewThreadID;
 
   // If a given assigned thread experiences a change of state, it sets the corresponding bit
-  std::vector<std::unique_ptr<RevThread>>
-    ThreadsThatChangedState{};  ///< RevCore: used to signal to RevCPU that the thread assigned to HART has changed state
+  std::vector<std::unique_ptr<RevThread>> ThreadsThatChangedState{
+  };  ///< RevCore: used to signal to RevCPU that the thread assigned to HART has changed state
 
   SST::Output* const                output;                       ///< RevCore: output handler
   std::unique_ptr<RevFeature>       CreateFeature();              ///< RevCore: Create a RevFeature object
@@ -317,8 +317,8 @@ private:
   RevCoreStats                      StatsTotal{};                 ///< RevCore: collection of total performance stats
   std::unique_ptr<RevPrefetcher>    sfetch{};                     ///< RevCore: stream instruction prefetcher
 
-  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>>
-    LSQueue{};  ///< RevCore: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
+  std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> LSQueue{
+  };  ///< RevCore: Load / Store queue used to track memory operations. Currently only tracks outstanding loads.
   TimeConverter* timeConverter{};  ///< RevCore: Time converter for RTC
 
   RevRegFile* RegFile        = nullptr;        ///< RevCore: Initial pointer to HartToDecodeID RegFile
@@ -671,7 +671,10 @@ private:
 
   EcallStatus ECALL_dump_thread_mem();         // 9006, dump_thread_mem()
   EcallStatus ECALL_dump_thread_mem_to_file(); // 9007, dump_thread_mem_to_file(const char* outputFile)
-  // clang-format on
+
+  // =============== REV print utilities
+  EcallStatus ECALL_fast_printf();             // 9010, rev_fast_printf(const char *, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a5=0, uint64_t a6=0)
+    // clang-format on
 
   /// RevCore: Table of ecall codes w/ corresponding function pointer implementations
   static const std::unordered_map<uint32_t, EcallStatus ( RevCore::* )()> Ecalls;

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -3390,7 +3390,7 @@ EcallStatus RevCore::ECALL_dump_thread_mem_to_file() {
   return EcallLoadAndParseString( pathname, action );
 }
 
-// 9110, rev_fast_printf(const char *, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a5=0, , uint64_t a6=0)
+// 9110, rev_fast_printf(const char *, uint64_t a1=0, uint64_t a2=0, uint64_t a3=0, uint64_t a4=0, uint64_t a5=0, uint64_t a6=0)
 //  printf helper executed on host rather than rev.
 //  Use xml-like tags to define <rev-print>start/end<rev-print> of printed text to allow post processor extraction
 //  Restrictions:
@@ -3412,7 +3412,7 @@ EcallStatus RevCore::ECALL_fast_printf() {
     int       cx;
     cx = snprintf( buffer, sz, EcallState.string.c_str(), a1, a2, a3, a4, a5, a6 );
     if( cx >= 0 && cx < sz )
-      output->verbose( CALL_INFO, 0, 0, "<rev-print>\n%s</rev-print>\n", buffer );
+      output->verbose( CALL_INFO, 0, 0, "<rev-print>%s</rev-print>\n", buffer );
   };
   return EcallLoadAndParseString( pFormat, action );
 }

--- a/test/tracer/Makefile
+++ b/test/tracer/Makefile
@@ -22,6 +22,7 @@ LOGS   = $(addsuffix .log,$(TLIST))
 TARGS = $(EXES) $(DIASMS) $(LOGS)
 
 CC=${RVCC}
+CXX=${RVCXX}
 OBJDUMP=${RISCV}/bin/riscv64-unknown-elf-objdump -D --source
 INCLUDE = -I../../common/syscalls -I../include
 
@@ -46,7 +47,7 @@ compile: $(EXES) $(DIASMS)
 %.memh.rv64g.log: REVCFG=./rev-test-tracer-memh.py
 
 %.exe: tracer.c
-	$(CC) -g -O0 -march=$(ARCH) $(OPTS) $(INCLUDE) -o  $@ $<
+	$(CXX) -g -O0 -march=$(ARCH) $(OPTS) $(INCLUDE) -o  $@ $<
 
 %.rv64g.log: ARCH=rv64g
 %.rv32i.log: ARCH=rv32i

--- a/test/tracer/Makefile
+++ b/test/tracer/Makefile
@@ -13,7 +13,9 @@
 .PHONY: src
 
 EXAMPLE ?= tracer
-TLIST   ?= $(addprefix $(EXAMPLE),.mem.rv32i .mem.rv64g .memh.rv32i .memh.rv64g)
+
+TLIST   = $(addprefix $(EXAMPLE),.mem.rv32i.c .mem.rv64g.c .memh.rv32i.c .memh.rv64g.c)
+TLIST   += $(addprefix $(EXAMPLE),.mem.rv32i.cpp .mem.rv64g.cpp .memh.rv32i.cpp .memh.rv64g.cpp)
 
 EXES   = $(addsuffix .exe,$(TLIST))
 DIASMS = $(addsuffix .dis,$(TLIST))
@@ -23,6 +25,7 @@ TARGS = $(EXES) $(DIASMS) $(LOGS)
 
 CC=${RVCC}
 CXX=${RVCXX}
+
 OBJDUMP=${RISCV}/bin/riscv64-unknown-elf-objdump -D --source
 INCLUDE = -I../../common/syscalls -I../include
 
@@ -34,23 +37,27 @@ compile: $(EXES) $(DIASMS)
 %.dis: %.exe
 	$(OBJDUMP) $< > $@
 
-%.rv32i.exe: ARCH=rv32i
-%.rv32i.exe: OPTS=-mabi=ilp32
+%.c.exe: GCC = $(CC)
+%.cpp.exe: GCC = $(CXX)
 
-%.rv64g.exe: ARCH=rv64g
-%.rv64g.exe: OPTS=-DRV64G
+%.rv32i.c.exe %.rv32i.cpp.exe: ARCH=rv32i
+%.rv32i.c.exe %.rv32i.cpp.exe: OPTS=-mabi=ilp32
 
-%.mem.rv32i.log:  REVCFG=./rev-test-tracer.py
-%.memh.rv32i.log: REVCFG=./rev-test-tracer-memh.py
+%.rv64g.c.exe %.rv64g.cpp.exe: ARCH=rv64g
+%.rv64g.c.exe %.rv64g.cpp.exe: OPTS=-DRV64G
 
-%.mem.rv64g.log:  REVCFG=./rev-test-tracer.py
-%.memh.rv64g.log: REVCFG=./rev-test-tracer-memh.py
+%.mem.rv32i.c.log %.mem.rv32i.cpp.log:   REVCFG=./rev-test-tracer.py
+%.memh.rv32i.c.log %.memh.rv32i.cpp.log: REVCFG=./rev-test-tracer-memh.py
+
+%.mem.rv64g.c.log %.mem.rv64g.cpp.log:   REVCFG=./rev-test-tracer.py
+%.memh.rv64g.c.log %.memh.rv64g.cpp.log: REVCFG=./rev-test-tracer-memh.py
 
 %.exe: tracer.c
-	$(CXX) -g -O0 -march=$(ARCH) $(OPTS) $(INCLUDE) -o  $@ $<
+	$(GCC) -g -O0 -march=$(ARCH) $(OPTS) $(INCLUDE) -o  $@ $<
 
-%.rv64g.log: ARCH=rv64g
-%.rv32i.log: ARCH=rv32i
+%.rv64g.c.log %.rv64g.cpp.log: ARCH=rv64g
+%.rv32i.c.log %.rv32i.cpp.log: ARCH=rv32i
+
 %.log: %.exe
 	@$(eval tmp := $(basename $@).tmplog)
 	ARCH=$(ARCH) REV_EXE=$< sst --add-lib-path=../../build/src $(REVCFG) > $(tmp)

--- a/test/tracer/tracer.c
+++ b/test/tracer/tracer.c
@@ -18,6 +18,12 @@
 
 #define assert TRACE_ASSERT
 
+#ifdef __cplusplus
+#define printf rev_fast_printf
+#else
+#define printf( ... )
+#endif
+
 // inefficient calculation of r-s
 int long_sub( int r, int s ) {
   for( int i = 0; i < s; i++ )
@@ -70,14 +76,14 @@ int main( int argc, char** argv ) {
   res     = long_sub( res, 1000 );
   // res == 2000;
 
-  rev_fast_printf( "Enable Tracing\n" );
+  printf( "Enable Tracing\n" );
   // enable tracing
   TRACE_ON;
   res = long_sub( res, 20 );
   // res == 1980
   assert( res == 1980 );
   TRACE_OFF;
-  rev_fast_printf( "Tracing Disabled\n" );
+  printf( "Tracing Disabled\n" );
 
   // not traced
   for( int i = 0; i < 1980 / 2; i++ )

--- a/test/tracer/tracer.c
+++ b/test/tracer/tracer.c
@@ -70,12 +70,14 @@ int main( int argc, char** argv ) {
   res     = long_sub( res, 1000 );
   // res == 2000;
 
+  rev_fast_printf( "Enable Tracing\n" );
   // enable tracing
   TRACE_ON;
   res = long_sub( res, 20 );
   // res == 1980
   assert( res == 1980 );
   TRACE_OFF;
+  rev_fast_printf( "Tracing Disabled\n" );
 
   // not traced
   for( int i = 0; i < 1980 / 2; i++ )


### PR DESCRIPTION
This custom ECALL is intended to help debug code by providing non-intrusive printf functionality to help speed up rev application and rev test code development. It is currently  limited to 1K output chars and takes a format string and up to 6 numeric parameters.

Advantages:
- allows formatting for numeric values
- thread safe with respect to other harts.
- single cycle execution
- does not clutter execution trace when someone just wants to print a few values.
- xml tagging allows for post-processing script to extract the printed strings.

Disadvantages:
- restricting usage to using only 1 numeric parameters and a 1K char buffer.
- cannot pass in strings as parameters.

Example:

```
#define printf rev_fast_printf
// ... bunch of code
      printf("Failed: check_data[%d]=0x%lx dram_src[%d]=0x%lx\n",
              i, check_data[i], i, dram_src[i]);
```

Output:
```
RevCPU[cpu0:operator():10080000]: <rev-print>Failed: check_data[0]=0xffffffffaced0000 dram_src[0]=0xffffffffaced0000
</rev-print>
```
