### PR TITLE
Add optional CSR handlers

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -39,19 +39,27 @@ namespace SST::RevCPU {
 /// Safe non-narrowing cast of enum to integer type
 /// C++17 allows non-narrowing cast of integer to scoped enum, but not the reverse
 template<typename INT, typename ENUM, typename = decltype( INT{ std::declval<std::underlying_type_t<ENUM>>() } )>
-inline constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_enum_v<ENUM>, INT> safe_static_cast( ENUM e ) {
+constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_enum_v<ENUM>, INT> safe_static_cast( ENUM e ) {
   return static_cast<INT>( e );
 }
 
 /// Allow non-narrowing int->int cast with enum_int_cast
 template<typename INT, typename ENUM, typename = decltype( INT{ std::declval<ENUM>() } )>
-inline constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_integral_v<ENUM>, INT> safe_static_cast( ENUM e ) {
+constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_integral_v<ENUM>, INT> safe_static_cast( ENUM e ) {
   return static_cast<INT>( e );
+}
+
+/// Make an expression dependent on arbitrary template type parameters.
+/// This has the effect of lazy evaluation of an expression until a template containing it is instantiated.
+/// It can be used to wrap an incomplete class type which will be completed by template instantiation time.
+template<typename..., typename T>
+constexpr T&& make_dependent( T&& x ) {
+  return std::forward<T>( x );
 }
 
 /// Zero-extend value of bits size
 template<typename T>
-inline constexpr auto ZeroExt( T val, size_t bits ) {
+constexpr auto ZeroExt( T val, size_t bits ) {
   return static_cast<std::make_unsigned_t<T>>( val ) & ( ( std::make_unsigned_t<T>( 1 ) << bits ) - 1 );
 }
 
@@ -64,7 +72,7 @@ constexpr auto SignExt( T val, size_t bits ) {
 
 /// Base-2 logarithm of integers
 template<typename T>
-inline constexpr int lg( T x ) {
+constexpr int lg( T x ) {
   static_assert( std::is_integral_v<T> );
 
   // We select the __builtin_clz which takes integers no smaller than x
@@ -101,7 +109,7 @@ enum class MemOp : uint8_t {
 std::ostream& operator<<( std::ostream& os, MemOp op );
 
 template<typename T>
-inline constexpr uint64_t LSQHash( T DestReg, RevRegClass RegType, unsigned Hart ) {
+constexpr uint64_t LSQHash( T DestReg, RevRegClass RegType, unsigned Hart ) {
   return static_cast<uint64_t>( RegType ) << ( 16 + 8 ) | static_cast<uint64_t>( DestReg ) << 16 | Hart;
 }
 

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -58,6 +58,16 @@ namespace SST::RevCPU {
 // which makes RevZicntr and RevCSR abstract classes which cannot be
 // instantiated except as a base class of RevRegFile, which defines GetCore().
 //
+// To register a handler to Get or Set a CSR register, call SetCSRGetter() and
+// SetCSRSetter(), supplying it a function. For CSR registers which are not
+// Hart-local but are Core-local, call SetCSRGetter() and SetCSRSetter() in
+// RevCore.
+//
+// The GetCSR() and SetCSR() functions in this class are called at the Hart
+// execution level, and the CSR registers in this class are hart-specific,
+// but the GetCSR() and SetCSR() functions can be overriden to read/write
+// resources outside of this class.
+//
 ////////////////////////////////////////////////////////////////////////////////
 
 class RevCore;

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -473,12 +473,12 @@ public:
 
   ///< RevCSR: Register a custom getter for a particular CSR register
   void SetCSRGetter( uint16_t csr, std::function<uint64_t( uint16_t )> handler ) {
-    Getter.insert_or_assign( csr, std::move( handler ) );
+    handler ? (void) Getter.insert_or_assign( csr, std::move( handler ) ) : (void) Getter.erase( csr );
   }
 
   ///< RevCSR: Register a custom setter for a particular CSR register
   void SetCSRSetter( uint16_t csr, std::function<bool( uint16_t, uint64_t )> handler ) {
-    Setter.insert_or_assign( csr, std::move( handler ) );
+    handler ? (void) Setter.insert_or_assign( csr, std::move( handler ) ) : (void) Setter.erase( csr );
   }
 
   /// Get the Floating-Point Rounding Mode

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -487,7 +487,7 @@ public:
   template<typename CSR, typename = std::enable_if_t<std::is_same_v<CSR, RevCSR>>>
   static std::function<uint64_t( uint16_t )> GetCSRGetter( const CSR* revcsr, uint16_t csr ) {
     auto it = revcsr->Getter.find( csr );
-    if( it == revcsr->Getter.end() ) {
+    if( it == revcsr->Getter.end() || !it->second ) {
       return revcsr->GetCore()->GetCSRGetter( csr );
     } else {
       return it->second;
@@ -499,7 +499,7 @@ public:
   template<typename CSR, typename = std::enable_if_t<std::is_same_v<CSR, RevCSR>>>
   static std::function<uint64_t( uint16_t, uint64_t )> GetCSRSetter( const CSR* revcsr, uint16_t csr ) {
     auto it = revcsr->Setter.find( csr );
-    if( it == revcsr->Setter.end() ) {
+    if( it == revcsr->Setter.end() || !it->second ) {
       return revcsr->GetCore()->GetCSRSetter( csr );
     } else {
       return it->second;

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -25,52 +25,38 @@
 
 namespace SST::RevCPU {
 
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// A note about the separation of scopes in include/insns/Zicsr.h and
-// include/RevCSR.h:
+// A note about the separation of scopes in include/insns/Zicsr.h and include/RevCSR.h:
 //
-// RevCSR.h: GetCSR() and SetCSR() are used to get and set specific CSR
-// registers in the register file, regardless of how we arrive here. If a
-// particular CSR register is disabled because of CPU extensions present, or if
-// a particular CSR register does not apply to it (such as RDTIMEH on RV64),
-// then raise an invalid instruction or other exception here.
+// RevCSR.h: GetCSR() and SetCSR() are used to get and set specific CSR registers in the register file, regardless of how we arrive
+// here. If a particular CSR register is disabled because of CPU extensions present, or if a particular CSR register does not apply
+// to it (such as RDTIMEH on RV64), then raise an invalid instruction or other exception here.
 //
-// Zicsr.h: Decode and execute one of only 6 CSR instructions (csrrw, csrrs,
-// csrrc, csrrwi, csrrsi, csrrci). Do not enable or disable certain CSR
-// registers, or implement the semantics of particular CSR registers here.
-// All CSR instructions with a valid encoding are valid as far as Zicsr.h is
-// concerned. The particular CSR register accessed in a CSR instruction is
-// secondary to the scope of Zicsr.h. Certain pseudoinstructions like RDTIME or
-// FRFLAGS are listed separately in Zicsr.h only for user-friendly disassembly,
-// not for enabling, disabling or implementing them.
+// Zicsr.h: Decode and execute one of only 6 CSR instructions (csrrw, csrrs, csrrc, csrrwi, csrrsi, csrrci). Do not enable or
+// disable certain CSR registers, or implement the semantics of particular CSR registers here. All CSR instructions with a valid
+// encoding are valid as far as Zicsr.h is concerned. The particular CSR register accessed in a CSR instruction is secondary to the
+// scope of Zicsr.h. Certain pseudoinstructions like RDTIME or FRFLAGS are listed separately in Zicsr.h only for user-friendly
+// disassembly, not for enabling, disabling or implementing them.
 //
-// To ease maintainability and prevent large code size, it is recommended that
-// functions related to specific CSR registers be made base classes of RevCSR
-// in separate header files (e.g. RevZicntr). RevCSR can then dispatch the
-// GetCSR()/SetCSR() functions of these CSR registers to the base class.
+// To ease maintainability and prevent large code size, it is recommended that functions related to specific CSR registers be made
+// base classes of RevCSR in separate header files (e.g. RevZicntr). RevCSR can then dispatch the GetCSR()/SetCSR() functions of
+// these CSR registers to the base class.
 //
-// To access a RevCSR or RevRegFile member function in one of its base classes,
-// it is recommended that the function be made a pure virtual function in the
-// base class so that RevCSR or RevRegFile must override it, similar to how
-// GetCore() is a pure virtual function in RevZicntr which RevRegFile
-// overrides. RevZicntr needs GetCore(), but rather than have to store a
-// pointer in RevZicntr's constructor, it is much simpler to simply declare
-// GetCore() as a pure virtual function in RevZicntr which must be overriden,
-// which makes RevZicntr and RevCSR abstract classes which cannot be
-// instantiated except as a base class of RevRegFile, which defines GetCore().
+// To access a RevCSR or RevRegFile member function in one of its base classes, it is recommended that the function be made a pure
+// virtual function in the base class so that RevCSR or RevRegFile must override it, similar to how GetCore() is a pure virtual
+// function in RevZicntr which RevRegFile overrides. RevZicntr needs GetCore(), but rather than have to store a pointer in
+// RevZicntr's constructor, it is much simpler to simply declare GetCore() as a pure virtual function in RevZicntr which must be
+// overriden, which makes RevZicntr and RevCSR abstract classes which cannot be instantiated except as a base class of RevRegFile,
+// which defines GetCore().
 //
-// To register a handler to Get or Set a CSR register, call SetCSRGetter() and
-// SetCSRSetter(), supplying it a function. For CSR registers which are not
-// Hart-local but are Core-local, call SetCSRGetter() and SetCSRSetter() in
-// RevCore.
+// To register a handler to Get or Set a CSR register, call SetCSRGetter() and SetCSRSetter(), supplying it a function. For CSR
+// registers which are not Hart-local but are Core-local, call SetCSRGetter() and SetCSRSetter() in RevCore.
 //
-// The GetCSR() and SetCSR() functions in this class are called at the Hart
-// execution level, and the CSR registers in this class are hart-specific,
-// but the GetCSR() and SetCSR() functions can be overriden to read/write
-// resources outside of this class.
+// The GetCSR() and SetCSR() functions in this class are called at the Hart execution level, and the CSR registers in this class
+// are hart-specific, but the GetCSR() and SetCSR() functions can be overriden to read/write CSR resources outside of this class.
 //
-////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class RevCore;
 
@@ -544,9 +530,8 @@ public:
     return true;
   }
 
-private:
   ///< RevCSR: Get the custom getter for a particular CSR register
-  // If no custom getter exists for this RevCSR, look for one in the owning core
+  // If no custom getter exists for this RevCSR, look for one in the owning RevCore
   template<typename CSR>
   auto GetCSRGetter( CSR csr ) const {
     auto it = Getter.find( csr );
@@ -554,13 +539,14 @@ private:
   }
 
   ///< RevCSR: Get the custom setter for a particular CSR register
-  // If no custom setter exists for this RevCSR, look for one in the owning core
+  // If no custom setter exists for this RevCSR, look for one in the owning RevCore
   template<typename CSR>
   auto GetCSRSetter( CSR csr ) {
     auto it = Setter.find( csr );
     return it != Setter.end() && it->second ? it->second : make_dependent<CSR>( GetCore() )->GetCSRSetter( csr );
   }
 
+private:
   std::array<uint64_t, CSR_LIMIT>                                         CSR{};     ///< RegCSR: CSR registers
   std::unordered_map<uint16_t, std::function<uint64_t( uint16_t )>>       Getter{};  ///< RevCSR: CSR Getters
   std::unordered_map<uint16_t, std::function<bool( uint16_t, uint64_t )>> Setter{};  ///< RevCSR: CSR Setters

--- a/include/RevCSR.h
+++ b/include/RevCSR.h
@@ -60,8 +60,7 @@ namespace SST::RevCPU {
 
 class RevCore;
 
-class RevCSR : public RevZicntr {
-public:
+struct RevCSR : RevZicntr {
   static constexpr size_t CSR_LIMIT = 0x1000;
 
   // CSR Registers
@@ -467,6 +466,22 @@ public:
     handler ? (void) Setter.insert_or_assign( csr, std::move( handler ) ) : (void) Setter.erase( csr );
   }
 
+  ///< RevCSR: Get the custom getter for a particular CSR register
+  // If no custom getter exists for this RevCSR, look for one in the owning RevCore
+  template<typename CSR>
+  auto GetCSRGetter( CSR csr ) const {
+    auto it = Getter.find( csr );
+    return it != Getter.end() && it->second ? it->second : make_dependent<CSR>( GetCore() )->GetCSRGetter( csr );
+  }
+
+  ///< RevCSR: Get the custom setter for a particular CSR register
+  // If no custom setter exists for this RevCSR, look for one in the owning RevCore
+  template<typename CSR>
+  auto GetCSRSetter( CSR csr ) {
+    auto it = Setter.find( csr );
+    return it != Setter.end() && it->second ? it->second : make_dependent<CSR>( GetCore() )->GetCSRSetter( csr );
+  }
+
   /// Get the Floating-Point Rounding Mode
   FRMode GetFRM() const { return static_cast<FRMode>( CSR[fcsr] >> 5 & 0b111 ); }
 
@@ -528,22 +543,6 @@ public:
     }
     // clang-format on
     return true;
-  }
-
-  ///< RevCSR: Get the custom getter for a particular CSR register
-  // If no custom getter exists for this RevCSR, look for one in the owning RevCore
-  template<typename CSR>
-  auto GetCSRGetter( CSR csr ) const {
-    auto it = Getter.find( csr );
-    return it != Getter.end() && it->second ? it->second : make_dependent<CSR>( GetCore() )->GetCSRGetter( csr );
-  }
-
-  ///< RevCSR: Get the custom setter for a particular CSR register
-  // If no custom setter exists for this RevCSR, look for one in the owning RevCore
-  template<typename CSR>
-  auto GetCSRSetter( CSR csr ) {
-    auto it = Setter.find( csr );
-    return it != Setter.end() && it->second ? it->second : make_dependent<CSR>( GetCore() )->GetCSRSetter( csr );
   }
 
 private:

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -288,23 +288,15 @@ public:
   }
 
   ///< RevCore: Get the custom getter for a particular CSR register
-  std::function<uint64_t( uint16_t )> GetCSRGetter( uint16_t csr ) const {
+  auto GetCSRGetter( uint16_t csr ) const {
     auto it = Getter.find( csr );
-    if( it == Getter.end() ) {
-      return {};
-    } else {
-      return it->second;
-    }
+    return it != Getter.end() ? it->second : std::function<uint64_t( uint16_t )>{};
   }
 
   ///< RevCore: Get the custom setter for a particular CSR register
-  std::function<uint64_t( uint16_t, uint64_t )> GetCSRSetter( uint16_t csr ) const {
+  auto GetCSRSetter( uint16_t csr ) const {
     auto it = Setter.find( csr );
-    if( it == Setter.end() ) {
-      return {};
-    } else {
-      return it->second;
-    }
+    return it != Setter.end() ? it->second : std::function<bool( uint16_t, uint64_t )>{};
   }
 
 private:

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -279,12 +279,12 @@ public:
 
   ///< RevCore: Register a custom getter for a particular CSR register
   void SetCSRGetter( uint16_t csr, std::function<uint64_t( uint16_t )> handler ) {
-    Getter.insert_or_assign( csr, std::move( handler ) );
+    handler ? (void) Getter.insert_or_assign( csr, std::move( handler ) ) : (void) Getter.erase( csr );
   }
 
   ///< RevCore: Register a custom setter for a particular CSR register
   void SetCSRSetter( uint16_t csr, std::function<bool( uint16_t, uint64_t )> handler ) {
-    Setter.insert_or_assign( csr, std::move( handler ) );
+    handler ? (void) Setter.insert_or_assign( csr, std::move( handler ) ) : (void) Setter.erase( csr );
   }
 
   ///< RevCore: Get the custom getter for a particular CSR register

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -277,7 +277,40 @@ public:
   ///< RevCore: Returns the number of cycles executed so far
   uint64_t GetCycles() const { return cycles; }
 
+  ///< RevCore: Register a custom getter for a particular CSR register
+  void SetCSRGetter( uint16_t csr, std::function<uint64_t( uint16_t )> handler ) {
+    Getter.insert_or_assign( csr, std::move( handler ) );
+  }
+
+  ///< RevCore: Register a custom setter for a particular CSR register
+  void SetCSRSetter( uint16_t csr, std::function<bool( uint16_t, uint64_t )> handler ) {
+    Setter.insert_or_assign( csr, std::move( handler ) );
+  }
+
+  ///< RevCore: Get the custom getter for a particular CSR register
+  std::function<uint64_t( uint16_t )> GetCSRGetter( uint16_t csr ) const {
+    auto it = Getter.find( csr );
+    if( it == Getter.end() ) {
+      return {};
+    } else {
+      return it->second;
+    }
+  }
+
+  ///< RevCore: Get the custom setter for a particular CSR register
+  std::function<uint64_t( uint16_t, uint64_t )> GetCSRSetter( uint16_t csr ) const {
+    auto it = Setter.find( csr );
+    if( it == Setter.end() ) {
+      return {};
+    } else {
+      return it->second;
+    }
+  }
+
 private:
+  std::unordered_map<uint16_t, std::function<uint64_t( uint16_t )>>       Getter{};
+  std::unordered_map<uint16_t, std::function<bool( uint16_t, uint64_t )>> Setter{};
+
   bool           Halted      = false;  ///< RevCore: determines if the core is halted
   bool           Stalled     = false;  ///< RevCore: determines if the core is stalled on instruction fetch
   bool           SingleStep  = false;  ///< RevCore: determines if we are in a single step

--- a/include/RevZicntr.h
+++ b/include/RevZicntr.h
@@ -34,30 +34,24 @@ class RevZicntr {
 
   // Performance counters
   // Template allows RevCore to be an incomplete type now
-  // std::enable_if_t<...> makes the functions only match ZICNTR == RevZicntr
 
-  template<typename ZICNTR, typename = std::enable_if_t<std::is_same_v<ZICNTR, RevZicntr>>>
-  static void fatal( const ZICNTR* Zicntr, const char* msg ) {
-    return Zicntr->GetCore()->output->fatal( CALL_INFO, -1, msg, Zicntr->GetPC() );
-  }
-
-  template<typename ZICNTR, typename = std::enable_if_t<std::is_same_v<ZICNTR, RevZicntr>>>
-  static bool isZicntr( const ZICNTR* Zicntr ) {
-    return Zicntr->GetCore()->GetRevFeature()->IsModeEnabled( RV_ZICNTR );
+  template<typename T>
+  void fatal( const T* msg ) const {
+    return make_dependent<T>( GetCore() )->output->fatal( CALL_INFO, -1, msg, GetPC() );
   }
 
 protected:
-  template<typename ZICNTR, typename = std::enable_if_t<std::is_same_v<ZICNTR, RevZicntr>>>
+  template<typename ZICNTR>
   static uint64_t rdcycle( const ZICNTR* Zicntr ) {
     return Zicntr->GetCore()->GetCycles();
   }
 
-  template<typename ZICNTR, typename = std::enable_if_t<std::is_same_v<ZICNTR, RevZicntr>>>
+  template<typename ZICNTR>
   static uint64_t rdtime( const ZICNTR* Zicntr ) {
     return Zicntr->GetCore()->GetCurrentSimCycle();
   }
 
-  template<typename ZICNTR, typename = std::enable_if_t<std::is_same_v<ZICNTR, RevZicntr>>>
+  template<typename ZICNTR>
   static uint64_t rdinstret( const ZICNTR* Zicntr ) {
     return Zicntr->InstRet;
   }
@@ -68,12 +62,12 @@ protected:
   // Passed a COUNTER function which gets the 64-bit value of a performance counter
   template<typename XLEN, Half HALF, uint64_t COUNTER( const RevZicntr* )>
   XLEN GetPerfCounter() const {
-    if( !isZicntr( this ) ) {
-      fatal( this, "Illegal instruction at PC = 0x%" PRIx64 ": Zicntr extension not available\n" );
+    if( !make_dependent<XLEN>( GetCore() )->GetRevFeature()->IsModeEnabled( RV_ZICNTR ) ) {
+      fatal( "Illegal instruction at PC = 0x%" PRIx64 ": Zicntr extension not available\n" );
       return 0;
     } else if( IsRV64() ) {
       if constexpr( HALF == Half::Hi ) {
-        fatal( this, "Illegal instruction at PC = 0x%" PRIx64 ": High half of Zicntr register not available on RV64\n" );
+        fatal( "Illegal instruction at PC = 0x%" PRIx64 ": High half of Zicntr register not available on RV64\n" );
         return 0;
       } else {
         return COUNTER( this );

--- a/include/insns/Zicsr.h
+++ b/include/insns/Zicsr.h
@@ -27,6 +27,12 @@
 // a particular CSR register does not apply to it (such as RDTIMEH on RV64),
 // then raise an invalid instruction or other exception here.
 //
+// DO NOT enable/disable CSR registers in this file, or make them get decoded
+// by a coprocessor instead of by the tables in here. These 6 instructions are
+// the same for any RISC-V processor with Zicsr. The semantics of specific CSR
+// registers and whether they are supported should not be handled here, but
+// rather in RevCSR.h and its registered SetCSRGetter() and SetCSRSetter().
+//
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef _SST_REVCPU_ZICSR_H_


### PR DESCRIPTION
This adds optional CSR handlers for getting/setting CSR registers. 

Some CSR registers, like the floating-point and performance counter registers, are already handled specially in `RevCSR.h` with `switch` statements, but they could be registered as handlers dynamically at runtime instead of being implemented statically in `RevCSR` or in one of its base classes like `RevZicntr`. After this change, there are three ways to implement CSR registers:
1. Implement them in the `RevCSR` class, like the floating-point CSR registers are handled today. A `switch` statement handles the `fcsr` register and the `frm` and `fflags` pseudo-registers.
2. Implement them in a base class of `RevCSR`, like the `Zicntr` performance counters are handled in `RevZicntr.h`, and dispatch to the base class functions which get/set them in a `switch` statement. The code is kept mostly separate from the `RevCSR` class, except that the CSR registers it needs to handle need to be dispatched in a `switch` statement.
3. Register Getter/Setter functions for specific CSR registers at runtime, so that `GetCSR()` and `SetCSR()` call these callback functions for specific CSR registers.

This PR allows any code, including coprocessor code, to register handler functions for specific CSR registers, without changing the decoding and execution of `Ziscr` extension CSR instructions.

The Getter function takes a `uint16_t` CSR register number and returns a `uint64_t` value (it does not matter whether XLEN==32 or XLEN==64 because `GetCSR()` explicitly casts it to the `XLEN` type, and `Zicsr.h` calls `GetCSR()` with either `XLEN=uint32_t` or `XLEN=uint64_t` depending on the mode in operation).

The Setter function takes a `uint16_t` CSR register number and a `uint64_t` value to set it to, and returns a `bool` indicating whether it was successful. If it returns `false`, a fatal error in the simulation occurs.

The Getter and Setter functions take a `uint16_t` argument so that the same function can be registered for multiple CSR registers and differentiate them when it is called.

The `SetCSRGetter()` and `SetCSRSetter()` functions in `RevCSR` allow a Getter and Setter function to be set. The `GetCSRGetter()` and `GetCSRGetter()` return the Getter and Setter functions set in `RevCSR`, or fall back to the Getter and Setter functions set in the parent `RevCore` if they were not set in `RevCSR`.

The default behavior of `GetCSR()` and `SetCSR()` is to read or write CSR registers as if they were ordinary registers, without any special semantics. If the CSR registers are simply load/store registers like GP registers, then no special handler needs to be registered if the CSR registers are hart-local.

All 4096 CSR registers **reside architecturally on the main core side**, but if they are core-local CSR registers instead of hart-local CSR registers, then the getters/setters need to store their data per-core and Getters/Setters be set in `RevCore`. The `RevCore` class has similar `SetCSRGetter()`, `SetCSRSetter()`, `GetCSRGetter()` and `GetCSRSetter()` functions.

All 6 CSR operational instructions (`csrrw`, `csrrs`, `csrrc`, `csrrwi`, `csrrsi`, `csrrci`) are handled exactly the same way for all 4096 CSR registers in `Zicsr.h` as a combination of optional read, optional modify, and optional write which is precisely specified in the `Zicsr` specification. There should be no handling of specific CSR registers in `Zicsr.h`, except that pseudoinstructions can be differentiated from their generic equivalents for friendly disassembly.

This adds the vector CSR registers by name and number in the `RevCSR` `enum`, but it removes any mention of whether they are implemented in a coprocessor. This is just a table of CSR register names and numbers made easy to access such as `RevCSR::vl`, but their semantics are handled elsewhere, and entries in this table do not imply the presence of any related extension.