### PR TITLE
Macroize fli instruction table generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-mismatched-tags -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra ${WERROR_FLAG} -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/include/insns/Zfa.h
+++ b/include/insns/Zfa.h
@@ -162,46 +162,63 @@ class Zfa : public RevExt {
     }
   };
 
+  // Macro to generate FLI entries
+#define FLI( index, mnemonic, value )                                                  \
+  ( RevZfaInstDefaults()                                                               \
+      .SetMnemonic( #mnemonic " %rd, " #value )                                        \
+      .SetPredicate( []( uint32_t Inst ) { return DECODE_RS1( Inst ) == ( index ); } ) \
+      .SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ) {                          \
+        R->SetFP( Inst.rd, ( value ) );                                                \
+        R->AdvancePC( Inst );                                                          \
+        return true;                                                                   \
+      } ) )
+
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Single-Precision Instructions
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#undef min
+#undef inf
+#undef nan
+#define min std::numeric_limits<float>::min()
+#define inf std::numeric_limits<float>::infinity()
+#define nan std::numeric_limits<float>::quiet_NaN()
+
   // clang-format off
   std::vector<RevInstEntry> ZfaTable = {
-
     // Load Immediates
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, -0x1p+0f " ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  0; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  -0x1p+0f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, min"       ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  1; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<float>::min() ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-16f"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  2; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p-16f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-15f " ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  3; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p-15f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-8f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  4; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-8f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-7f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  5; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-7f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-4f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  6; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-4f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-3f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  7; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-3f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-2f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  8; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-2f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.4p-2f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  9; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p-2f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.8p-2f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 10; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p-2f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.cp-2f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 11; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp-2f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p-1f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 12; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.4p-1f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 13; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p-1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.8p-1f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 14; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p-1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.cp-1f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 15; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp-1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+0f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 16; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+0f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.4p+0f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 17; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p+0f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.8p+0f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 18; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p+0f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.cp+0f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 19; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp+0f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+1f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 20; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.4p+1f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 21; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p+1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1.8p+1f" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 22; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p+1f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+2f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 23; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+2f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+3f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 24; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+3f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+4f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 25; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+4f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+7f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 26; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+7f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+8f"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 27; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+8f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+15f"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 28; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p+15f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, 0x1p+16f"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 29; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p+16f ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, inf"       ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 30; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<float>::infinity()  ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaInstDefaults().SetMnemonic( "fli.s %rd, nan"       ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 31; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<float>::quiet_NaN() ); R->AdvancePC( Inst ); return true; } ),
+    FLI(  0, fli.s, -0x1p+0f  ),
+    FLI(  1, fli.s, min       ),
+    FLI(  2, fli.s, 0x1p-16f  ),
+    FLI(  3, fli.s, 0x1p-15f  ),
+    FLI(  4, fli.s, 0x1p-8f   ),
+    FLI(  5, fli.s, 0x1p-7f   ),
+    FLI(  6, fli.s, 0x1p-4f   ),
+    FLI(  7, fli.s, 0x1p-3f   ),
+    FLI(  8, fli.s, 0x1p-2f   ),
+    FLI(  9, fli.s, 0x1.4p-2f ),
+    FLI( 10, fli.s, 0x1.8p-2f ),
+    FLI( 11, fli.s, 0x1.cp-2f ),
+    FLI( 12, fli.s, 0x1p-1f   ),
+    FLI( 13, fli.s, 0x1.4p-1f ),
+    FLI( 14, fli.s, 0x1.8p-1f ),
+    FLI( 15, fli.s, 0x1.cp-1f ),
+    FLI( 16, fli.s, 0x1p+0f   ),
+    FLI( 17, fli.s, 0x1.4p+0f ),
+    FLI( 18, fli.s, 0x1.8p+0f ),
+    FLI( 19, fli.s, 0x1.cp+0f ),
+    FLI( 20, fli.s, 0x1p+1f   ),
+    FLI( 21, fli.s, 0x1.4p+1f ),
+    FLI( 22, fli.s, 0x1.8p+1f ),
+    FLI( 23, fli.s, 0x1p+2f   ),
+    FLI( 24, fli.s, 0x1p+3f   ),
+    FLI( 25, fli.s, 0x1p+4f   ),
+    FLI( 26, fli.s, 0x1p+7f   ),
+    FLI( 27, fli.s, 0x1p+8f   ),
+    FLI( 28, fli.s, 0x1p+15f  ),
+    FLI( 29, fli.s, 0x1p+16f  ),
+    FLI( 30, fli.s, inf       ),
+    FLI( 31, fli.s, nan       ),
 
     // FP Minimum and Maximum with NaN returned if any argument is NaN
     RevZfaInstDefaults().SetMnemonic( "fminm.s %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b010 ).SetFunct2or7( 0b0010100 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fminms ),
@@ -217,68 +234,75 @@ class Zfa : public RevExt {
 
   };
 
+  // clang-format on
+
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Double-Precision Instructions
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   struct RevZfaDInstDefaults : RevZfaInstDefaults {
-    RevZfaDInstDefaults() {
-      SetFunct2or7( 0b1111001 );
-    }
+    RevZfaDInstDefaults() { SetFunct2or7( 0b1111001 ); }
   };
 
+#undef min
+#undef inf
+#undef nan
+#define min std::numeric_limits<double>::min()
+#define inf std::numeric_limits<double>::infinity()
+#define nan std::numeric_limits<double>::quiet_NaN()
+
+  // clang-format off
   static std::vector<RevInstEntry> ZfaTableD() { return {
+      // Load Immediates
+      FLI(  0, fli.d, -0x1p+0  ),
+      FLI(  1, fli.d, min      ),
+      FLI(  2, fli.d, 0x1p-16  ),
+      FLI(  3, fli.d, 0x1p-15  ),
+      FLI(  4, fli.d, 0x1p-8   ),
+      FLI(  5, fli.d, 0x1p-7   ),
+      FLI(  6, fli.d, 0x1p-4   ),
+      FLI(  7, fli.d, 0x1p-3   ),
+      FLI(  8, fli.d, 0x1p-2   ),
+      FLI(  9, fli.d, 0x1.4p-2 ),
+      FLI( 10, fli.d, 0x1.8p-2 ),
+      FLI( 11, fli.d, 0x1.cp-2 ),
+      FLI( 12, fli.d, 0x1p-1   ),
+      FLI( 13, fli.d, 0x1.4p-1 ),
+      FLI( 14, fli.d, 0x1.8p-1 ),
+      FLI( 15, fli.d, 0x1.cp-1 ),
+      FLI( 16, fli.d, 0x1p+0   ),
+      FLI( 17, fli.d, 0x1.4p+0 ),
+      FLI( 18, fli.d, 0x1.8p+0 ),
+      FLI( 19, fli.d, 0x1.cp+0 ),
+      FLI( 20, fli.d, 0x1p+1   ),
+      FLI( 21, fli.d, 0x1.4p+1 ),
+      FLI( 22, fli.d, 0x1.8p+1 ),
+      FLI( 23, fli.d, 0x1p+2   ),
+      FLI( 24, fli.d, 0x1p+3   ),
+      FLI( 25, fli.d, 0x1p+4   ),
+      FLI( 26, fli.d, 0x1p+7   ),
+      FLI( 27, fli.d, 0x1p+8   ),
+      FLI( 28, fli.d, 0x1p+15  ),
+      FLI( 29, fli.d, 0x1p+16  ),
+      FLI( 30, fli.d, inf      ),
+      FLI( 31, fli.d, nan      ),
 
-    // Load Immediates
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, -0x1p+0"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  0; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  -0x1p+0 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, min"      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  1; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<double>::min() ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-16"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  2; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p-16 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-15"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  3; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p-15 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-8"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  4; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-8 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-7"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  5; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-7 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-4"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  6; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-4 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-3"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  7; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-3 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-2"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  8; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-2 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.4p-2" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) ==  9; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p-2 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.8p-2" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 10; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p-2 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.cp-2" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 11; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp-2 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p-1"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 12; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p-1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.4p-1" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 13; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p-1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.8p-1" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 14; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p-1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.cp-1" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 15; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp-1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+0"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 16; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+0 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.4p+0" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 17; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p+0 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.8p+0" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 18; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p+0 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.cp+0" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 19; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.cp+0 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+1"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 20; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.4p+1" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 21; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.4p+1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1.8p+1" ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 22; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, 0x1.8p+1 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+2"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 23; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+2 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+3"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 24; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+3 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+4"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 25; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+4 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+7"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 26; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+7 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+8"   ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 27; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,   0x1p+8 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+15"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 28; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p+15 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, 0x1p+16"  ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 29; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd,  0x1p+16 ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, inf"      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 30; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<double>::infinity()  ); R->AdvancePC( Inst ); return true; } ),
-    RevZfaDInstDefaults().SetMnemonic( "fli.d %rd, nan"      ).SetPredicate( []( uint32_t Inst ){ return DECODE_RS1( Inst ) == 31; } ).SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ){ R->SetFP( Inst.rd, std::numeric_limits<double>::quiet_NaN() ); R->AdvancePC( Inst ); return true; } ),
+      // FP Minimum and Maximum with NaN returned if any argument is NaN
+      RevZfaDInstDefaults().SetMnemonic( "fminm.d %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b010 ).SetFunct2or7( 0b0010101 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fminmd ),
+      RevZfaDInstDefaults().SetMnemonic( "fmaxm.d %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b011 ).SetFunct2or7( 0b0010101 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fmaxmd ),
 
-    // FP Minimum and Maximum with NaN returned if any argument is NaN
-    RevZfaDInstDefaults().SetMnemonic( "fminm.d %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b010 ).SetFunct2or7( 0b0010101 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fminmd ),
-    RevZfaDInstDefaults().SetMnemonic( "fmaxm.d %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b011 ).SetFunct2or7( 0b0010101 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fmaxmd ),
+      // FP Round To Integer with and without inexact exception
+      RevZfaDInstDefaults().SetMnemonic( "fround.d %rd, %rs1"   ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegUNKNOWN ).SetRaiseFPE( true ).SetFunct2or7( 0b0100001 ).Setrs2fcvtOp( 0b00100 ).SetImplFunc( froundd   ),
+      RevZfaDInstDefaults().SetMnemonic( "froundnx.d %rd, %rs1" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegUNKNOWN ).SetRaiseFPE( true ).SetFunct2or7( 0b0100001 ).Setrs2fcvtOp( 0b00101 ).SetImplFunc( froundnxd ),
 
-    // FP Round To Integer with and without inexact exception
-    RevZfaDInstDefaults().SetMnemonic( "fround.d %rd, %rs1"   ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegUNKNOWN ).SetRaiseFPE( true ).SetFunct2or7( 0b0100001 ).Setrs2fcvtOp( 0b00100 ).SetImplFunc( froundd   ),
-    RevZfaDInstDefaults().SetMnemonic( "froundnx.d %rd, %rs1" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegUNKNOWN ).SetRaiseFPE( true ).SetFunct2or7( 0b0100001 ).Setrs2fcvtOp( 0b00101 ).SetImplFunc( froundnxd ),
+      // Quiet FP ordered comparison without raising exceptions on NaN inputs
+      RevZfaDInstDefaults().SetMnemonic( "fltq.d %rd, %rs1, %rs2" ).SetFunct3( 0b101 ).SetFunct2or7( 0b1010001 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fltqd ).SetrdClass( RevRegClass::RegGPR ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ),
+      RevZfaDInstDefaults().SetMnemonic( "fleq.d %rd, %rs1, %rs2" ).SetFunct3( 0b100 ).SetFunct2or7( 0b1010001 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fleqd ).SetrdClass( RevRegClass::RegGPR ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ),
 
-    // Quiet FP ordered comparison without raising exceptions on NaN inputs
-    RevZfaDInstDefaults().SetMnemonic( "fltq.d %rd, %rs1, %rs2" ).SetFunct3( 0b101 ).SetFunct2or7( 0b1010001 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fltqd ).SetrdClass( RevRegClass::RegGPR ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ),
-    RevZfaDInstDefaults().SetMnemonic( "fleq.d %rd, %rs1, %rs2" ).SetFunct3( 0b100 ).SetFunct2or7( 0b1010001 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fleqd ).SetrdClass( RevRegClass::RegGPR ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ),
+      // Modular conversion to integer
+      RevZfaDInstDefaults().SetMnemonic( "fcvtmod.w.d %rd, %rs1, rtz" ).SetFunct2or7( 0b1100001 ).SetImplFunc( fcvtmodwd ).SetrdClass( RevRegClass::RegGPR ).Setrs2fcvtOp( 0b01000 ).SetFunct3( 0b001 ).Setrs1Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ),
 
-    // Modular conversion to integer
-    RevZfaDInstDefaults().SetMnemonic( "fcvtmod.w.d %rd, %rs1, rtz" ).SetFunct2or7( 0b1100001 ).SetImplFunc( fcvtmodwd ).SetrdClass( RevRegClass::RegGPR ).Setrs2fcvtOp( 0b01000 ).SetFunct3( 0b001 ).Setrs1Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ),
-
-  }; }
+    }; }
 
   // clang-format on
 

--- a/include/insns/Zfa.h
+++ b/include/insns/Zfa.h
@@ -306,6 +306,10 @@ class Zfa : public RevExt {
 
   // clang-format on
 
+#undef min
+#undef inf
+#undef nan
+
 public:
   /// Zfa: standard constructor
   Zfa( const RevFeature* Feature, RevMem* RevMem, SST::Output* Output ) : RevExt( "Zfa", Feature, RevMem, Output ) {


### PR DESCRIPTION
This uses a new macro `FLI( index, mnemonic, value)` to generate `fli` instructions in the `Zfa` extension. Since there are 32 constants for each floating-point type, this makes the code more concise, and will allow F16 and BF16 to be more easily added later.

