### PR TITLE
Add warnings suggesting format and noreturn attributes, and override and final keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-Wmismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ endif()
 # Compiler Options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(FP_MODE_FLAG "-ffp-model=strict -frounding-math -ftrapping-math")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
 else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Werror")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,14 +76,13 @@ endif()
 
 # Compiler Options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(WERROR_FLAG "")
   set(FP_MODE_FLAG "-ffp-model=strict -frounding-math -ftrapping-math")
 else()
-  set(WERROR_FLAG "-Werror")
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Werror")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-Wmismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Werror")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wsuggest-override -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/include/RevCPU.h
+++ b/include/RevCPU.h
@@ -55,13 +55,13 @@ public:
   RevCPU& operator=( const RevCPU& ) = delete;
 
   /// RevCPU: standard SST component 'setup' function
-  void setup();
+  void setup() final;
 
   /// RevCPU: standard SST component 'finish' function
-  void finish();
+  void finish() final;
 
   /// RevCPU: standard SST component 'init' function
-  void init( unsigned int phase );
+  void init( unsigned int phase ) final;
 
   /// RevCPU: standard SST component clock function
   bool clockTick( SST::Cycle_t currentCycle );

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -61,7 +61,14 @@ namespace SST::RevCPU {
 class RevCore;
 
 struct RevCSR : RevZicntr {
-  static constexpr size_t CSR_LIMIT = 0x1000;
+  static constexpr size_t CSR_LIMIT  = 0x1000;
+
+  RevCSR()                           = default;
+  RevCSR( const RevCSR& )            = delete;
+  RevCSR( RevCSR&& )                 = default;
+  RevCSR& operator=( const RevCSR& ) = delete;
+  RevCSR& operator=( RevCSR&& )      = delete;
+  virtual ~RevCSR()                  = default;
 
   // CSR Registers
   enum : uint16_t {
@@ -549,10 +556,7 @@ private:
   std::array<uint64_t, CSR_LIMIT>                                         CSR{};     ///< RegCSR: CSR registers
   std::unordered_map<uint16_t, std::function<uint64_t( uint16_t )>>       Getter{};  ///< RevCSR: CSR Getters
   std::unordered_map<uint16_t, std::function<bool( uint16_t, uint64_t )>> Setter{};  ///< RevCSR: CSR Setters
-
-  /// RevCSR: Get the core owning this hart
-  virtual RevCore* GetCore() const = 0;
-};  // class RevCSR
+};                                                                                   // class RevCSR
 
 }  // namespace SST::RevCPU
 

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -63,12 +63,11 @@ public:
   virtual bool sendRawData( std::vector<uint8_t> Data ) { return true; }
 
   /// RevCoProc: retrieve raw data from the coprocessor
-  virtual const std::vector<uint8_t> getRawData() {
+  virtual std::vector<uint8_t> getRawData() {
     output->fatal( CALL_INFO, -1, "Error : no override method defined for getRawData()\n" );
 
     // inserting code to quiesce warnings
-    std::vector<uint8_t> D;
-    return D;
+    return {};
   }
 
   // --------------------
@@ -130,7 +129,7 @@ public:
   );
 
   // Enum for referencing statistics
-  enum CoProcStats {
+  enum class CoProcStats {
     InstRetired = 0,
   };
 
@@ -138,30 +137,30 @@ public:
   RevSimpleCoProc( ComponentId_t id, Params& params, RevCore* parent );
 
   /// RevSimpleCoProc: destructor
-  virtual ~RevSimpleCoProc()                           = default;
+  ~RevSimpleCoProc() final                             = default;
 
   /// RevSimpleCoProc: disallow copying and assignment
   RevSimpleCoProc( const RevSimpleCoProc& )            = delete;
   RevSimpleCoProc& operator=( const RevSimpleCoProc& ) = delete;
 
-  /// RevSimpleCoProc: clock tick function - currently not registeres with SST, called by RevCPU
-  virtual bool ClockTick( SST::Cycle_t cycle );
+  /// RevSimpleCoProc: clock tick function - currently not registered with SST, called by RevCPU
+  bool ClockTick( SST::Cycle_t cycle ) final;
 
   void registerStats();
 
   /// RevSimpleCoProc: Enqueue Inst into the InstQ and return
-  virtual bool IssueInst( const RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst );
+  bool IssueInst( const RevFeature* F, RevRegFile* R, RevMem* M, uint32_t Inst ) final;
 
   /// RevSimpleCoProc: Reset the co-processor by emmptying the InstQ
-  virtual bool Reset();
+  bool Reset() final;
 
-  /// RevSimpleCoProv: Called when the attached RevCore completes simulation. Could be used to
+  /// RevSimpleCoProc: Called when the attached RevCore completes simulation. Could be used to
   ///                   also signal to SST that the co-processor is done if ClockTick is registered
   ///                   to SSTCore vs. being driven by RevCPU
-  virtual bool Teardown() { return Reset(); };
+  bool Teardown() final { return Reset(); };
 
   /// RevSimpleCoProc: Returns true if instruction queue is empty
-  virtual bool IsDone() { return InstQ.empty(); }
+  bool IsDone() final { return InstQ.empty(); }
 
 private:
   struct RevCoProcInst {

--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -101,7 +101,7 @@ protected:
 // ----------------------------------------
 // RevSimpleCoProc
 // ----------------------------------------
-class RevSimpleCoProc : public RevCoProc {
+class RevSimpleCoProc final : public RevCoProc {
 public:
   SST_ELI_REGISTER_SUBCOMPONENT(
     RevSimpleCoProc,

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -436,7 +436,7 @@ private:
   EcallStatus ECALL_capget();                 // 90, rev_capget(cap_user_header_t header, cap_user_data_t dataptr)
   EcallStatus ECALL_capset();                 // 91, rev_capset(cap_user_header_t header, const cap_user_data_t data)
   EcallStatus ECALL_personality();            // 92, rev_personality(unsigned int personality)
-  EcallStatus ECALL_exit();                   // 93, rev_exit(int error_code)
+  [[noreturn]] EcallStatus ECALL_exit();      // 93, rev_exit(int error_code)
   EcallStatus ECALL_exit_group();             // 94, rev_exit_group(int error_code)
   EcallStatus ECALL_waitid();                 // 95, rev_waitid(int which, pid_t pid, struct siginfo  *infop, int options, struct rusage  *ru)
   EcallStatus ECALL_set_tid_address();        // 96, rev_set_tid_address(int  *tidptr)
@@ -816,7 +816,7 @@ private:
   }
 
   /// RevCore: Check LS queue for outstanding load - ignore x0
-  bool LSQCheck( unsigned HartID, const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) const {
+  static bool LSQCheck( unsigned HartID, const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) {
     if( reg == 0 && regClass == RevRegClass::RegGPR ) {
       return false;  // GPR x0 is not considered
     } else {
@@ -825,7 +825,7 @@ private:
   }
 
   /// RevCore: Check scoreboard for a source register dependency
-  bool ScoreboardCheck( const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) const {
+  static bool ScoreboardCheck( const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) {
     switch( regClass ) {
     case RevRegClass::RegGPR: return reg != 0 && regFile->RV_Scoreboard[reg];
     case RevRegClass::RegFLOAT: return regFile->FP_Scoreboard[reg];

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -47,7 +47,8 @@ enum RevFeatureType : uint32_t {
   RV_ZTSO     = 1 << 21,  ///< RevFeatureType: Ztso-extension
 };
 
-struct RevFeature {
+class RevFeature {
+public:
   /// RevFeature: standard constructor
   RevFeature( std::string Machine, SST::Output* Output, unsigned Min, unsigned Max, unsigned Id );
 

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -78,7 +78,8 @@ enum class RevImmFunc {  ///< Rev Immediate Values
  * following a successful crack + decode
  *
  */
-struct RevInst {
+class RevInst {
+public:
   uint8_t  opcode    = 0;         ///< RevInst: opcode
   uint8_t  funct2    = 0;         ///< RevInst: compressed funct2 value
   uint8_t  funct3    = 0;         ///< RevInst: funct3 value

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -215,13 +215,13 @@ public:
   RevMemCtrl& operator=( const RevMemCtrl& )                                                                            = delete;
 
   /// RevMemCtrl: initialization function
-  virtual void init( unsigned int phase )                                                                               = 0;
+  void init( unsigned int phase ) override                                                                              = 0;
 
   /// RevMemCtrl: setup function
-  virtual void setup()                                                                                                  = 0;
+  void setup() override                                                                                                 = 0;
 
   /// RevMemCtrl: finish function
-  virtual void finish()                                                                                                 = 0;
+  void finish() override                                                                                                = 0;
 
   /// RevMemCtrl: determines if outstanding requests exist
   virtual bool outstandingRqsts()                                                                                       = 0;
@@ -425,103 +425,101 @@ public:
   RevBasicMemCtrl( ComponentId_t id, const Params& params );
 
   /// RevBasicMemCtrl: destructor
-  virtual ~RevBasicMemCtrl();
+  ~RevBasicMemCtrl() final;
 
   /// RevBasicMemCtrl: disallow copying and assignment
   RevBasicMemCtrl( const RevBasicMemCtrl& )            = delete;
   RevBasicMemCtrl& operator=( const RevBasicMemCtrl& ) = delete;
 
   /// RevBasicMemCtrl: initialization function
-  virtual void init( unsigned int phase ) override;
+  void init( unsigned int phase ) final;
 
   /// RevBasicMemCtrl: setup function
-  virtual void setup() override;
+  void setup() final;
 
   /// RevBasicMemCtrl: finish function
-  virtual void finish() override;
+  void finish() final;
 
   /// RevBasicMemCtrl: clock tick function
   virtual bool clockTick( Cycle_t cycle );
 
   /// RevBasicMemCtrl: determines if outstanding requests exist
-  bool outstandingRqsts() override;
+  bool outstandingRqsts() final;
 
   /// RevBasicMemCtrl: returns the cache line size
-  unsigned getLineSize() override { return lineSize; }
+  unsigned getLineSize() final { return lineSize; }
 
   /// RevBasicMemCtrl: memory event processing handler
   void processMemEvent( StandardMem::Request* ev );
 
   /// RevBasicMemCtrl: send a flush request
-  virtual bool sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t PAdr, uint32_t Size, bool Inv, RevFlag flags ) override;
+  bool sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t PAdr, uint32_t Size, bool Inv, RevFlag flags ) final;
 
   /// RevBasicMemCtrl: send a read request
-  virtual bool sendREADRequest(
+  bool sendREADRequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
-  ) override;
+  ) final;
 
   /// RevBasicMemCtrl: send a write request
-  virtual bool sendWRITERequest(
+  bool sendWRITERequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags = RevFlag::F_NONE
-  ) override;
+  ) final;
 
   /// RevBasicMemCtrl: send an AMO request
-  virtual bool sendAMORequest(
+  bool sendAMORequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, const MemReq& req, RevFlag flags
-  ) override;
+  ) final;
 
   // RevBasicMemCtrl: send a readlock request
-  virtual bool sendREADLOCKRequest(
+  bool sendREADLOCKRequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
-  ) override;
+  ) final;
 
   // RevBasicMemCtrl: send a writelock request
-  virtual bool
-    sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) override;
+  bool sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a loadlink request
-  virtual bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) override;
+  bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a storecond request
-  virtual bool
-    sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) override;
+  bool sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send an void custom read memory request
-  virtual bool sendCUSTOMREADRequest(
+  bool sendCUSTOMREADRequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned Opc, RevFlag flags
-  ) override;
+  ) final;
 
   // RevBasicMemCtrl: send a custom write request
-  virtual bool sendCUSTOMWRITERequest(
+  bool sendCUSTOMWRITERequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned Opc, RevFlag flags
-  ) override;
+  ) final;
 
   // RevBasicMemCtrl: send a FENCE request
-  virtual bool sendFENCE( unsigned Hart ) override;
+  bool sendFENCE( unsigned Hart ) final;
 
   /// RevBasicMemCtrl: handle a read response
-  virtual void handleReadResp( StandardMem::ReadResp* ev ) override;
+  void handleReadResp( StandardMem::ReadResp* ev ) final;
 
   /// RevBasicMemCtrl: handle a write response
-  virtual void handleWriteResp( StandardMem::WriteResp* ev ) override;
+  void handleWriteResp( StandardMem::WriteResp* ev ) final;
 
   /// RevBasicMemCtrl: handle a flush response
-  virtual void handleFlushResp( StandardMem::FlushResp* ev ) override;
+  void handleFlushResp( StandardMem::FlushResp* ev ) final;
 
   /// RevBasicMemCtrl: handle a custom response
-  virtual void handleCustomResp( StandardMem::CustomResp* ev ) override;
+  void handleCustomResp( StandardMem::CustomResp* ev ) final;
 
   /// RevBasicMemCtrl: handle an invalidate response
-  virtual void handleInvResp( StandardMem::InvNotify* ev ) override;
+  void handleInvResp( StandardMem::InvNotify* ev ) final;
 
   /// RevBasicMemCtrl: handle RevMemCtrl flags for write responses
-  virtual void handleFlagResp( RevMemOp* op ) override { RevHandleFlagResp( op->getTarget(), op->getSize(), op->getFlags() ); }
+  void handleFlagResp( RevMemOp* op ) final { RevHandleFlagResp( op->getTarget(), op->getSize(), op->getFlags() ); }
 
   /// RevBasicMemCtrl: handle an AMO for the target READ+MODIFY+WRITE triplet
-  virtual void handleAMO( RevMemOp* op ) override;
+  void handleAMO( RevMemOp* op ) final;
 
   /// RevBasicMemCtrl: assign tracer pointer
-  virtual void setTracer( RevTracer* tracer ) override;
+  void setTracer( RevTracer* tracer ) final;
 
 protected:
   // ----------------------------------------
@@ -535,26 +533,26 @@ protected:
     RevStdMemHandlers( RevBasicMemCtrl* Ctrl, SST::Output* output );
 
     /// RevStdMemHandlers: destructor
-    virtual ~RevStdMemHandlers();
+    ~RevStdMemHandlers() final;
 
     /// RevStdMemHandlers: disallow copying and assignment
     RevStdMemHandlers( const RevStdMemHandlers& )            = delete;
     RevStdMemHandlers& operator=( const RevStdMemHandlers& ) = delete;
 
     /// RevStdMemHandlers: handle read response
-    virtual void handle( StandardMem::ReadResp* ev );
+    void handle( StandardMem::ReadResp* ev ) final;
 
     /// RevStdMemhandlers: handle write response
-    virtual void handle( StandardMem::WriteResp* ev );
+    void handle( StandardMem::WriteResp* ev ) final;
 
     /// RevStdMemHandlers: handle flush response
-    virtual void handle( StandardMem::FlushResp* ev );
+    void handle( StandardMem::FlushResp* ev ) final;
 
     /// RevStdMemHandlers: handle custom response
-    virtual void handle( StandardMem::CustomResp* ev );
+    void handle( StandardMem::CustomResp* ev ) final;
 
     /// RevStdMemHandlers: handle invalidate response
-    virtual void handle( StandardMem::InvNotify* ev );
+    void handle( StandardMem::InvNotify* ev ) final;
 
   private:
     RevBasicMemCtrl* Ctrl{};  ///< RevStdMemHandlers: memory controller object

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -305,7 +305,7 @@ protected:
 // ----------------------------------------
 // RevBasicMemCtrl
 // ----------------------------------------
-class RevBasicMemCtrl : public RevMemCtrl {
+class RevBasicMemCtrl final : public RevMemCtrl {
 public:
   SST_ELI_REGISTER_SUBCOMPONENT(
     RevBasicMemCtrl,

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -525,7 +525,7 @@ protected:
   // ----------------------------------------
   // RevStdMemHandlers
   // ----------------------------------------
-  class RevStdMemHandlers : public Interfaces::StandardMem::RequestHandler {
+  class RevStdMemHandlers final : public Interfaces::StandardMem::RequestHandler {
   public:
     friend class RevBasicMemCtrl;
 

--- a/include/RevNIC.h
+++ b/include/RevNIC.h
@@ -102,7 +102,7 @@ public:
 /**
  * RevNIC: the Rev network interface controller subcomponent
  */
-class RevNIC : public nicAPI {
+class RevNIC final : public nicAPI {
 public:
   // Register with the SST Core
   SST_ELI_REGISTER_SUBCOMPONENT(

--- a/include/RevNIC.h
+++ b/include/RevNIC.h
@@ -27,7 +27,7 @@ namespace SST::RevCPU {
 /**
  * nicEvent : inherited class to handle the individual network events for RevNIC
  */
-class nicEvent : public SST::Event {
+class nicEvent final : public SST::Event {
 public:
   /// nicEvent: standard constructor
   explicit nicEvent( std::string name ) : Event(), SrcName( std::move( name ) ) {}

--- a/include/RevNIC.h
+++ b/include/RevNIC.h
@@ -42,7 +42,7 @@ public:
   std::vector<uint8_t> getData() { return Data; }
 
   /// nicEvent: virtual function to clone an event
-  virtual Event* clone( void ) override {
+  Event* clone() final {
     nicEvent* ev = new nicEvent( *this );
     return ev;
   }
@@ -53,10 +53,11 @@ private:
 
 public:
   /// nicEvent: secondary constructor
-  nicEvent() : Event() {}
+  nicEvent()        = default;
+  ~nicEvent() final = default;
 
   /// nicEvent: event serializer
-  void serialize_order( SST::Core::Serialization::serializer& ser ) override {
+  void serialize_order( SST::Core::Serialization::serializer& ser ) final {
     Event::serialize_order( ser );
     ser& SrcName;
     ser& Data;
@@ -74,19 +75,19 @@ public:
   SST_ELI_REGISTER_SUBCOMPONENT_API( SST::RevCPU::nicAPI )
 
   /// nicEvent: constructor
-  nicAPI( ComponentId_t id, Params& params ) : SubComponent( id ) {}
+  nicAPI( ComponentId_t id, Params& ) : SubComponent( id ) {}
 
   /// nicEvent: default destructor
-  virtual ~nicAPI()                                         = default;
+  ~nicAPI() override                                         = default;
 
   /// nicEvent: registers the event handler with the core
-  virtual void setMsgHandler( Event::HandlerBase* handler ) = 0;
+  virtual void setMsgHandler( Event::HandlerBase* handler )  = 0;
 
   /// nicEvent: initializes the network
-  virtual void init( unsigned int phase )                   = 0;
+  void init( unsigned int phase ) override                   = 0;
 
   /// nicEvent: setup the network
-  virtual void setup() {}
+  void setup() override                                      = 0;
 
   /// nicEvent: send a message on the network
   virtual void send( nicEvent* ev, int dest )                = 0;
@@ -125,25 +126,25 @@ public:
   RevNIC( ComponentId_t id, Params& params );
 
   /// RevNIC: destructor
-  virtual ~RevNIC();
+  ~RevNIC() final;
 
   /// RevNIC: Callback to parent on received messages
-  virtual void setMsgHandler( Event::HandlerBase* handler );
+  void setMsgHandler( Event::HandlerBase* handler ) final;
 
   /// RevNIC: initialization function
-  virtual void init( unsigned int phase );
+  void init( unsigned int phase ) final;
 
   /// RevNIC: setup function
-  virtual void setup();
+  void setup() final;
 
   /// RevNIC: send event to the destination id
-  virtual void send( nicEvent* ev, int dest );
+  void send( nicEvent* ev, int dest ) final;
 
   /// RevNIC: retrieve the number of destinations
-  virtual int getNumDestinations();
+  int getNumDestinations() final;
 
   /// RevNIC: get the endpoint's network address
-  virtual SST::Interfaces::SimpleNetwork::nid_t getAddress();
+  SST::Interfaces::SimpleNetwork::nid_t getAddress() final;
 
   /// RevNIC: callback function for the SimpleNetwork interface
   bool msgNotify( int virtualNetwork );

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -130,7 +130,7 @@ enum class RevExceptionCause : int32_t {
 class RevCore;
 class RevTracer;
 
-class RevRegFile : public RevCSR {
+class RevRegFile final : public RevCSR {
   RevCore* const Core;       ///< RevRegFile: Owning core of this register file's hart
   const bool     IsRV64_v;   ///< RevRegFile: Cached copy of Features->IsRV64()
   const bool     HasD_v;     ///< RevRegFile: Cached copy of Features->HasD()

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -192,7 +192,7 @@ public:
   RevRegFile& operator=( const RevRegFile& ) = delete;
 
   /// RevRegFile: standard destructor
-  ~RevRegFile()                              = default;
+  ~RevRegFile() final                        = default;
 
   ///< RevRegFile: Return the core owning this hart
   RevCore* GetCore() const final { return Core; }

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -195,11 +195,11 @@ public:
   ~RevRegFile()                              = default;
 
   ///< RevRegFile: Return the core owning this hart
-  RevCore* GetCore() const { return Core; }
+  RevCore* GetCore() const final { return Core; }
 
   // Feature tests
   ///< RevRegFile: Whether it is RV64
-  bool IsRV64() const { return IsRV64_v; }
+  bool IsRV64() const final { return IsRV64_v; }
 
   ///< RevRegFile: Whenter it is D
   bool HasD() const { return HasD_v; }
@@ -298,7 +298,7 @@ public:
   }
 
   /// GetPC: Get the Program Counter
-  uint64_t GetPC() const {
+  uint64_t GetPC() const final {
     if( IsRV64() ) {
       return RV64_PC;
     } else {

--- a/include/RevZicntr.h
+++ b/include/RevZicntr.h
@@ -23,6 +23,7 @@ class RevCore;
 class RevZicntr {
   uint64_t InstRet{};  ///< RevZicntr: Number of instructions retired
 
+protected:
   /// RevZicntr: Get the core owning this hart
   virtual RevCore* GetCore() const = 0;
 
@@ -40,7 +41,12 @@ class RevZicntr {
     return make_dependent<T>( GetCore() )->output->fatal( CALL_INFO, -1, msg, GetPC() );
   }
 
-protected:
+  RevZicntr()                              = default;
+  RevZicntr( const RevZicntr& )            = delete;
+  RevZicntr( RevZicntr&& )                 = default;
+  RevZicntr& operator=( const RevZicntr& ) = delete;
+  RevZicntr& operator=( RevZicntr&& )      = delete;
+
   template<typename ZICNTR>
   static uint64_t rdcycle( const ZICNTR* Zicntr ) {
     return Zicntr->GetCore()->GetCycles();

--- a/include/SST.h
+++ b/include/SST.h
@@ -17,6 +17,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#pragma GCC diagnostic ignored "-Wsuggest-final-methods"
+#pragma GCC diagnostic ignored "-Wsuggest-final-types"
 
 // The #include order is important, so we prevent clang-format from reordering
 // clang-format off

--- a/include/SST.h
+++ b/include/SST.h
@@ -19,8 +19,11 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
+
+#if defined( __GNUC__ ) && !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#endif
 
 // The #include order is important, so we prevent clang-format from reordering
 // clang-format off

--- a/include/SST.h
+++ b/include/SST.h
@@ -18,6 +18,7 @@
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wsuggest-override"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"
 #pragma GCC diagnostic ignored "-Wsuggest-final-types"
 

--- a/scripts/slurm/build-gcc11-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc11-sst13.1.0.sh
@@ -25,7 +25,7 @@ export CC=gcc-11
 export CXX=g++-11
 export RVCC=riscv64-unknown-elf-gcc
 
-exec >> "../rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
 sst --version
 sst-info revcpu
 

--- a/scripts/slurm/build-gcc11-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc11-sst13.1.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc11-sst14.0.0.sh
+++ b/scripts/slurm/build-gcc11-sst14.0.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc11-sst14.1.0.sh
+++ b/scripts/slurm/build-gcc11-sst14.1.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc11.sh
+++ b/scripts/slurm/build-gcc11.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc13-sst13.1.0.sh
+++ b/scripts/slurm/build-gcc13-sst13.1.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc13-sst14.0.0.sh
+++ b/scripts/slurm/build-gcc13-sst14.0.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-gcc13.sh
+++ b/scripts/slurm/build-gcc13.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-llvm12-sst13.1.0.sh
+++ b/scripts/slurm/build-llvm12-sst13.1.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-llvm12-sst14.0.0.sh
+++ b/scripts/slurm/build-llvm12-sst14.0.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-llvm12-sst14.1.0.sh
+++ b/scripts/slurm/build-llvm12-sst14.1.0.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/scripts/slurm/build-llvm12.sh
+++ b/scripts/slurm/build-llvm12.sh
@@ -35,7 +35,7 @@ cd build || exit
 rm -Rf ./*
 
 #-- Stage 3: initiate the build
-cmake -DBUILD_ASM_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
 make clean
 make uninstall
 make -j

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -449,12 +449,9 @@ void RevCPU::handleMessage( Event* ev ) {
 uint8_t RevCPU::createTag() {
   uint8_t rtn = 0;
   if( PrivTag == 0b11111111 ) {
-    rtn     = 0b00000000;
     PrivTag = 0b00000001;
-    return 0b00000000;
   } else {
-    rtn = PrivTag;
-    PrivTag += 1;
+    rtn = PrivTag++;
   }
   return rtn;
 }

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1049,7 +1049,7 @@ EcallStatus RevCore::ECALL_exit() {
     status
   );
   exit( status );
-  return EcallStatus::SUCCESS;
+  // return EcallStatus::SUCCESS;
 }
 
 // 94, rev_exit_group(int error_code)


### PR DESCRIPTION
Add warnings suggesting the `__attribute__((format(...)))` and `[[noreturn]]` attributes when they are missing on a function which is passed `printf`/`scanf` format strings, or a function which never returns.

Add warnings suggesting the `override` and `final` inheritance-controlling keywords when they can enforce overriding or devirtualize method calls, respectively.

Fix code to fix warnings, including a couple from `clang-tidy`, such as `RevCore` functions which can be `static`, a variable assignment which isn't used, and a `[[noreturn]]` function which returned a value.

The `override` keyword implies `virtual` but also ensures that the function overrides a virtual function in a base class. Specifying `virtual` is redundant with `override`.

The `final` keyword prevents derived classes from overriding it. It requires `virtual`, either by overriding a virtual function in a base class, or by explicitly declaring it as the first and final instance of a virtual function with both `virtual` and `final`. If a `final` method is supposed to override a base class virtual function, then the `virtual` keyword should be left out and `final` is sufficient to ensure it overrides a base class virtual function -- `override` is never needed with `final`.

If a function is declared `final` and is invoked through a pointer / reference to a class type which is equal to or derived from the class type with the `final` method, then VTable lookups can be optimized away by the compiler, and a direct call to the derived class function can be made.

The [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override) recommend that exactly one of `virtual`, `override` or `final` be used for each virtual function declaration.
