### PR TITLE
Add function to do safe casts from enum->int and int->int

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -36,9 +36,22 @@ namespace SST::RevCPU {
 
 // using float16 = _Float16;
 
+/// Safe non-narrowing cast of enum to integer type
+/// C++17 allows non-narrowing cast of integer to scoped enum, but not the reverse
+template<typename INT, typename ENUM, typename = decltype( INT{ std::declval<std::underlying_type_t<ENUM>>() } )>
+inline constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_enum_v<ENUM>, INT> safe_static_cast( ENUM e ) {
+  return static_cast<INT>( e );
+}
+
+/// Allow non-narrowing int->int cast with enum_int_cast
+template<typename INT, typename ENUM, typename = decltype( INT{ std::declval<ENUM>() } )>
+inline constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_integral_v<ENUM>, INT> safe_static_cast( ENUM e ) {
+  return static_cast<INT>( e );
+}
+
 /// Zero-extend value of bits size
 template<typename T>
-constexpr auto ZeroExt( T val, size_t bits ) {
+inline constexpr auto ZeroExt( T val, size_t bits ) {
   return static_cast<std::make_unsigned_t<T>>( val ) & ( ( std::make_unsigned_t<T>( 1 ) << bits ) - 1 );
 }
 
@@ -51,7 +64,7 @@ constexpr auto SignExt( T val, size_t bits ) {
 
 /// Base-2 logarithm of integers
 template<typename T>
-constexpr int lg( T x ) {
+inline constexpr int lg( T x ) {
   static_assert( std::is_integral_v<T> );
 
   // We select the __builtin_clz which takes integers no smaller than x
@@ -88,7 +101,7 @@ enum class MemOp : uint8_t {
 std::ostream& operator<<( std::ostream& os, MemOp op );
 
 template<typename T>
-constexpr uint64_t LSQHash( T DestReg, RevRegClass RegType, unsigned Hart ) {
+inline constexpr uint64_t LSQHash( T DestReg, RevRegClass RegType, unsigned Hart ) {
   return static_cast<uint64_t>( RegType ) << ( 16 + 8 ) | static_cast<uint64_t>( DestReg ) << 16 | Hart;
 }
 

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -67,7 +67,7 @@ static_assert( std::is_same_v<StandardMem::Request::flags_t, std::underlying_typ
 
 /// RevFlag: determine if the request is an AMO
 constexpr bool RevFlagHas( RevFlag flag, RevFlag has ) {
-  return ( static_cast<uint32_t>( flag ) & static_cast<uint32_t>( has ) ) != 0;
+  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( has ) ) != 0;
 }
 
 inline void RevFlagSet( RevFlag& flag, RevFlag set ) {
@@ -139,10 +139,10 @@ public:
   RevFlag getFlags() const { return flags; }
 
   /// RevMemOp: retrieve the standard set of memory flags for MemEventBase
-  RevFlag getStdFlags() const { return RevFlag{ static_cast<uint32_t>( flags ) & 0xFFFF }; }
+  RevFlag getStdFlags() const { return RevFlag{ safe_static_cast<uint32_t>( flags ) & 0xFFFF }; }
 
   /// RevMemOp: retrieve the flags for MemEventBase without caching enable
-  RevFlag getNonCacheFlags() const { return RevFlag{ static_cast<uint32_t>( flags ) & 0xFFFD }; }
+  RevFlag getNonCacheFlags() const { return RevFlag{ safe_static_cast<uint32_t>( flags ) & 0xFFFD }; }
 
   /// RevMemOp: sets the number of split cache line requests
   void setSplitRqst( unsigned S ) { SplitRqst = S; }
@@ -175,7 +175,9 @@ public:
   const MemReq& getMemReq() const { return procReq; }
 
   // RevMemOp: determine if the request is cache-able
-  bool isCacheable() const { return ( static_cast<uint32_t>( flags ) & static_cast<uint32_t>( RevFlag::F_NONCACHEABLE ) ) == 0; }
+  bool isCacheable() const {
+    return ( safe_static_cast<uint32_t>( flags ) & safe_static_cast<uint32_t>( RevFlag::F_NONCACHEABLE ) ) == 0;
+  }
 
 private:
   unsigned             Hart{};       ///< RevMemOp: RISC-V Hart

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -839,7 +839,7 @@ void RevMem::DumpMem( const uint64_t startAddr, const uint64_t numBytes, const u
     for( uint64_t i = 0; i < bytesPerRow; ++i ) {
       if( addr + i < endAddr ) {
         uint8_t byte = physMem[addr + i];
-        outputStream << std::setw( 2 ) << std::setfill( '0' ) << std::hex << static_cast<uint32_t>( byte ) << " ";
+        outputStream << std::setw( 2 ) << std::setfill( '0' ) << std::hex << uint32_t{ byte } << " ";
       } else {
         outputStream << "   ";
       }

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -117,19 +117,19 @@ void RevTracer::CheckUserControls( uint64_t cycle ) {
 
   // programatic controls
   bool nextState = outputEnabled;
-  if( insn == nops[static_cast<unsigned>( TRC_CMD_IDX::TRACE_OFF )] ) {
+  if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_OFF )] ) {
     nextState = false;
-  } else if( insn == nops[static_cast<unsigned>( TRC_CMD_IDX::TRACE_ON )] ) {
+  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_ON )] ) {
     nextState = true;
-  } else if( insn == nops[static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_OFF )] ) {
+  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_OFF )] ) {
     enableQ[enableQindex] = outputEnabled;
     enableQindex          = ( enableQindex + 1 ) % MAX_ENABLE_Q;
     nextState             = false;
-  } else if( insn == nops[static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_ON )] ) {
+  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_ON )] ) {
     enableQ[enableQindex] = outputEnabled;
     enableQindex          = ( enableQindex + 1 ) % MAX_ENABLE_Q;
     nextState             = true;
-  } else if( insn == nops[static_cast<unsigned>( TRC_CMD_IDX::TRACE_POP )] ) {
+  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_POP )] ) {
     enableQindex = ( enableQindex - 1 ) % MAX_ENABLE_Q;
     nextState    = enableQ[enableQindex];
   }


### PR DESCRIPTION
Normally, `static_cast` must be used to convert `enum class` to integer types. This can be unsafe, because it may convert it to a smaller size than the underlying type of the `enum class`.

This adds a `safe_static_cast` function which acts just like `static_cast`, except it does not allow narrowing conversions (conversions which go from a larger integer/enumeration type to a smaller one).

All places where `static_cast` is used to convert `enum class` to integer have been replaced with `safe_static_cast`.

More changes like this will be needed on Forzarev, since it has many more `enum class` -> integer conversions.

