### PR TITLE
Cleanup shellcheck errors

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -181,8 +181,6 @@ reformat_files() {
     get_files
 
     errors=false
-    flake8_warning=false
-    shellcheck_warning=false
 
     # Fix formatting on text files
     for file in "${FILES[@]}"; do
@@ -216,8 +214,9 @@ reformat_files() {
                 if command -v flake8 >/dev/null 2>&1; then
                     flake8 --color=always --max-line-length 131 "$file" || errors=true
                 else
-                    printf "${YELLOW}Warning: flake8 utility not found. $file not checked with flake8.${END}\n"
-                    flake8_warning=true
+                    printf "${RED}Error: flake8 utility not found. %s not checked with flake8.${END}\n" "$file"
+                    printf "${YELLOW}\nTo Install flake8, type:\n\npip install flake8\n\n${END}"
+                    exit 1
                 fi
             fi
 
@@ -226,20 +225,13 @@ reformat_files() {
                 if command -v shellcheck >/dev/null 2>&1; then
                     shellcheck -o all -e 1091,2059,2154,2248,2250,2312 "$file" || errors=true
                 else
-                    printf "${YELLOW}Warning: shellcheck utility not found. $file not checked with shellcheck.${END}\n"
-                    shellcheck_warning=true
+                    printf "${RED}Error: shellcheck utility not found. %s not checked with shellcheck.${END}\n" "$file"
+                    howto_install shellcheck
+                    exit 1
                 fi
             fi
         fi
     done
-
-    if [[ $flake8_warning = true ]]; then
-        printf "${YELLOW}\nTo Install flake8, type:\n\npip install flake8\n\n${END}"
-    fi
-
-    if [[ $shellcheck_warning = true ]]; then
-        howto_install shellcheck
-    fi
 
     if [[ $errors = true ]]; then
         exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -219,7 +219,7 @@ reformat_files() {
             # Shell scripts
             if [[ $file = *.sh || $file = .githooks/pre-commit ]]; then
                 if command -v shellcheck >/dev/null 2>&1; then
-                    shellcheck --color=always "$file" || errors=true
+                    shellcheck -o all -e 1091,2059,2154,2248,2250,2312 "$file" || errors=true
                 else
                     printf "${YELLOW}Warning: shellcheck utility not found. $file not checked with shellcheck.${END}\n"
                 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -180,9 +180,13 @@ reformat_files() {
     # Get the list of files into FILES
     get_files
 
-    errors=false
-
     # Fix formatting on text files
+    if [[ ${#FILES[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    errors=false
+# Fix formatting on text files
     for file in "${FILES[@]}"; do
         if [[ -f $file ]] && is_text_file "$file"; then
             # Replace non-ASCII characters with ASCII equivalents

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -71,31 +71,38 @@ parse_options() {
     fi
 }
 
+# How to install a package
+howto_install() {
+    package=$1
+
+    INSTALL=
+    if [[ $OSTYPE = darwin* ]]; then
+        if command -v brew >/dev/null; then
+            INSTALL="brew install $package"
+        fi
+    elif [[ $OSTYPE = linux* ]]; then
+        if [[ -f /etc/redhat-release ]]; then
+            if command -v dnf >/dev/null; then
+                INSTALL="sudo dnf install $package"
+            elif command -v yum >/dev/null; then
+                INSTALL="sudo yum install $package"
+            fi
+        elif [[ -f /etc/debian_version ]] && command -v apt-get >/dev/null; then
+            INSTALL="sudo apt-get install $package"
+        fi
+    fi
+    if [[ -n $INSTALL ]]; then
+        printf "${YELLOW}\nTo install $package, run:\n\n%s\n\n${END}" "$INSTALL"
+    else
+        printf "${YELLOW}\nInstall $package and make sure it is in PATH.\n\n${END}"
+    fi
+}
+
 # Check for existence of clang-format or print error message on how to install
 check_clang_format() {
     if ! command -v clang-format >/dev/null; then
-        printf "${RED}\nError: clang-format not found\n"
-        INSTALL=
-        if [[ $OSTYPE = darwin* ]]; then
-            if command -v brew >/dev/null; then
-                INSTALL="brew install clang-format"
-            fi
-        elif [[ $OSTYPE = linux* ]]; then
-            if [[ -f /etc/redhat-release ]]; then
-                if command -v dnf >/dev/null; then
-                    INSTALL="sudo dnf install clang-format"
-                elif command -v yum >/dev/null; then
-                    INSTALL="sudo yum install clang-format"
-                fi
-            elif [[ -f /etc/debian_version ]] && command -v apt-get >/dev/null; then
-                INSTALL="sudo apt-get install clang-format"
-            fi
-        fi
-        if [[ -n $INSTALL ]]; then
-            printf "To install clang-format, run:\n\n%s\n${END}" "$INSTALL"
-        else
-            printf "Install clang-format and make sure it is in PATH.\n${END}"
-        fi
+        printf "${RED}\nError: clang-format not found\n${END}"
+        howto_install clang-format
         exit 1
     fi
 }
@@ -175,6 +182,7 @@ reformat_files() {
 
     errors=false
     flake8_warning=false
+    shellcheck_warning=false
 
     # Fix formatting on text files
     for file in "${FILES[@]}"; do
@@ -209,10 +217,7 @@ reformat_files() {
                     flake8 --color=always --max-line-length 131 "$file" || errors=true
                 else
                     printf "${YELLOW}Warning: flake8 utility not found. $file not checked with flake8.${END}\n"
-                    if [[ $flake8_warning = false ]]; then
-                        flake8_warning=true
-                        printf "${YELLOW}\nTo Install flake8, type:\n\npip install flake8\n\n${END}"
-                    fi
+                    flake8_warning=true
                 fi
             fi
 
@@ -222,10 +227,19 @@ reformat_files() {
                     shellcheck -o all -e 1091,2059,2154,2248,2250,2312 "$file" || errors=true
                 else
                     printf "${YELLOW}Warning: shellcheck utility not found. $file not checked with shellcheck.${END}\n"
+                    shellcheck_warning=true
                 fi
             fi
         fi
     done
+
+    if [[ $flake8_warning = true ]]; then
+        printf "${YELLOW}\nTo Install flake8, type:\n\npip install flake8\n\n${END}"
+    fi
+
+    if [[ $shellcheck_warning = true ]]; then
+        howto_install shellcheck
+    fi
 
     if [[ $errors = true ]]; then
         exit 1

--- a/scripts/cleanmanpages.sh
+++ b/scripts/cleanmanpages.sh
@@ -3,4 +3,4 @@
 
 BASE=$1
 
-rm -Rf $BASE/_*.3
+rm -Rf "$BASE"/_*.3

--- a/scripts/slurm/build-gcc11-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc11-sst13.1.0.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "../rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-gcc11-sst14.0.0.sh
+++ b/scripts/slurm/build-gcc11-sst14.0.0.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-gcc11.sh
+++ b/scripts/slurm/build-gcc11.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-gcc13-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc13-sst13.1.0.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-gcc13-sst14.0.0.sh
+++ b/scripts/slurm/build-gcc13-sst14.0.0.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-gcc13.sh
+++ b/scripts/slurm/build-gcc13.sh
@@ -25,23 +25,23 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-llvm12-sst13.1.0.sh
+++ b/scripts/slurm/build-llvm12-sst13.1.0.sh
@@ -25,23 +25,23 @@ export CC=clang
 export CXX=clang++
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-llvm12-sst14.0.0.sh
+++ b/scripts/slurm/build-llvm12-sst14.0.0.sh
@@ -25,23 +25,23 @@ export CC=clang
 export CXX=clang++
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/build-llvm12.sh
+++ b/scripts/slurm/build-llvm12.sh
@@ -25,23 +25,23 @@ export CC=clang
 export CXX=clang++
 export RVCC=riscv64-unknown-elf-gcc
 
-touch rev.jenkins.${SLURM_JOB_ID}.out
-sst --version >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-sst-info revcpu >> rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
 
 #-- Stage 2: setup the build directories
 mkdir -p build
-cd build
+cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../ >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make clean >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make uninstall >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-make -j >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
-#make install >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
 
 #-- Stage 4: test everything
-make test >> ../rev.jenkins.${SLURM_JOB_ID}.out 2>&1
+make test
 
 #-- EOF

--- a/scripts/slurm/exec_build.sh
+++ b/scripts/slurm/exec_build.sh
@@ -14,33 +14,32 @@ USER=$(id -un)
 
 #-- execute the job
 SCRIPT=$1
-SLURM_ID=`sbatch -N1 --export=ALL $SCRIPT | awk '{print $4}'`
+SLURM_ID=$(sbatch -N1 --export=ALL "$SCRIPT" | awk '{print $4}')
 
 #-- wait for completion
-COMPLETE=`squeue -u $USER | grep ${SLURM_ID}`
+COMPLETE=$(squeue -u "$USER" | grep "${SLURM_ID}")
 while [[ -n $COMPLETE ]]; do
   sleep 1
-  COMPLETE=`squeue -u $USER | grep ${SLURM_ID}`
+  COMPLETE=$(squeue -u "$USER" | grep "${SLURM_ID}")
 done
 
 #-- echo the result to the log
-cat rev.jenkins.${SLURM_ID}.out
+cat "rev.jenkins.${SLURM_ID}.out"
 
 #-- job has completed, test for status
-STATE=`cat rev.jenkins.${SLURM_ID}.out | grep "tests failed out of"`
-NUM_FAILED=`cat rev.jenkins.${SLURM_ID}.out | grep "tests failed out of" | awk '{print $4}'`
+STATE=$(grep "tests failed out of" < "rev.jenkins.${SLURM_ID}.out")
+NUM_FAILED=$(grep "tests failed out of" < "rev.jenkins.${SLURM_ID}.out" | awk '{print $4}')
 
 
 if [[ $NUM_FAILED -eq 0 ]];
 then
   echo "TEST PASSED FOR JOB_ID = ${JOB_ID}; SLURM_JOB=${SLURM_ID}"
-  echo $STATE
+  echo "$STATE"
   exit 0
 else
   echo "TEST FAILED FOR JOB_ID = ${JOB_ID}; SLURM_JOB=${SLURM_ID}"
-  echo $STATE
-  exit -1
+  echo "$STATE"
+  exit 1
 fi
 
-exit 0
 #-- EOF

--- a/test/argc_short/run_argc_short.sh
+++ b/test/argc_short/run_argc_short.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x argc.exe ]; then
+if [[ -x argc.exe ]]; then
         set -e
 	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "argc.exe" --args "one" --enableMemH=0
 	echo "Test ARGC_SHORT_REVMEM: Completed"

--- a/test/argv_limit/run_argv_limit.sh
+++ b/test/argv_limit/run_argv_limit.sh
@@ -6,19 +6,19 @@ make clean && make
 args=()
 for arg in {1..4096}
 do
-    args+=($arg)
+    args+=("$arg")
 done
 
 IFS=,
-args=$(echo "[${args[*]}]")
+argstr="[${args[*]}]"
 IFS=
 
 # Check that the exec was built...
 if [[ -x argv_limit.exe ]]; then
         set -e
-	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "argv_limit.exe" --enableMemH=0 --args "$args"
+	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "argv_limit.exe" --enableMemH=0 --args "$argstr"
 	echo "Test ARGV_LIMIT_REVMEM: Completed"
-	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "argv_limit.exe" --enableMemH=1 --args "$args"
+	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program "argv_limit.exe" --enableMemH=1 --args "$argstr"
 	echo "Test ARGV_LIMIT_MEMH: Completed"
 else
 	echo "Test ARGV_LIMIT: argv_limit.exe not Found - likely build failed"

--- a/test/backingstore/run_backingstore.sh
+++ b/test/backingstore/run_backingstore.sh
@@ -6,11 +6,11 @@ STORE="backingstore.bin"
 make clean && make
 
 # Check that the exec was built...
-if [ -x backingstore.exe ]; then
+if [[ -x backingstore.exe ]]; then
         dd if=/dev/zero of=$STORE bs=64M count=16
-        SHA1BEFORE=`sha1sum $STORE | awk '{print $1}'`
+        SHA1BEFORE=$(sha1sum $STORE | awk '{print $1}')
 	sst --add-lib-path=../../build/src/ ./rev-backingstore.py
-        SHA1AFTER=`sha1sum $STORE | awk '{print $1}'`
+        SHA1AFTER=$(sha1sum $STORE | awk '{print $1}')
         if test "$SHA1BEFORE" = "$SHA1AFTER"
         then
           echo "FAILED: HASHES ARE THE SAME"

--- a/test/bge_ble/run_bge_ble.sh
+++ b/test/bge_ble/run_bge_ble.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x bge_ble.exe ]; then
+if [[ -x bge_ble.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-bge-ble.py
 else
 	echo "Test BGE_BLE: bge_ble.exe not Found - likely build failed"

--- a/test/big_loop/run_big_loop.sh
+++ b/test/big_loop/run_big_loop.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x big_loop.exe ]; then
+if [[ -x big_loop.exe ]]; then
 	sst --add-lib-path=../../build/src/ ../rev-model-options-config.py -- --program="big_loop.exe" --numHarts=1 --numCores=1
 else
 	echo "Test BIG_LOOP: big_loop.exe not Found - likely build failed"

--- a/test/cache_1/run_cache_1.sh
+++ b/test/cache_1/run_cache_1.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x cache_1.exe ]; then
+if [[ -x cache_1.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-test-cache1.py
 else
 	echo "Test CACHE-TEST1: cache_test1.exe not Found - likely build failed"

--- a/test/cache_2/run_cache_2.sh
+++ b/test/cache_2/run_cache_2.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x cache_2.exe ]; then
+if [[ -x cache_2.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-test-cache2.py
 else
 	echo "Test TEST_CACHE2: cache_test2.exe not Found - likely build failed"

--- a/test/coproc_ex/run_coproc_ex.sh
+++ b/test/coproc_ex/run_coproc_ex.sh
@@ -4,7 +4,7 @@
 make
 
 # Check that the exec was built...
-if [ -x coproc_ex.exe ]; then
+if [[ -x coproc_ex.exe ]]; then
 	sst-info revcpu
 	sst --add-lib-path=../../build/src/ ./rev-test-coproc_ex.py
 else

--- a/test/dcmp/run_dcmp.sh
+++ b/test/dcmp/run_dcmp.sh
@@ -4,7 +4,7 @@
 make
 
 # Check that the exec was built...
-if [ -x dcmp.exe ]; then
+if [[ -x dcmp.exe ]]; then
 	sst --add-lib-path=../../src/ ./rev-dcmp.py
 else
 	echo "Test DCMP: dcmp.exe not Found - likely build failed"

--- a/test/dot_double/run_dot_double.sh
+++ b/test/dot_double/run_dot_double.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x dot_double.exe ]; then
+if [[ -x dot_double.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./dot_double.py
 else
 	echo "Test DOT_DOUBLE: dot_double.exe not Found - likely build failed"

--- a/test/dot_single/run_dot_single.sh
+++ b/test/dot_single/run_dot_single.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x dot_single.exe ]; then
+if [[ -x dot_single.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./dot_single.py
 else
 	echo "Test DOT_SINGLE: dot_single.exe not Found - likely build failed"

--- a/test/isa/run_asm_test.sh
+++ b/test/isa/run_asm_test.sh
@@ -4,8 +4,8 @@
 make
 
 # Check that the exec was built...
-if [ -x $RVASM.exe ]; then
-	sst --add-lib-path=../../build/src/ --model-options=$RVASM.exe ./rev-isa-test.py
+if [[ -x $RVASM.exe ]]; then
+	sst --add-lib-path=../../build/src/ "--model-options=$RVASM.exe" ./rev-isa-test.py
 else
 	echo "Test $RVASM ASM: File not found - likely build failed"
 	exit 1

--- a/test/many_core/run_many_core.sh
+++ b/test/many_core/run_many_core.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x many_core.exe ]; then
+if [[ -x many_core.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-many-core.py
 else
 	echo "Test MANY_CORE: many_core.exe not Found - likely build failed"

--- a/test/mem_dump/run_mem_dump.sh
+++ b/test/mem_dump/run_mem_dump.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x basic.exe ]; then
+if [[ -x basic.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./mem_dump.py
 else
 	echo "Test mem_dump (python config options - not syscall version): basic.exe not Found - likely build failed"

--- a/test/memset/run_memset.sh
+++ b/test/memset/run_memset.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -f memset.exe ]; then
+if [[ -f memset.exe ]]; then
   sst --add-lib-path=../../build/src/ ./memset.py
 else
   echo "Test MEMSET: memset.exe not Found - likely build failed"

--- a/test/minfft/run_minfft.sh
+++ b/test/minfft/run_minfft.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -f minfft.exe ]; then
+if [[ -f minfft.exe ]]; then
   sst --add-lib-path=../../build/src/ ./rev-test-minfft.py
 else
   echo "Test MINFFT: minfft.exe not Found - likely build failed"

--- a/test/strlen_c/run_strlen_c.sh
+++ b/test/strlen_c/run_strlen_c.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x strlen_c.exe ]; then
+if [[ -x strlen_c.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./strlen_c.py
 else
 	echo "Test STRLEN_C: strlen_c.exe not Found - likely build failed"

--- a/test/strlen_cxx/run_strlen_cxx.sh
+++ b/test/strlen_cxx/run_strlen_cxx.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x strlen_cxx.exe ]; then
+if [[ -x strlen_cxx.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./strlen_cxx.py
 else
 	echo "Test STRLEN_CXX: strlen_cxx.exe not Found - likely build failed"

--- a/test/strstr/run_strstr.sh
+++ b/test/strstr/run_strstr.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x strstr.exe ]; then
+if [[ -x strstr.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-strstr.py
 else
 	echo "Test STRSTR: strstr.exe not Found - likely build failed"

--- a/test/tracer/bug-fastprint.sh
+++ b/test/tracer/bug-fastprint.sh
@@ -3,9 +3,8 @@
 declare -a opts=("O0" "O1" "O2" "O3")
 
 for opt in "${opts[@]}"; do
-    riscv64-unknown-elf-g++ -g -$opt -march=rv64g -DRV64G -I../../common/syscalls -I../include -o bug-fastprint.$opt.exe bug-fastprint.cc
-    riscv64-unknown-elf-objdump -D --source bug-fastprint.$opt.exe > bug-fastprint.$opt.dis
-    ARCH=rv64g REV_EXE=bug-fastprint.$opt.exe sst --add-lib-path=../../build/src ./rev-test-tracer.py > bug-fastprint.$opt.log
-   ../../scripts/rev-print.py -l bug-fastprint.$opt.log | tee bug-fastprint.$opt.revlog
+    riscv64-unknown-elf-g++ -g "-$opt" -march=rv64g -DRV64G -I../../common/syscalls -I../include -o "bug-fastprint.$opt.exe" bug-fastprint.cc
+    riscv64-unknown-elf-objdump -D --source "bug-fastprint.$opt.exe" > "bug-fastprint.$opt.dis"
+    ARCH=rv64g "REV_EXE=bug-fastprint.$opt.exe" sst --add-lib-path=../../build/src ./rev-test-tracer.py > "bug-fastprint.$opt.log"
+   ../../scripts/rev-print.py -l "bug-fastprint.$opt.log" | tee "bug-fastprint.$opt.revlog"
 done
-

--- a/test/x0/run_x0.sh
+++ b/test/x0/run_x0.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x x0.exe ]; then
+if [[ -x x0.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-test-x0.py
 else
 	echo "Test X0: x0.exe not Found - likely build failed"

--- a/test/zicbom/run_zicbom.sh
+++ b/test/zicbom/run_zicbom.sh
@@ -4,7 +4,7 @@
 make clean && make
 
 # Check that the exec was built...
-if [ -x zicbom.exe ]; then
+if [[ -x zicbom.exe ]]; then
 	sst --add-lib-path=../../build/src/ ./rev-test-zicbom.py
 else
 	echo "Test TEST_ZICBOM: zicbom.exe not Found - likely build failed"


### PR DESCRIPTION
This fixes warnings from the [shellcheck](https://www.shellcheck.net/) linter.

All default and optional warnings except a few have been enabled.

In all of the CI Slurm scripts, multiple redirections in multiple commands were replaced with a single `exec` redirection, which redirects the current shell and its children.

`.githooks/pre-commit` warns if you don't have `shellcheck` installed -- it can be installed with `brew install shellcheck` or `apt-get install shellcheck`.
