### PR TITLE
Handle iconv errors more gracefully

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -195,7 +195,18 @@ reformat_files() {
     for file in "${FILES[@]}"; do
         if [[ -f $file ]] && is_text_file "$file"; then
             # Replace non-ASCII characters with ASCII equivalents
-            iconv -s -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"
+           if ! iconv -s -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"; then
+                cat <<EOF
+${YELLOW}iconv -f utf-8 -t ascii//TRANSLIT "$file" > "$temp"${END}
+EOF
+                iconv -f utf-8 -t ascii//TRANSLIT "$file" > "$temp" || true
+                fold -s -w79 <<EOF
+${RED}Some non-ASCII characters in $file could not be converted into equivalent
+ASCII characters. Please replace non-ASCII characters in $file and try again.${END}
+EOF
+                exit 1
+            fi
+
             detect_change "$file" "$temp" "%s: Converting non-ASCII characters to ASCII equivalents"
 
             # Change the copyright date at the top of any text files


### PR DESCRIPTION
`iconv` is used in `pre-commit` to convert non-ASCII symbols like smart quotes or continuous vertical or horizontal lines with no gaps into ASCII equivalents.

On MacOS this sometimes fails because it cannot find a conversion. In the example of horizontal and vertical lines @kpgriesser  put in `README.md`, the `iconv` on MacOS failed and the `pre-commit` script failed silently, preventing a commit unless `--no-verify` is used. On Linux, `iconv` converts these characters just fine, replacing them with `|` `+` and `-` characters.

This PR makes `pre-commit` display an informative error message if `iconv` fails, rather than failing silently.
