### PR TITLE
Fix casting in SetX

### DIFF
--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -286,15 +286,14 @@ public:
   /// SetX: Set the specifed X register to a specific value
   template<typename T, typename U>
   void SetX( U rd, T val ) {
-    T res;
     if( IsRV64() ) {
-      res                = RevReg( rd ) != RevReg::zero ? uint64_t( val ) : 0;
+      uint64_t res       = RevReg( rd ) != RevReg::zero ? uint64_t( val ) : 0;
       RV64[size_t( rd )] = res;
-      TRACE_REG_WRITE( size_t( rd ), uint64_t( res ) );
+      TRACE_REG_WRITE( size_t( rd ), res );
     } else {
-      res                = RevReg( rd ) != RevReg::zero ? uint32_t( val ) : 0;
+      uint32_t res       = RevReg( rd ) != RevReg::zero ? uint32_t( val ) : 0;
       RV32[size_t( rd )] = res;
-      TRACE_REG_WRITE( size_t( rd ), uint32_t( res ) );
+      TRACE_REG_WRITE( size_t( rd ), res );
     }
   }
 


### PR DESCRIPTION
This fixes casting in `SetX` so that the temporary result `res` is `uint64_t` or `uint32_t` depending on RV64/RV32, instead of being the same as the type of the argument being passed to `SetX`.

It might not actually affect the behavior, but on RV64, if an `int32_t` is passed in, the current code converts `int32_t` -> `uint64_t` (which in C++ rules sign-extends a signed `int32_t` to 64 bits), but then truncates it back to `int32_t` because that's the type of `res`, and then it assigns `res` to the `uint64_t` `RV64[]` register, which should again perform the sign extension.

This makes the conversion happen in only one place, and it makes the type of `res` depend on RV32/RV64 mode, so that there aren't hidden conversions going on.

@tdysart