### PR TITLE
Move test of read-only CSR to SetCSR()

### DIFF
--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -474,6 +474,10 @@ public:
   /// Set a CSR register
   template<typename XLEN>
   bool SetCSR( uint16_t csr, XLEN val ) {
+    // Read-only CSRs cannot be written to
+    if( csr >= 0xc00 && csr < 0xe00 )
+      return false;
+
     switch( csr ) {
     case fflags: CSR[fcsr] = ( CSR[fcsr] & ~uint64_t{ 0b00011111 } ) | ( val & 0b00011111 ); break;
     case frm: CSR[fcsr] = ( CSR[fcsr] & ~uint64_t{ 0b11100000 } ) | ( val & 0b00000111 ) << 5; break;

--- a/include/insns/Zicsr.h
+++ b/include/insns/Zicsr.h
@@ -72,10 +72,6 @@ class Zicsr : public RevExt {
       }
     }
 
-    // Read-only CSRs cannot be written to
-    if( Inst.imm >= 0xc00 && Inst.imm < 0xe00 )
-      return false;
-
     // Write the new CSR value
     if( !R->SetCSR( Inst.imm, val ) )
       return false;


### PR DESCRIPTION
Move the test for read-only CSRs to `SetCSR()`.