### PR TITLE
Print warnings about C++ filename extensions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -149,17 +149,18 @@ is_text_file() {
 
 # Test if argument is a C/C++ file
 is_cxx_file() {
+    trap "$(shopt -p nocasematch)" RETURN
+    shopt -u nocasematch
     case $1 in
         *.c|*.h|*.cc) true ;;
         *.hpp) printf "${RED}$1: Error: C++ header files should have .h extension instead of .hpp${END}\n"
-               errors=true
-               true ;;
+               errors=true ;;
         *.cxx) printf "${RED}$1: Error: C++ source files should have .cc extension instead of .cxx${END}\n"
-               errors=true
-               true ;;
+               errors=true ;;
         *.cpp) printf "${RED}$1: Error: C++ source files should have .cc extension instead of .cpp${END}\n"
-               errors=true
-               true ;;
+               errors=true ;;
+        *.C)   printf "${RED}$1: Error: C++ source files should have .cc extension instead of .C${END}\n"
+               errors=true ;;
         *) false
     esac
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -150,7 +150,16 @@ is_text_file() {
 # Test if argument is a C/C++ file
 is_cxx_file() {
     case $1 in
-        *.c|*.h|*.cc|*.hpp|*.cpp|*.cxx) true ;;
+        *.c|*.h|*.cc) true ;;
+        *.hpp) printf "${RED}$1: Error: C++ header files should have .h extension instead of .hpp${END}\n"
+               errors=true
+               true ;;
+        *.cxx) printf "${RED}$1: Error: C++ source files should have .cc extension instead of .cxx${END}\n"
+               errors=true
+               true ;;
+        *.cpp) printf "${RED}$1: Error: C++ source files should have .cc extension instead of .cpp${END}\n"
+               errors=true
+               true ;;
         *) false
     esac
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@
 # Based on https://github.com/rocm/rocBLAS
 #
 # shellcheck enable=all
-# shellcheck disable=2034,2059,2250,2310,2312
+# shellcheck disable=2034,2059,2064,2250,2310,2312
 
 set_shell_options() {
     set -eEu -o pipefail
@@ -217,7 +217,7 @@ reformat_files() {
             fi
 
             # Shell scripts
-            if [[ $file = *.sh ]]; then
+            if [[ $file = *.sh || $file = .githooks/pre-commit ]]; then
                 if command -v shellcheck >/dev/null 2>&1; then
                     shellcheck --color=always "$file" || errors=true
                 else


### PR DESCRIPTION
This enforces the `.cc` and `.h` filename extensions, printing an error if `.cxx`, `.cpp`, `.C` or `.hpp` are used.
