### PR TITLE
Add bit manipulation functions and prevent implicit changes in integer signedness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations -Werror ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined -Werror ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Werror")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
 else()
   set(FP_MODE_FLAG "-frounding-math -ftrapping-math")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile -Werror")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations -Werror ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/include/RevCPU.h
+++ b/include/RevCPU.h
@@ -61,7 +61,7 @@ public:
   void finish() final;
 
   /// RevCPU: standard SST component 'init' function
-  void init( unsigned int phase ) final;
+  void init( uint32_t phase ) final;
 
   /// RevCPU: standard SST component clock function
   bool clockTick( SST::Cycle_t currentCycle );
@@ -214,10 +214,10 @@ public:
 private:
   uint32_t numCores{};     ///< RevCPU: number of RISC-V cores
   uint32_t numHarts{};     ///< RevCPU: number of RISC-V cores
-  unsigned msgPerCycle{};  ///< RevCPU: number of messages to send per cycle
-  //  unsigned          RDMAPerCycle{};  ///< RevCPU: number of RDMA messages per cycle to inject into PAN network
-  //  unsigned          testStage{};     ///< RevCPU: controls the PAN Test harness staging
-  //  unsigned          testIters{};     ///< RevCPU: the number of message iters for each PAN Test
+  uint32_t msgPerCycle{};  ///< RevCPU: number of messages to send per cycle
+  //  uint32_t          RDMAPerCycle{};  ///< RevCPU: number of RDMA messages per cycle to inject into PAN network
+  //  uint32_t          testStage{};     ///< RevCPU: controls the PAN Test harness staging
+  //  uint32_t          testIters{};     ///< RevCPU: the number of message iters for each PAN Test
   std::unique_ptr<RevOpts>              Opts;     ///< RevCPU: Simulation options object
   std::unique_ptr<RevMem>               Mem;      ///< RevCPU: RISC-V main memory object
   std::unique_ptr<RevLoader>            Loader;   ///< RevCPU: RISC-V loader
@@ -233,7 +233,7 @@ private:
 
   // Adds Thread with ThreadID to AssignedThreads vector for ProcID
   // - Handles updating LSQueue & MarkLoadComplete function pointers
-  void AssignThread( std::unique_ptr<RevThread>&& ThreadToAssign, unsigned ProcID );
+  void AssignThread( std::unique_ptr<RevThread>&& ThreadToAssign, uint32_t ProcID );
 
   // Checks the status of ALL threads that are currently blocked.
   void CheckBlockedThreads();
@@ -268,7 +268,7 @@ private:
 
   int address{ -1 };  ///< RevCPU: local network address
 
-  unsigned fault_width{};  ///< RevCPU: the width (in bits) for target faults
+  uint32_t fault_width{};  ///< RevCPU: the width (in bits) for target faults
   // int64_t  fault_range{};  ///< RevCPU: the range of cycles to inject the fault
   int64_t FaultCntr{};  ///< RevCPU: the fault counter
 
@@ -300,7 +300,7 @@ private:
   std::list<std::pair<uint8_t, int>>     TrackTags{};  ///< RevCPU: tracks the outgoing messages; pair<Tag, Dest>
   std::vector<std::tuple<uint8_t, uint64_t, uint32_t>>
     TrackGets{};  ///< RevCPU: tracks the outstanding get messages; tuple<Tag, Addr, Sz>
-  std::vector<std::tuple<uint8_t, uint32_t, unsigned, int, uint64_t>> ReadQueue{};  ///< RevCPU: outgoing memory read queue
+  std::vector<std::tuple<uint8_t, uint32_t, uint32_t, int, uint64_t>> ReadQueue{};  ///< RevCPU: outgoing memory read queue
   ///<         - Tag
   ///<         - Size
   ///<         - Cost
@@ -406,7 +406,7 @@ private:
   void HandleALUFault( SST::Cycle_t currentCycle );
 
   /// RevCPU: updates sst statistics on a per core basis
-  void UpdateCoreStatistics( unsigned coreNum );
+  void UpdateCoreStatistics( uint32_t coreNum );
 
 };  // class RevCPU
 

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -62,9 +62,9 @@ class RevCore {
 public:
   /// RevCore: standard constructor
   RevCore(
-    unsigned                  id,
+    uint32_t                  id,
     RevOpts*                  opts,
-    unsigned                  numHarts,
+    uint32_t                  numHarts,
     RevMem*                   mem,
     RevLoader*                loader,
     std::function<uint32_t()> GetNewThreadID,
@@ -100,28 +100,28 @@ public:
   void SetTimeConverter( TimeConverter* tc ) { timeConverter = tc; }
 
   /// RevCore: Debug mode read a register
-  bool DebugReadReg( unsigned Idx, uint64_t* Value ) const;
+  bool DebugReadReg( uint32_t Idx, uint64_t* Value ) const;
 
   /// RevCore: Debug mode write a register
-  bool DebugWriteReg( unsigned Idx, uint64_t Value ) const;
+  bool DebugWriteReg( uint32_t Idx, uint64_t Value ) const;
 
   /// RevCore: Set an optional tracer
   void SetTracer( RevTracer* T ) { Tracer = T; }
 
   /// RevCore: Retrieve a random memory cost value
-  unsigned RandCost() { return mem->RandCost( feature->GetMinCost(), feature->GetMaxCost() ); }
+  uint32_t RandCost() { return mem->RandCost( feature->GetMinCost(), feature->GetMaxCost() ); }
 
   /// RevCore: Handle register faults
-  void HandleRegFault( unsigned width );
+  void HandleRegFault( uint32_t width );
 
   /// RevCore: Handle crack+decode faults
-  void HandleCrackFault( unsigned width );
+  void HandleCrackFault( uint32_t width );
 
   /// RevCore: Handle ALU faults
-  void HandleALUFault( unsigned width );
+  void HandleALUFault( uint32_t width );
 
   /// RevCore: Handle ALU faults
-  void InjectALUFault( std::pair<unsigned, unsigned> EToE, RevInst& Inst );
+  void InjectALUFault( std::pair<uint32_t, uint32_t> EToE, RevInst& Inst );
 
   struct RevCoreStats {
     uint64_t totalCycles;
@@ -184,10 +184,10 @@ public:
   void SetCoProc( RevCoProc* coproc );
 
   /// GetHartToExecID: Retrieve the current executing Hart
-  unsigned GetHartToExecID() const { return HartToExecID; }
+  uint32_t GetHartToExecID() const { return HartToExecID; }
 
   /// SetHartToExecID: Set the current executing Hart
-  void SetHartToExecID( unsigned hart ) { HartToExecID = hart; }
+  void SetHartToExecID( uint32_t hart ) { HartToExecID = hart; }
 
   //--------------- External Interface for use with Co-Processor -------------------------
   ///< RevCore: Allow a co-processor to query the bits in scoreboard. Note the RevCorePassKey may only
@@ -261,7 +261,7 @@ public:
   void UpdateStatusOfHarts();
 
   ///< RevCore: Returns the id of an idle hart (or _INVALID_HART_ID_ if none are idle)
-  unsigned FindIdleHartID() const;
+  uint32_t FindIdleHartID() const;
 
   ///< RevCore: Returns true if all harts are available (ie. There is nothing executing on this Core)
   bool HasNoBusyHarts() const { return IdleHarts == ValidHarts; }
@@ -712,22 +712,22 @@ private:
   bool ExecEcall();
 
   /// RevCore: Get a pointer to the register file loaded into Hart w/ HartID
-  RevRegFile* GetRegFile( unsigned HartID ) const;
+  RevRegFile* GetRegFile( uint32_t HartID ) const;
 
   std::vector<RevInstEntry>            InstTable{};   ///< RevCore: target instruction table
   std::vector<std::unique_ptr<RevExt>> Extensions{};  ///< RevCore: vector of enabled extensions
   //std::vector<std::tuple<uint16_t, RevInst, bool>>  Pipeline; ///< RevCore: pipeline of instructions
   std::deque<std::pair<uint16_t, RevInst>>    Pipeline{};     ///< RevCore: pipeline of instructions
-  std::unordered_map<std::string, unsigned>   NameToEntry{};  ///< RevCore: instruction mnemonic to table entry mapping
-  std::unordered_multimap<uint64_t, unsigned> EncToEntry{};   ///< RevCore: instruction encoding to table entry mapping
-  std::unordered_multimap<uint64_t, unsigned> CEncToEntry{};  ///< RevCore: compressed instruction encoding to table entry mapping
-  std::unordered_map<unsigned, std::pair<unsigned, unsigned>> EntryToExt{};  ///< RevCore: instruction entry to extension mapping
+  std::unordered_map<std::string, uint32_t>   NameToEntry{};  ///< RevCore: instruction mnemonic to table entry mapping
+  std::unordered_multimap<uint64_t, uint32_t> EncToEntry{};   ///< RevCore: instruction encoding to table entry mapping
+  std::unordered_multimap<uint64_t, uint32_t> CEncToEntry{};  ///< RevCore: compressed instruction encoding to table entry mapping
+  std::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> EntryToExt{};  ///< RevCore: instruction entry to extension mapping
   ///           first = Master table entry number
   ///           second = pair<Extension Index, Extension Entry>
 
   /// RevCore: finds an entry which matches an encoding whose predicate is true
   auto matchInst(
-    const std::unordered_multimap<uint64_t, unsigned>& map,
+    const std::unordered_multimap<uint64_t, uint32_t>& map,
     uint64_t                                           encoding,
     const std::vector<RevInstEntry>&                   InstTable,
     uint32_t                                           Inst
@@ -779,58 +779,58 @@ private:
   RevInst DecodeCompressed( uint32_t Inst ) const;
 
   /// RevCore: decode an R-type instruction
-  RevInst DecodeRInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeRInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode an I-type instruction
-  RevInst DecodeIInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeIInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode an S-type instruction
-  RevInst DecodeSInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeSInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a U-type instruction
-  RevInst DecodeUInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeUInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a B-type instruction
-  RevInst DecodeBInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeBInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a J-type instruction
-  RevInst DecodeJInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeJInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode an R4-type instruction
-  RevInst DecodeR4Inst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeR4Inst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CR-type isntruction
-  RevInst DecodeCRInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCRInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CI-type isntruction
-  RevInst DecodeCIInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CSS-type isntruction
-  RevInst DecodeCSSInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSSInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CIW-type isntruction
-  RevInst DecodeCIWInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIWInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CL-type isntruction
-  RevInst DecodeCLInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCLInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CS-type isntruction
-  RevInst DecodeCSInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CA-type isntruction
-  RevInst DecodeCAInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCAInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CB-type isntruction
-  RevInst DecodeCBInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCBInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: decode a compressed CJ-type isntruction
-  RevInst DecodeCJInst( uint32_t Inst, unsigned Entry ) const;
+  RevInst DecodeCJInst( uint32_t Inst, uint32_t Entry ) const;
 
   /// RevCore: Determine next thread to execute
-  unsigned GetNextHartToDecodeID() const;
+  uint32_t GetNextHartToDecodeID() const;
 
   /// RevCore: Whether any scoreboard bits are set
-  bool AnyDependency( unsigned HartID, RevRegClass regClass = RevRegClass::RegUNKNOWN ) const {
+  bool AnyDependency( uint32_t HartID, RevRegClass regClass = RevRegClass::RegUNKNOWN ) const {
     const RevRegFile* regFile = GetRegFile( HartID );
     switch( regClass ) {
     case RevRegClass::RegGPR: return regFile->RV_Scoreboard.any();
@@ -841,7 +841,7 @@ private:
   }
 
   /// RevCore: Check LS queue for outstanding load - ignore x0
-  static bool LSQCheck( unsigned HartID, const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) {
+  static bool LSQCheck( uint32_t HartID, const RevRegFile* regFile, uint16_t reg, RevRegClass regClass ) {
     if( reg == 0 && regClass == RevRegClass::RegGPR ) {
       return false;  // GPR x0 is not considered
     } else {
@@ -858,25 +858,25 @@ private:
     }
   }
 
-  bool HartHasNoDependencies( unsigned HartID ) const { return !AnyDependency( HartID ); }
+  bool HartHasNoDependencies( uint32_t HartID ) const { return !AnyDependency( HartID ); }
 
   ///< Removes thread from Hart and returns it
-  std::unique_ptr<RevThread> PopThreadFromHart( unsigned HartID );
+  std::unique_ptr<RevThread> PopThreadFromHart( uint32_t HartID );
 
   /// RevCore: Check scoreboard for pipeline hazards
-  bool DependencyCheck( unsigned HartID, const RevInst* Inst ) const;
+  bool DependencyCheck( uint32_t HartID, const RevInst* Inst ) const;
 
   /// RevCore: Set or clear scoreboard based on instruction destination
-  void DependencySet( unsigned HartID, const RevInst* Inst, bool value = true ) {
+  void DependencySet( uint32_t HartID, const RevInst* Inst, bool value = true ) {
     DependencySet( HartID, Inst->rd, InstTable[Inst->entry].rdClass, value );
   }
 
   /// RevCore: Clear scoreboard on instruction retirement
-  void DependencyClear( unsigned HartID, const RevInst* Inst ) { DependencySet( HartID, Inst, false ); }
+  void DependencyClear( uint32_t HartID, const RevInst* Inst ) { DependencySet( HartID, Inst, false ); }
 
   /// RevCore: Set or clear scoreboard based on register number and floating point.
   template<typename T>
-  void DependencySet( unsigned HartID, T RegNum, RevRegClass regClass, bool value = true ) {
+  void DependencySet( uint32_t HartID, T RegNum, RevRegClass regClass, bool value = true ) {
     if( size_t( RegNum ) < _REV_NUM_REGS_ ) {
       RevRegFile* regFile = GetRegFile( HartID );
       switch( regClass ) {
@@ -892,7 +892,7 @@ private:
 
   /// RevCore: Clear scoreboard on instruction retirement
   template<typename T>
-  void DependencyClear( unsigned HartID, T RegNum, RevRegClass regClass ) {
+  void DependencyClear( uint32_t HartID, T RegNum, RevRegClass regClass ) {
     DependencySet( HartID, RegNum, regClass, false );
   }
 

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -690,15 +690,15 @@ private:
   EcallStatus ECALL_pthread_exit();           // 1002, rev_pthread_exit(void* retval);
 
   EcallStatus ECALL_dump_mem_range();         // 9000, dump_mem_range(uint64_t addr, uint64_t size)
-  EcallStatus ECALL_dump_mem_range_to_file(); // 9001, dump_mem_range_to_file(const char* outputFile, uint64_t addr, uint64_t size)
+  EcallStatus ECALL_dump_mem_range_to_file(); // 9001, dump_mem_range_to_file(const unsigned char* outputFile, uint64_t addr, uint64_t size)
   EcallStatus ECALL_dump_stack();             // 9002, dump_stack()
-  EcallStatus ECALL_dump_stack_to_file();     // 9003, dump_stack(const char* outputFile)
+  EcallStatus ECALL_dump_stack_to_file();     // 9003, dump_stack(const unsigned char* outputFile)
 
   EcallStatus ECALL_dump_valid_mem();         // 9004, dump_valid_mem()
-  EcallStatus ECALL_dump_valid_mem_to_file(); // 9005, dump_valid_mem_to_file(const char* outputFile)
+  EcallStatus ECALL_dump_valid_mem_to_file(); // 9005, dump_valid_mem_to_file(const unsigned char* outputFile)
 
   EcallStatus ECALL_dump_thread_mem();         // 9006, dump_thread_mem()
-  EcallStatus ECALL_dump_thread_mem_to_file(); // 9007, dump_thread_mem_to_file(const char* outputFile)
+  EcallStatus ECALL_dump_thread_mem_to_file(); // 9007, dump_thread_mem_to_file(const unsigned char* outputFile)
 
   // =============== REV print utilities
   EcallStatus ECALL_fast_printf();             // 9010, rev_fast_printf(const char *, ...)

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -800,31 +800,31 @@ private:
   RevInst DecodeR4Inst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CR-type isntruction
-  RevInst DecodeCRInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCRInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CI-type isntruction
-  RevInst DecodeCIInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CSS-type isntruction
-  RevInst DecodeCSSInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSSInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CIW-type isntruction
-  RevInst DecodeCIWInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCIWInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CL-type isntruction
-  RevInst DecodeCLInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCLInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CS-type isntruction
-  RevInst DecodeCSInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCSInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CA-type isntruction
-  RevInst DecodeCAInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCAInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CB-type isntruction
-  RevInst DecodeCBInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCBInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: decode a compressed CJ-type isntruction
-  RevInst DecodeCJInst( uint16_t Inst, unsigned Entry ) const;
+  RevInst DecodeCJInst( uint32_t Inst, unsigned Entry ) const;
 
   /// RevCore: Determine next thread to execute
   unsigned GetNextHartToDecodeID() const;

--- a/include/RevCore.h
+++ b/include/RevCore.h
@@ -308,11 +308,11 @@ private:
   bool           SingleStep  = false;  ///< RevCore: determines if we are in a single step
   bool           CrackFault  = false;  ///< RevCore: determines if we need to handle a crack fault
   bool           ALUFault    = false;  ///< RevCore: determines if we need to handle an ALU fault
-  unsigned       fault_width = 0;      ///< RevCore: the width of the target fault
-  unsigned const id;                   ///< RevCore: processor id
+  uint32_t       fault_width = 0;      ///< RevCore: the width of the target fault
+  uint32_t const id;                   ///< RevCore: processor id
   uint64_t       ExecPC          = 0;  ///< RevCore: executing PC
-  unsigned       HartToDecodeID  = 0;  ///< RevCore: Current executing ThreadID
-  unsigned       HartToExecID    = 0;  ///< RevCore: Thread to dispatch instruction
+  uint32_t       HartToDecodeID  = 0;  ///< RevCore: Current executing ThreadID
+  uint32_t       HartToExecID    = 0;  ///< RevCore: Thread to dispatch instruction
   uint64_t       currentSimCycle = 0;  ///< RevCore: Current simulation cycle
 
   std::vector<std::shared_ptr<RevHart>> Harts{};                ///< RevCore: vector of Harts without a thread assigned to them
@@ -321,7 +321,7 @@ private:
   std::bitset<_MAX_HARTS_>              HartsClearToDecode{};   ///< RevCore: Thread is clear to start (proceed with decode)
   std::bitset<_MAX_HARTS_>              HartsClearToExecute{};  ///< RevCore: Thread is clear to execute (no register dependencides)
 
-  unsigned   numHarts{};  ///< RevCore: Number of Harts for this core
+  uint32_t   numHarts{};  ///< RevCore: Number of Harts for this core
   RevOpts*   opts{};      ///< RevCore: options object
   RevMem*    mem{};       ///< RevCore: memory object
   RevCoProc* coProc{};    ///< RevCore: attached co-processor

--- a/include/RevExt.h
+++ b/include/RevExt.h
@@ -55,7 +55,7 @@ struct RevExt {
   std::string_view GetName() const { return name; }
 
   /// RevExt: baseline execution function
-  bool Execute( unsigned Inst, const RevInst& Payload, uint16_t HartID, RevRegFile* regFile ) const;
+  bool Execute( uint32_t Inst, const RevInst& Payload, uint16_t HartID, RevRegFile* regFile ) const;
 
   /// RevExt: retrieves the extension's instruction table
   const std::vector<RevInstEntry>& GetTable() const { return table; }

--- a/include/RevFeature.h
+++ b/include/RevFeature.h
@@ -50,7 +50,7 @@ enum RevFeatureType : uint32_t {
 class RevFeature {
 public:
   /// RevFeature: standard constructor
-  RevFeature( std::string Machine, SST::Output* Output, unsigned Min, unsigned Max, unsigned Id );
+  RevFeature( std::string Machine, SST::Output* Output, uint32_t Min, uint32_t Max, uint32_t Id );
 
   /// RevFeature: standard destructor
   ~RevFeature()                              = default;
@@ -98,17 +98,17 @@ public:
   uint16_t GetHartToExecID() const { return HartToExecID; }
 
   /// SetHartToExecID: Set the current executing Hart
-  void SetHartToExecID( unsigned hart ) { HartToExecID = hart; }
+  void SetHartToExecID( uint32_t hart ) { HartToExecID = hart; }
 
 private:
   const std::string  machine;                 ///< RevFeature: feature string
   SST::Output* const output;                  ///< RevFeature: output handler
-  const unsigned     MinCost;                 ///< RevFeature: min memory cost
-  const unsigned     MaxCost;                 ///< RevFeature: max memory cost
-  const unsigned     ProcID;                  ///< RevFeature: RISC-V Proc ID
-  unsigned           HartToExecID{};          ///< RevFeature: The current executing Hart on RevCore
+  const uint32_t     MinCost;                 ///< RevFeature: min memory cost
+  const uint32_t     MaxCost;                 ///< RevFeature: max memory cost
+  const uint32_t     ProcID;                  ///< RevFeature: RISC-V Proc ID
+  uint32_t           HartToExecID{};          ///< RevFeature: The current executing Hart on RevCore
   RevFeatureType     features{ RV_UNKNOWN };  ///< RevFeature: feature elements
-  unsigned           xlen{};                  ///< RevFeature: RISC-V Xlen
+  uint32_t           xlen{};                  ///< RevFeature: RISC-V Xlen
 
   /// ParseMachineModel: parse the machine model string
   bool ParseMachineModel();

--- a/include/RevHart.h
+++ b/include/RevHart.h
@@ -20,7 +20,7 @@ namespace SST::RevCPU {
 
 class RevHart {
   ///< RevHart: Id for the Hart (0,1,2,3,etc)
-  unsigned ID{};
+  uint32_t ID{};
 
   ///< RevHart: State management object when a Hart is executing a system call
   EcallState Ecall{};
@@ -41,7 +41,7 @@ class RevHart {
 public:
   ///< RevHart: Constructor
   RevHart(
-    unsigned                                                          ID,
+    uint32_t                                                          ID,
     const std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>>& LSQueue,
     std::function<void( const MemReq& )>                              MarkLoadCompleteFunc
   )

--- a/include/RevInstHelpers.h
+++ b/include/RevInstHelpers.h
@@ -64,7 +64,7 @@ inline constexpr double fpmin<double, uint64_t> = 0x0p+0;
 
 /// General template for converting between Floating Point and Integer.
 /// FP values outside the range of the target integer type are clipped
-/// at the integer type's numerical limits, whether signed or unsigned.
+/// at the integer type's numerical limits, whether signed or uint32_t.
 template<typename INT, typename FP>
 bool fcvtif( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   // Read the FP register. Round to integer according to current rounding mode.

--- a/include/RevInstHelpers.h
+++ b/include/RevInstHelpers.h
@@ -138,7 +138,7 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
       sizeof( T ) < sizeof( int32_t ) ? std::is_signed_v<T> ? RevFlag::F_SEXT32 : RevFlag::F_ZEXT32 : RevFlag::F_NONE;
     auto   rs1 = R->GetX<uint64_t>( Inst.rs1 );  // read once for tracer
     MemReq req{
-      rs1 + Inst.ImmSignExt( 12 ),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       Inst.rd,
       RevRegClass::RegGPR,
       F->GetHartToExecID(),
@@ -147,14 +147,18 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
     M->ReadVal(
-      F->GetHartToExecID(), rs1 + Inst.ImmSignExt( 12 ), reinterpret_cast<T*>( &R->RV32[Inst.rd] ), std::move( req ), flags
+      F->GetHartToExecID(),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
+      reinterpret_cast<T*>( &R->RV32[Inst.rd] ),
+      std::move( req ),
+      flags
     );
   } else {
     static constexpr RevFlag flags =
       sizeof( T ) < sizeof( int64_t ) ? std::is_signed_v<T> ? RevFlag::F_SEXT64 : RevFlag::F_ZEXT64 : RevFlag::F_NONE;
     auto   rs1 = R->GetX<uint64_t>( Inst.rs1 );
     MemReq req{
-      rs1 + Inst.ImmSignExt( 12 ),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       Inst.rd,
       RevRegClass::RegGPR,
       F->GetHartToExecID(),
@@ -163,7 +167,11 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
     M->ReadVal(
-      F->GetHartToExecID(), rs1 + Inst.ImmSignExt( 12 ), reinterpret_cast<T*>( &R->RV64[Inst.rd] ), std::move( req ), flags
+      F->GetHartToExecID(),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
+      reinterpret_cast<T*>( &R->RV64[Inst.rd] ),
+      std::move( req ),
+      flags
     );
   }
 
@@ -176,7 +184,7 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
 /// Store template
 template<typename T>
 bool store( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ), R->GetX<T>( Inst.rs2 ) );
+  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), R->GetX<T>( Inst.rs2 ) );
   R->AdvancePC( Inst );
   return true;
 }
@@ -188,7 +196,7 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
     static constexpr RevFlag flags = sizeof( T ) < sizeof( double ) ? RevFlag::F_BOXNAN : RevFlag::F_NONE;
     uint64_t                 rs1   = R->GetX<uint64_t>( Inst.rs1 );
     MemReq                   req{
-      rs1 + Inst.ImmSignExt( 12 ),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       Inst.rd,
       RevRegClass::RegFLOAT,
       F->GetHartToExecID(),
@@ -197,12 +205,16 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
     M->ReadVal(
-      F->GetHartToExecID(), rs1 + Inst.ImmSignExt( 12 ), reinterpret_cast<T*>( &R->DPF[Inst.rd] ), std::move( req ), flags
+      F->GetHartToExecID(),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
+      reinterpret_cast<T*>( &R->DPF[Inst.rd] ),
+      std::move( req ),
+      flags
     );
   } else {
     uint64_t rs1 = R->GetX<uint64_t>( Inst.rs1 );
     MemReq   req{
-      rs1 + Inst.ImmSignExt( 12 ),
+      rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       Inst.rd,
       RevRegClass::RegFLOAT,
       F->GetHartToExecID(),
@@ -210,7 +222,9 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
       true,
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
-    M->ReadVal( F->GetHartToExecID(), rs1 + Inst.ImmSignExt( 12 ), &R->SPF[Inst.rd], std::move( req ), RevFlag::F_NONE );
+    M->ReadVal(
+      F->GetHartToExecID(), rs1 + uint64_t( Inst.ImmSignExt( 12 ) ), &R->SPF[Inst.rd], std::move( req ), RevFlag::F_NONE
+    );
   }
   // update the cost
   R->cost += M->RandCost( F->GetMinCost(), F->GetMaxCost() );
@@ -222,7 +236,7 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
 template<typename T>
 bool fstore( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   T val = R->GetFP<T, true>( Inst.rs2 );
-  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ), val );
+  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), val );
   R->AdvancePC( Inst );
   return true;
 }
@@ -305,8 +319,8 @@ bool oper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
 /// Left shift functor
 template<typename = void>
 struct ShiftLeft {
-  template<typename T>
-  constexpr T operator()( T val, unsigned shift ) const {
+  template<typename T, typename U>
+  constexpr T operator()( T val, U shift ) const {
     return val << ( sizeof( T ) == 4 ? shift & 0x1f : shift & 0x3f );
   }
 };
@@ -314,8 +328,8 @@ struct ShiftLeft {
 /// Right shift functor
 template<typename = void>
 struct ShiftRight {
-  template<typename T>
-  constexpr T operator()( T val, unsigned shift ) const {
+  template<typename T, typename U>
+  constexpr T operator()( T val, U shift ) const {
     return val >> ( sizeof( T ) == 4 ? shift & 0x1f : shift & 0x3f );
   }
 };
@@ -394,7 +408,7 @@ bool bcond( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
     cond = OP()( R->GetX<SIGN<int32_t>>( Inst.rs1 ), R->GetX<SIGN<int32_t>>( Inst.rs2 ) );
   }
   if( cond ) {
-    R->SetPC( R->GetPC() + Inst.ImmSignExt( 13 ) );
+    R->SetPC( R->GetPC() + uint64_t( Inst.ImmSignExt( 13 ) ) );
   } else {
     R->AdvancePC( Inst );
   }

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -27,18 +27,18 @@ namespace SST::RevCPU {
 
 // Register Decoding functions
 // clang-format off
-constexpr uint8_t  DECODE_RD        ( uint32_t Inst ) { return Inst >>  7 &                0b11111; }
-constexpr uint8_t  DECODE_RS1       ( uint32_t Inst ) { return Inst >> 15 &                0b11111; }
-constexpr uint8_t  DECODE_RS2       ( uint32_t Inst ) { return Inst >> 20 &                0b11111; }
-constexpr uint8_t  DECODE_RS3       ( uint32_t Inst ) { return Inst >> 27 &                0b11111; }
-constexpr uint16_t DECODE_IMM12     ( uint32_t Inst ) { return Inst >> 20 &         0b111111111111; }
+constexpr uint32_t DECODE_RD        ( uint32_t Inst ) { return Inst >>  7 &                0b11111; }
+constexpr uint32_t DECODE_RS1       ( uint32_t Inst ) { return Inst >> 15 &                0b11111; }
+constexpr uint32_t DECODE_RS2       ( uint32_t Inst ) { return Inst >> 20 &                0b11111; }
+constexpr uint32_t DECODE_RS3       ( uint32_t Inst ) { return Inst >> 27 &                0b11111; }
+constexpr uint32_t DECODE_IMM12     ( uint32_t Inst ) { return Inst >> 20 &         0b111111111111; }
 constexpr uint32_t DECODE_IMM20     ( uint32_t Inst ) { return Inst >> 12 & 0b11111111111111111111; }
-constexpr uint8_t  DECODE_LOWER_CRS2( uint32_t Inst ) { return Inst >>  2 &                0b11111; }
-constexpr uint8_t  DECODE_FUNCT7    ( uint32_t Inst ) { return Inst >> 25 &              0b1111111; }
-constexpr uint8_t  DECODE_FUNCT2    ( uint32_t Inst ) { return Inst >> 25 &                   0b11; }
-constexpr uint8_t  DECODE_FUNCT3    ( uint32_t Inst ) { return Inst >> 12 &                  0b111; }
-constexpr bool     DECODE_RL        ( uint32_t Inst ) { return Inst >> 25 &                    0b1; }
-constexpr bool     DECODE_AQ        ( uint32_t Inst ) { return Inst >> 26 &                    0b1; }
+constexpr uint32_t DECODE_LOWER_CRS2( uint32_t Inst ) { return Inst >>  2 &                0b11111; }
+constexpr uint32_t DECODE_FUNCT7    ( uint32_t Inst ) { return Inst >> 25 &              0b1111111; }
+constexpr uint32_t DECODE_FUNCT2    ( uint32_t Inst ) { return Inst >> 25 &                   0b11; }
+constexpr uint32_t DECODE_FUNCT3    ( uint32_t Inst ) { return Inst >> 12 &                  0b111; }
+constexpr uint32_t DECODE_RL        ( uint32_t Inst ) { return Inst >> 25 &                    0b1; }
+constexpr uint32_t DECODE_AQ        ( uint32_t Inst ) { return Inst >> 26 &                    0b1; }
 constexpr FRMode   DECODE_RM        ( uint32_t Inst ) { return FRMode{ Inst >> 12 &          0b111 }; }
 
 // clang-format on

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -100,7 +100,7 @@ public:
   uint8_t  instSize     = 0;         ///< RevInst: size of the instruction in bytes
   bool     compressed   = 0;         ///< RevInst: determines if the instruction is compressed
   uint32_t cost         = 0;         ///< RevInst: the cost to execute this instruction, in clock cycles
-  unsigned entry        = 0;         ///< RevInst: Where to find this instruction in the InstTables
+  uint32_t entry        = 0;         ///< RevInst: Where to find this instruction in the InstTables
   uint16_t hart         = 0;         ///< RevInst: What hart is this inst being executed on
   bool     isCoProcInst = 0;         ///< RevInst: whether instruction is coprocessor instruction
 

--- a/include/RevInstTable.h
+++ b/include/RevInstTable.h
@@ -80,34 +80,34 @@ enum class RevImmFunc {  ///< Rev Immediate Values
  */
 class RevInst {
 public:
-  uint8_t  opcode    = 0;         ///< RevInst: opcode
-  uint8_t  funct2    = 0;         ///< RevInst: compressed funct2 value
-  uint8_t  funct3    = 0;         ///< RevInst: funct3 value
-  uint8_t  funct4    = 0;         ///< RevInst: compressed funct4 value
-  uint8_t  funct6    = 0;         ///< RevInst: compressed funct6 value
-  uint8_t  funct2or7 = 0;         ///< RevInst: uncompressed funct2 or funct7 value
-  uint64_t rd        = ~0;        ///< RevInst: rd value
-  uint64_t rs1       = ~0;        ///< RevInst: rs1 value
-  uint64_t rs2       = ~0;        ///< RevInst: rs2 value
-  uint64_t rs3       = ~0;        ///< RevInst: rs3 value
-  uint64_t imm       = 0;         ///< RevInst: immediate value
-  bool     raisefpe  = 0;         ///< RevInst: raises FP exceptions
-  FRMode   rm{ FRMode::None };    ///< RevInst: floating point rounding mode
-  bool     aq           = false;  ///< RevInst: aqr field for atomic instructions
-  bool     rl           = false;  ///< RevInst: rel field for atomic instructions
-  uint16_t offset       = 0;      ///< RevInst: compressed offset
-  uint16_t jumpTarget   = 0;      ///< RevInst: compressed jumpTarget
-  uint8_t  instSize     = 0;      ///< RevInst: size of the instruction in bytes
-  bool     compressed   = 0;      ///< RevInst: determines if the instruction is compressed
-  uint32_t cost         = 0;      ///< RevInst: the cost to execute this instruction, in clock cycles
-  unsigned entry        = 0;      ///< RevInst: Where to find this instruction in the InstTables
-  uint16_t hart         = 0;      ///< RevInst: What hart is this inst being executed on
-  bool     isCoProcInst = 0;      ///< RevInst: whether instruction is coprocessor instruction
+  uint8_t  opcode    = 0;            ///< RevInst: opcode
+  uint8_t  funct2    = 0;            ///< RevInst: compressed funct2 value
+  uint8_t  funct3    = 0;            ///< RevInst: funct3 value
+  uint8_t  funct4    = 0;            ///< RevInst: compressed funct4 value
+  uint8_t  funct6    = 0;            ///< RevInst: compressed funct6 value
+  uint8_t  funct2or7 = 0;            ///< RevInst: uncompressed funct2 or funct7 value
+  uint64_t rd        = ~uint64_t{};  ///< RevInst: rd value
+  uint64_t rs1       = ~uint64_t{};  ///< RevInst: rs1 value
+  uint64_t rs2       = ~uint64_t{};  ///< RevInst: rs2 value
+  uint64_t rs3       = ~uint64_t{};  ///< RevInst: rs3 value
+  uint64_t imm       = 0;            ///< RevInst: immediate value
+  bool     raisefpe  = 0;            ///< RevInst: raises FP exceptions
+  FRMode   rm{ FRMode::None };       ///< RevInst: floating point rounding mode
+  bool     aq           = false;     ///< RevInst: aqr field for atomic instructions
+  bool     rl           = false;     ///< RevInst: rel field for atomic instructions
+  uint16_t offset       = 0;         ///< RevInst: compressed offset
+  uint16_t jumpTarget   = 0;         ///< RevInst: compressed jumpTarget
+  uint8_t  instSize     = 0;         ///< RevInst: size of the instruction in bytes
+  bool     compressed   = 0;         ///< RevInst: determines if the instruction is compressed
+  uint32_t cost         = 0;         ///< RevInst: the cost to execute this instruction, in clock cycles
+  unsigned entry        = 0;         ///< RevInst: Where to find this instruction in the InstTables
+  uint16_t hart         = 0;         ///< RevInst: What hart is this inst being executed on
+  bool     isCoProcInst = 0;         ///< RevInst: whether instruction is coprocessor instruction
 
   explicit RevInst()    = default;  // prevent aggregate initialization
 
   ///< RevInst: Sign-extended immediate value
-  constexpr int32_t ImmSignExt( size_t bits ) const { return SignExt( imm, bits ); }
+  constexpr int64_t ImmSignExt( int bits ) const { return SignExt( imm, bits ); }
 };  // RevInst
 
 /// CRegIdx: Maps the compressed index to normal index

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -137,7 +137,7 @@ public:
   void handleEvent( Interfaces::StandardMem::Request* ev ) {}
 
   /// RevMem: handle memory injection
-  void HandleMemFault( unsigned width );
+  void HandleMemFault( uint32_t width );
 
   /// RevMem: get the stack_top address
   uint64_t GetStackTop() { return stacktop; }
@@ -155,10 +155,10 @@ public:
   uint64_t GetStackBottom() { return stacktop - _STACK_SIZE_; }
 
   /// RevMem: initiate a memory fence
-  bool FenceMem( unsigned Hart );
+  bool FenceMem( uint32_t Hart );
 
   /// RevMem: retrieves the cache line size.  Returns 0 if no cache is configured
-  unsigned getLineSize() { return ctrl ? ctrl->getLineSize() : 64; }
+  uint32_t getLineSize() { return ctrl ? ctrl->getLineSize() : 64; }
 
   /// RevMem: Enable tracing of load and store instructions.
   void SetTracer( RevTracer* tracer ) { Tracer = tracer; }
@@ -167,38 +167,38 @@ public:
   // ---- Base Memory Interfaces
   // ----------------------------------------------------
   /// RevMem: write to the target memory location with the target flags
-  bool WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void* Data, RevFlag flags = RevFlag::F_NONE );
+  bool WriteMem( uint32_t Hart, uint64_t Addr, size_t Len, const void* Data, RevFlag flags = RevFlag::F_NONE );
 
   /// RevMem: read data from the target memory location
-  bool ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void* Target, const MemReq& req, RevFlag flags = RevFlag::F_NONE );
+  bool ReadMem( uint32_t Hart, uint64_t Addr, size_t Len, void* Target, const MemReq& req, RevFlag flags = RevFlag::F_NONE );
 
   /// RevMem: flush a cache line
-  bool FlushLine( unsigned Hart, uint64_t Addr );
+  bool FlushLine( uint32_t Hart, uint64_t Addr );
 
   /// RevMem: invalidate a cache line
-  bool InvLine( unsigned Hart, uint64_t Addr );
+  bool InvLine( uint32_t Hart, uint64_t Addr );
 
   /// RevMem: clean a line
-  bool CleanLine( unsigned Hart, uint64_t Addr );
+  bool CleanLine( uint32_t Hart, uint64_t Addr );
 
   // ----------------------------------------------------
   // ---- Read Memory Interfaces
   // ----------------------------------------------------
   /// RevMem: template read memory interface
   template<typename T>
-  bool ReadVal( unsigned Hart, uint64_t Addr, T* Target, const MemReq& req, RevFlag flags ) {
+  bool ReadVal( uint32_t Hart, uint64_t Addr, T* Target, const MemReq& req, RevFlag flags ) {
     return ReadMem( Hart, Addr, sizeof( T ), Target, req, flags );
   }
 
   ///  RevMem: LOAD RESERVE memory interface
-  void LR( unsigned hart, uint64_t addr, size_t len, void* target, const MemReq& req, RevFlag flags );
+  void LR( uint32_t hart, uint64_t addr, size_t len, void* target, const MemReq& req, RevFlag flags );
 
   ///  RevMem: STORE CONDITIONAL memory interface
-  bool SC( unsigned Hart, uint64_t addr, size_t len, void* data, RevFlag flags );
+  bool SC( uint32_t Hart, uint64_t addr, size_t len, void* data, RevFlag flags );
 
   /// RevMem: template AMO memory interface
   template<typename T>
-  bool AMOVal( unsigned Hart, uint64_t Addr, T* Data, T* Target, const MemReq& req, RevFlag flags ) {
+  bool AMOVal( uint32_t Hart, uint64_t Addr, T* Data, T* Target, const MemReq& req, RevFlag flags ) {
     return AMOMem( Hart, Addr, sizeof( T ), Data, Target, req, flags );
   }
 
@@ -207,7 +207,7 @@ public:
   // ----------------------------------------------------
 
   template<typename T>
-  void Write( unsigned Hart, uint64_t Addr, T Value ) {
+  void Write( uint32_t Hart, uint64_t Addr, T Value ) {
     if( std::is_same_v<T, float> ) {
       memStats.floatsWritten++;
     } else if( std::is_same_v<T, double> ) {
@@ -228,10 +228,10 @@ public:
   // ---- Atomic/Future/LRSC Interfaces
   // ----------------------------------------------------
   /// RevMem: Initiated an AMO request
-  bool AMOMem( unsigned Hart, uint64_t Addr, size_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags );
+  bool AMOMem( uint32_t Hart, uint64_t Addr, size_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags );
 
   /// RevMem: Invalidate Matching LR reservations
-  bool InvalidateLRReservations( unsigned hart, uint64_t addr, size_t len );
+  bool InvalidateLRReservations( uint32_t hart, uint64_t addr, size_t len );
 
   /// RevMem: Initiates a future operation [RV64P only]
   bool SetFuture( uint64_t Addr );
@@ -243,16 +243,16 @@ public:
   bool StatusFuture( uint64_t Addr );
 
   /// RevMem: Randomly assign a memory cost
-  unsigned RandCost( unsigned Min, unsigned Max ) { return RevRand( Min, Max ); }
+  uint32_t RandCost( uint32_t Min, uint32_t Max ) { return RevRand( Min, Max ); }
 
   /// RevMem: Used to access & incremenet the global software PID counter
   uint32_t GetNewThreadPID();
 
   /// RevMem: Used to set the size of the TLBSize
-  void SetTLBSize( unsigned numEntries ) { tlbSize = numEntries; }
+  void SetTLBSize( uint32_t numEntries ) { tlbSize = numEntries; }
 
   /// RevMem: Used to set the size of the TLBSize
-  void SetMaxHeapSize( const unsigned MaxHeapSize ) { maxHeapSize = MaxHeapSize; }
+  void SetMaxHeapSize( uint64_t MaxHeapSize ) { maxHeapSize = MaxHeapSize; }
 
   /// RevMem: Get memSize value set in .py file
   uint64_t GetMemSize() const { return memSize; }
@@ -366,9 +366,9 @@ private:
   RevMemStats memStats{};
   RevMemStats memStatsTotal{};
 
-  unsigned long memSize{};      ///< RevMem: size of the target memory
-  unsigned      tlbSize{};      ///< RevMem: number of entries in the TLB
-  unsigned      maxHeapSize{};  ///< RevMem: maximum size of the heap
+  uint64_t memSize{};      ///< RevMem: size of the target memory
+  uint32_t tlbSize{};      ///< RevMem: number of entries in the TLB
+  uint64_t maxHeapSize{};  ///< RevMem: maximum size of the heap
   std::unordered_map<uint64_t, std::pair<uint64_t, std::list<uint64_t>::iterator>> TLB{};
   std::list<uint64_t> LRUQueue{};  ///< RevMem: List ordered by last access for implementing LRU policy when TLB fills up
   RevOpts*            opts{};      ///< RevMem: options object
@@ -405,7 +405,7 @@ private:
   uint64_t stacktop{};   ///< RevMem: top of the stack
 
   std::vector<uint64_t>                                     FutureRes{};  ///< RevMem: future operation reservations
-  std::unordered_map<unsigned, std::pair<uint64_t, size_t>> LRSC{};       ///< RevMem: load reserve/store conditional set
+  std::unordered_map<uint32_t, std::pair<uint64_t, size_t>> LRSC{};       ///< RevMem: load reserve/store conditional set
 };                                                                        // class RevMem
 
 }  // namespace SST::RevCPU

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -360,7 +360,7 @@ public:
   void DumpThreadMem( const uint64_t bytesPerRow = 16, std::ostream& outputStream = std::cout );
 
 protected:
-  char* physMem = nullptr;  ///< RevMem: memory container
+  unsigned char* physMem = nullptr;  ///< RevMem: memory container
 
 private:
   RevMemStats memStats{};

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -689,7 +689,7 @@ private:
 /// The operation described by "flags" is applied to memory "Target" with value "value"
 template<typename T>
 void ApplyAMO( RevFlag flags, void* Target, T value ) {
-  // Target and value cast to signed and unsigned versions
+  // Target and value cast to signed and uint32_t versions
   auto* TmpTarget  = static_cast<std::make_signed_t<T>*>( Target );
   auto* TmpTargetU = static_cast<std::make_unsigned_t<T>*>( Target );
   auto  TmpBuf     = static_cast<std::make_signed_t<T>>( value );

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -83,30 +83,30 @@ void RevHandleFlagResp( void* target, size_t size, RevFlag flags );
 class RevMemOp {
 public:
   /// RevMemOp constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, MemOp Op, RevFlag flags );
+  RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, MemOp Op, RevFlag flags );
 
   /// RevMemOp constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, MemOp Op, RevFlag flags );
+  RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, MemOp Op, RevFlag flags );
 
   /// RevMemOp overloaded constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags );
+  RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags );
 
   /// RevMemOp overloaded constructor
   RevMemOp(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
   );
 
   /// RevMemOp overloaded constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags );
+  RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags );
 
   /// RevMemOp overloaded constructor
   RevMemOp(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned CustomOpc, MemOp Op, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t CustomOpc, MemOp Op, RevFlag flags
   );
 
   /// RevMemOp overloaded constructor
   RevMemOp(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, uint32_t CustomOpc, MemOp Op, RevFlag flags
   );
 
   /// RevMemOp default destructor
@@ -120,7 +120,7 @@ public:
   MemOp getOp() const { return Op; }
 
   /// RevMemOp: retrieve the custom opcode
-  unsigned getCustomOpc() const { return CustomOpc; }
+  uint32_t getCustomOpc() const { return CustomOpc; }
 
   /// RevMemOp: retrieve the target address
   uint64_t getAddr() const { return Addr; }
@@ -147,13 +147,13 @@ public:
   RevFlag getNonCacheFlags() const { return RevFlag{ safe_static_cast<uint32_t>( flags ) & 0xFFFD }; }
 
   /// RevMemOp: sets the number of split cache line requests
-  void setSplitRqst( unsigned S ) { SplitRqst = S; }
+  void setSplitRqst( uint32_t S ) { SplitRqst = S; }
 
   /// RevMemOp: set the invalidate flag
   void setInv( bool I ) { Inv = I; }
 
   /// RevMemOp: set the hart
-  void setHart( unsigned H ) { Hart = H; }
+  void setHart( uint32_t H ) { Hart = H; }
 
   /// RevMemOp: set the originating memory request
   void setMemReq( const MemReq& req ) { procReq = req; }
@@ -165,13 +165,13 @@ public:
   bool getInv() const { return Inv; }
 
   /// RevMemOp: retrieve the number of split cache line requests
-  unsigned getSplitRqst() const { return SplitRqst; }
+  uint32_t getSplitRqst() const { return SplitRqst; }
 
   /// RevMemOp: retrieve the target address
   void* getTarget() const { return target; }
 
   /// RevMemOp: retrieve the hart
-  unsigned getHart() const { return Hart; }
+  uint32_t getHart() const { return Hart; }
 
   /// RevMemOp: Get the originating proc memory request
   const MemReq& getMemReq() const { return procReq; }
@@ -182,14 +182,14 @@ public:
   }
 
 private:
-  unsigned             Hart{};       ///< RevMemOp: RISC-V Hart
+  uint32_t             Hart{};       ///< RevMemOp: RISC-V Hart
   uint64_t             Addr{};       ///< RevMemOp: address
   uint64_t             PAddr{};      ///< RevMemOp: physical address (for RevMem I/O)
   uint32_t             Size{};       ///< RevMemOp: size of the memory operation in bytes
   bool                 Inv{};        ///< RevMemOp: flush operation invalidate flag
   MemOp                Op{};         ///< RevMemOp: target memory operation
-  unsigned             CustomOpc{};  ///< RevMemOp: custom memory opcode
-  unsigned             SplitRqst{};  ///< RevMemOp: number of split cache line requests
+  uint32_t             CustomOpc{};  ///< RevMemOp: custom memory opcode
+  uint32_t             SplitRqst{};  ///< RevMemOp: number of split cache line requests
   std::vector<uint8_t> membuf{};     ///< RevMemOp: buffer
   std::vector<uint8_t> tempT{};      ///< RevMemOp: temporary target buffer for R-M-W ops
   RevFlag              flags{};      ///< RevMemOp: request flags
@@ -217,7 +217,7 @@ public:
   RevMemCtrl& operator=( const RevMemCtrl& )                                                                            = delete;
 
   /// RevMemCtrl: initialization function
-  void init( unsigned int phase ) override                                                                              = 0;
+  void init( uint32_t phase ) override                                                                                  = 0;
 
   /// RevMemCtrl: setup function
   void setup() override                                                                                                 = 0;
@@ -229,20 +229,20 @@ public:
   virtual bool outstandingRqsts()                                                                                       = 0;
 
   /// RevMemCtrl: send flush request
-  virtual bool sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, bool Inv, RevFlag flags ) = 0;
+  virtual bool sendFLUSHRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, bool Inv, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send a read request
   virtual bool sendREADRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
   ) = 0;
 
   /// RevMemCtrl: send a write request
   virtual bool
-    sendWRITERequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
+    sendWRITERequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send an AMO request
   virtual bool sendAMORequest(
-    unsigned       Hart,
+    uint32_t       Hart,
     uint64_t       Addr,
     uint64_t       PAddr,
     uint32_t       Size,
@@ -254,32 +254,32 @@ public:
 
   /// RevMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
   ) = 0;
 
   /// RevMemCtrl: send a writelock request
   virtual bool
-    sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
+    sendWRITELOCKRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send a loadlink request
-  virtual bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags )              = 0;
+  virtual bool sendLOADLINKRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags )              = 0;
 
   /// RevMemCtrl: send a storecond request
   virtual bool
-    sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
+    sendSTORECONDRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send an void custom read memory request
   virtual bool sendCUSTOMREADRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned Opc, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t Opc, RevFlag flags
   ) = 0;
 
   /// RevMemCtrl: send a custom write request
   virtual bool sendCUSTOMWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, uint32_t Opc, RevFlag flags
   )                                                            = 0;
 
   /// RevMemCtrl: send a FENCE request
-  virtual bool sendFENCE( unsigned Hart )                      = 0;
+  virtual bool sendFENCE( uint32_t Hart )                      = 0;
 
   /// RevMemCtrl: handle a read response
   virtual void handleReadResp( StandardMem::ReadResp* ev )     = 0;
@@ -303,7 +303,7 @@ public:
   virtual void handleAMO( RevMemOp* op )                       = 0;
 
   /// RevMemCtrl: returns the cache line size
-  virtual unsigned getLineSize()                               = 0;
+  virtual uint32_t getLineSize()                               = 0;
 
   /// Assign processor tracer
   virtual void setTracer( RevTracer* tracer )                  = 0;
@@ -444,7 +444,7 @@ public:
   RevBasicMemCtrl& operator=( const RevBasicMemCtrl& ) = delete;
 
   /// RevBasicMemCtrl: initialization function
-  void init( unsigned int phase ) final;
+  void init( uint32_t phase ) final;
 
   /// RevBasicMemCtrl: setup function
   void setup() final;
@@ -459,27 +459,27 @@ public:
   bool outstandingRqsts() final;
 
   /// RevBasicMemCtrl: returns the cache line size
-  unsigned getLineSize() final { return lineSize; }
+  uint32_t getLineSize() final { return lineSize; }
 
   /// RevBasicMemCtrl: memory event processing handler
   void processMemEvent( StandardMem::Request* ev );
 
   /// RevBasicMemCtrl: send a flush request
-  bool sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t PAdr, uint32_t Size, bool Inv, RevFlag flags ) final;
+  bool sendFLUSHRequest( uint32_t Hart, uint64_t Addr, uint64_t PAdr, uint32_t Size, bool Inv, RevFlag flags ) final;
 
   /// RevBasicMemCtrl: send a read request
   bool sendREADRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
   ) final;
 
   /// RevBasicMemCtrl: send a write request
   bool sendWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags = RevFlag::F_NONE
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags = RevFlag::F_NONE
   ) final;
 
   /// RevBasicMemCtrl: send an AMO request
   bool sendAMORequest(
-    unsigned       Hart,
+    uint32_t       Hart,
     uint64_t       Addr,
     uint64_t       PAddr,
     uint32_t       Size,
@@ -491,32 +491,32 @@ public:
 
   // RevBasicMemCtrl: send a readlock request
   bool sendREADLOCKRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
   ) final;
 
   // RevBasicMemCtrl: send a writelock request
   bool
-    sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
+    sendWRITELOCKRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a loadlink request
-  bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) final;
+  bool sendLOADLINKRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a storecond request
   bool
-    sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
+    sendSTORECONDRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send an void custom read memory request
   bool sendCUSTOMREADRequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned Opc, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t Opc, RevFlag flags
   ) final;
 
   // RevBasicMemCtrl: send a custom write request
   bool sendCUSTOMWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
+    uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, uint32_t Opc, RevFlag flags
   ) final;
 
   // RevBasicMemCtrl: send a FENCE request
-  bool sendFENCE( unsigned Hart ) final;
+  bool sendFENCE( uint32_t Hart ) final;
 
   /// RevBasicMemCtrl: handle a read response
   void handleReadResp( StandardMem::ReadResp* ev ) final;
@@ -583,26 +583,26 @@ protected:
 private:
   /// RevBasicMemCtrl: process the next memory request
   bool processNextRqst(
-    unsigned& t_max_loads,
-    unsigned& t_max_stores,
-    unsigned& t_max_flush,
-    unsigned& t_max_llsc,
-    unsigned& t_max_readlock,
-    unsigned& t_max_writeunlock,
-    unsigned& t_max_custom,
-    unsigned& t_max_ops
+    uint32_t& t_max_loads,
+    uint32_t& t_max_stores,
+    uint32_t& t_max_flush,
+    uint32_t& t_max_llsc,
+    uint32_t& t_max_readlock,
+    uint32_t& t_max_writeunlock,
+    uint32_t& t_max_custom,
+    uint32_t& t_max_ops
   );
 
   /// RevBasicMemCtrl: determine if we can instantiate the target memory operation
   bool isMemOpAvail(
     RevMemOp* Op,
-    unsigned& t_max_loads,
-    unsigned& t_max_stores,
-    unsigned& t_max_flush,
-    unsigned& t_max_llsc,
-    unsigned& t_max_readlock,
-    unsigned& t_max_writeunlock,
-    unsigned& t_max_custom
+    uint32_t& t_max_loads,
+    uint32_t& t_max_stores,
+    uint32_t& t_max_flush,
+    uint32_t& t_max_llsc,
+    uint32_t& t_max_readlock,
+    uint32_t& t_max_writeunlock,
+    uint32_t& t_max_custom
   );
 
   /// RevBasicMemCtrl: build a standard memory request
@@ -615,13 +615,13 @@ private:
   bool buildCacheMemRqst( RevMemOp* op, bool& Success );
 
   /// RevBasicMemCtrl: determine if there are any pending AMOs that would prevent a request from dispatching
-  bool isPendingAMO( unsigned Slot );
+  bool isPendingAMO( uint32_t Slot );
 
   /// RevBasicMemCtrl: determine if we need to utilize AQ ordering semantics
-  bool isAQ( unsigned Slot, unsigned Hart );
+  bool isAQ( uint32_t Slot, uint32_t Hart );
 
   /// RevBasicMemCtrl: determine if we need to utilize RL ordering semantics
-  bool isRL( unsigned Slot, unsigned Hart );
+  bool isRL( uint32_t Slot, uint32_t Hart );
 
   /// RevBasicMemCtrl: register statistics
   void registerStats();
@@ -633,30 +633,30 @@ private:
   uint64_t getTotalRqsts();
 
   /// RevBasicMemCtrl: Determine the number of cache lines are required
-  unsigned getNumCacheLines( uint64_t Addr, uint32_t Size );
+  uint32_t getNumCacheLines( uint64_t Addr, uint32_t Size );
 
   /// RevBasicMemCtrl: Retrieve the base cache line request size
-  unsigned getBaseCacheLineSize( uint64_t Addr, uint32_t Size );
+  uint32_t getBaseCacheLineSize( uint64_t Addr, uint32_t Size );
 
   /// RevBasicMemCtrl: retrieve the number of outstanding requests on the wire
-  unsigned getNumSplitRqsts( RevMemOp* op );
+  uint32_t getNumSplitRqsts( RevMemOp* op );
 
   /// RevBasicMemCtrl: perform the MODIFY portion of the AMO (READ+MODIFY+WRITE)
-  void performAMO( std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry );
+  void performAMO( std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry );
 
   // -- private data members
   StandardMem*       memIface{};         ///< StandardMem memory interface
   RevStdMemHandlers* stdMemHandlers{};   ///< StandardMem interface response handlers
   bool               hasCache{};         ///< detects whether cache layers are present
-  unsigned           lineSize{};         ///< cache line size
-  unsigned           max_loads{};        ///< maximum number of outstanding loads
-  unsigned           max_stores{};       ///< maximum number of outstanding stores
-  unsigned           max_flush{};        ///< maximum number of oustanding flush events
-  unsigned           max_llsc{};         ///< maximum number of outstanding llsc events
-  unsigned           max_readlock{};     ///< maximum number of oustanding readlock events
-  unsigned           max_writeunlock{};  ///< maximum number of oustanding writelock events
-  unsigned           max_custom{};       ///< maximum number of oustanding custom events
-  unsigned           max_ops{};          ///< maximum number of ops to issue per cycle
+  uint64_t           lineSize{};         ///< cache line size
+  uint64_t           max_loads{};        ///< maximum number of outstanding loads
+  uint64_t           max_stores{};       ///< maximum number of outstanding stores
+  uint64_t           max_flush{};        ///< maximum number of oustanding flush events
+  uint64_t           max_llsc{};         ///< maximum number of outstanding llsc events
+  uint64_t           max_readlock{};     ///< maximum number of oustanding readlock events
+  uint64_t           max_writeunlock{};  ///< maximum number of oustanding writelock events
+  uint64_t           max_custom{};       ///< maximum number of oustanding custom events
+  uint64_t           max_ops{};          ///< maximum number of ops to issue per cycle
 
   uint64_t num_read{};         ///< number of outstanding read requests
   uint64_t num_write{};        ///< number of outstanding write requests
@@ -679,7 +679,7 @@ private:
 #define AMOTABLE_IN     5
 
   /// RevBasicMemCtrl: map of amo operations to memory addresses
-  std::multimap<uint64_t, std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
+  std::multimap<uint64_t, std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
 
   std::vector<Statistic<uint64_t>*> stats{};  ///< statistics vector
 

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -89,10 +89,12 @@ public:
   RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, MemOp Op, RevFlag flags );
 
   /// RevMemOp overloaded constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, MemOp Op, RevFlag flags );
+  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags );
 
   /// RevMemOp overloaded constructor
-  RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, MemOp Op, RevFlag flags );
+  RevMemOp(
+    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
+  );
 
   /// RevMemOp overloaded constructor
   RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags );
@@ -104,7 +106,7 @@ public:
 
   /// RevMemOp overloaded constructor
   RevMemOp(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
+    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
   );
 
   /// RevMemOp default destructor
@@ -232,29 +234,39 @@ public:
   /// RevMemCtrl: send a read request
   virtual bool sendREADRequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
-  )                                                                                                                         = 0;
+  ) = 0;
 
   /// RevMemCtrl: send a write request
-  virtual bool sendWRITERequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) = 0;
+  virtual bool
+    sendWRITERequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send an AMO request
   virtual bool sendAMORequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, const MemReq& req, RevFlag flags
+    unsigned       Hart,
+    uint64_t       Addr,
+    uint64_t       PAddr,
+    uint32_t       Size,
+    unsigned char* buffer,
+    void*          target,
+    const MemReq&  req,
+    RevFlag        flags
   ) = 0;
 
   /// RevMemCtrl: send a readlock request
   virtual bool sendREADLOCKRequest(
     unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
-  )                                                                                                                             = 0;
+  ) = 0;
 
   /// RevMemCtrl: send a writelock request
-  virtual bool sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) = 0;
+  virtual bool
+    sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send a loadlink request
-  virtual bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags )                = 0;
+  virtual bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags )              = 0;
 
   /// RevMemCtrl: send a storecond request
-  virtual bool sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) = 0;
+  virtual bool
+    sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) = 0;
 
   /// RevMemCtrl: send an void custom read memory request
   virtual bool sendCUSTOMREADRequest(
@@ -263,7 +275,7 @@ public:
 
   /// RevMemCtrl: send a custom write request
   virtual bool sendCUSTOMWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned Opc, RevFlag flags
+    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
   )                                                            = 0;
 
   /// RevMemCtrl: send a FENCE request
@@ -462,12 +474,19 @@ public:
 
   /// RevBasicMemCtrl: send a write request
   bool sendWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags = RevFlag::F_NONE
+    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags = RevFlag::F_NONE
   ) final;
 
   /// RevBasicMemCtrl: send an AMO request
   bool sendAMORequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, const MemReq& req, RevFlag flags
+    unsigned       Hart,
+    uint64_t       Addr,
+    uint64_t       PAddr,
+    uint32_t       Size,
+    unsigned char* buffer,
+    void*          target,
+    const MemReq&  req,
+    RevFlag        flags
   ) final;
 
   // RevBasicMemCtrl: send a readlock request
@@ -476,13 +495,15 @@ public:
   ) final;
 
   // RevBasicMemCtrl: send a writelock request
-  bool sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) final;
+  bool
+    sendWRITELOCKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a loadlink request
   bool sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send a storecond request
-  bool sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) final;
+  bool
+    sendSTORECONDRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags ) final;
 
   // RevBasicMemCtrl: send an void custom read memory request
   bool sendCUSTOMREADRequest(
@@ -491,7 +512,7 @@ public:
 
   // RevBasicMemCtrl: send a custom write request
   bool sendCUSTOMWRITERequest(
-    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned Opc, RevFlag flags
+    unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
   ) final;
 
   // RevBasicMemCtrl: send a FENCE request
@@ -621,7 +642,7 @@ private:
   unsigned getNumSplitRqsts( RevMemOp* op );
 
   /// RevBasicMemCtrl: perform the MODIFY portion of the AMO (READ+MODIFY+WRITE)
-  void performAMO( std::tuple<unsigned, char*, void*, RevFlag, RevMemOp*, bool> Entry );
+  void performAMO( std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry );
 
   // -- private data members
   StandardMem*       memIface{};         ///< StandardMem memory interface
@@ -658,7 +679,7 @@ private:
 #define AMOTABLE_IN     5
 
   /// RevBasicMemCtrl: map of amo operations to memory addresses
-  std::multimap<uint64_t, std::tuple<unsigned, char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
+  std::multimap<uint64_t, std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
 
   std::vector<Statistic<uint64_t>*> stats{};  ///< statistics vector
 

--- a/include/RevNIC.h
+++ b/include/RevNIC.h
@@ -84,7 +84,7 @@ public:
   virtual void setMsgHandler( Event::HandlerBase* handler )  = 0;
 
   /// nicEvent: initializes the network
-  void init( unsigned int phase ) override                   = 0;
+  void init( uint32_t phase ) override                       = 0;
 
   /// nicEvent: setup the network
   void setup() override                                      = 0;
@@ -132,7 +132,7 @@ public:
   void setMsgHandler( Event::HandlerBase* handler ) final;
 
   /// RevNIC: initialization function
-  void init( unsigned int phase ) final;
+  void init( uint32_t phase ) final;
 
   /// RevNIC: setup function
   void setup() final;

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -26,16 +26,16 @@ namespace SST::RevCPU {
 class RevOpts {
 public:
   /// RevOpts: options constructor
-  RevOpts( unsigned NumCores, unsigned NumHarts, const int Verbosity );
+  RevOpts( uint32_t NumCores, uint32_t NumHarts, const int Verbosity );
 
   /// RevOpts: options destructor
   ~RevOpts() = default;
 
   /// RevOpts: retrieve the number of configured cores
-  unsigned GetNumCores() { return numCores; }
+  uint32_t GetNumCores() { return numCores; }
 
   /// RevOpts: retrieve the number of configured harts per core
-  unsigned GetNumHarts() { return numHarts; }
+  uint32_t GetNumHarts() { return numHarts; }
 
   /// RevOpts: retrieve the verbosity level
   int GetVerbosity() { return verbosity; }
@@ -59,22 +59,22 @@ public:
   bool InitPrefetchDepth( const std::vector<std::string>& Depths );
 
   /// RevOpts: retrieve the start address for the target core
-  bool GetStartAddr( unsigned Core, uint64_t& StartAddr );
+  bool GetStartAddr( uint32_t Core, uint64_t& StartAddr );
 
   /// RevOpts: retrieve the start symbol for the target core
-  bool GetStartSymbol( unsigned Core, std::string& Symbol );
+  bool GetStartSymbol( uint32_t Core, std::string& Symbol );
 
   /// RevOpts: retrieve the machine model string for the target core
-  bool GetMachineModel( unsigned Core, std::string& MachModel );
+  bool GetMachineModel( uint32_t Core, std::string& MachModel );
 
   /// RevOpts: retrieve instruction table for the target core
-  bool GetInstTable( unsigned Core, std::string& Table );
+  bool GetInstTable( uint32_t Core, std::string& Table );
 
   /// RevOpts: retrieve the memory cost range for the target core
-  bool GetMemCost( unsigned Core, unsigned& Min, unsigned& Max );
+  bool GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max );
 
   /// RevOpts: retrieve the prefetch depth for the target core
-  bool GetPrefetchDepth( unsigned Core, unsigned& Depth );
+  bool GetPrefetchDepth( uint32_t Core, uint32_t& Depth );
 
   /// RevOpts: set the argv array
   void SetArgs( const SST::Params& params );
@@ -91,16 +91,16 @@ public:
   }
 
 private:
-  unsigned numCores{};   ///< RevOpts: number of initialized cores
-  unsigned numHarts{};   ///< RevOpts: number of harts per core
+  uint32_t numCores{};   ///< RevOpts: number of initialized cores
+  uint32_t numHarts{};   ///< RevOpts: number of harts per core
   int      verbosity{};  ///< RevOpts: verbosity level
 
-  std::unordered_map<unsigned, uint64_t>     startAddr{};      ///< RevOpts: map of core id to starting address
-  std::unordered_map<unsigned, std::string>  startSym{};       ///< RevOpts: map of core id to starting symbol
-  std::unordered_map<unsigned, std::string>  machine{};        ///< RevOpts: map of core id to machine model
-  std::unordered_map<unsigned, std::string>  table{};          ///< RevOpts: map of core id to inst table
-  std::unordered_map<unsigned, unsigned>     prefetchDepth{};  ///< RevOpts: map of core id to prefretch depth
-  std::vector<std::pair<unsigned, unsigned>> memCosts{};       ///< RevOpts: vector of memory cost ranges
+  std::unordered_map<uint32_t, uint64_t>     startAddr{};      ///< RevOpts: map of core id to starting address
+  std::unordered_map<uint32_t, std::string>  startSym{};       ///< RevOpts: map of core id to starting symbol
+  std::unordered_map<uint32_t, std::string>  machine{};        ///< RevOpts: map of core id to machine model
+  std::unordered_map<uint32_t, std::string>  table{};          ///< RevOpts: map of core id to inst table
+  std::unordered_map<uint32_t, uint32_t>     prefetchDepth{};  ///< RevOpts: map of core id to prefretch depth
+  std::vector<std::pair<uint32_t, uint32_t>> memCosts{};       ///< RevOpts: vector of memory cost ranges
   std::vector<std::string>                   Argv{};           ///< RevOpts: vector of function arguments
   std::vector<std::string>                   MemDumpRanges{};  ///< RevOpts: vector of function arguments
 

--- a/include/RevPrefetcher.h
+++ b/include/RevPrefetcher.h
@@ -30,7 +30,7 @@ public:
   RevPrefetcher(
     RevMem*                                                    Mem,
     RevFeature*                                                Feature,
-    unsigned                                                   Depth,
+    uint32_t                                                   Depth,
     std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> lsq,
     std::function<void( const MemReq& )>                       func
   )
@@ -55,7 +55,7 @@ public:
 private:
   RevMem*                                                    mem{};       ///< RevMem object
   RevFeature*                                                feature{};   ///< RevFeature object
-  unsigned                                                   depth{};     ///< Depth of each prefetcher stream
+  uint32_t                                                   depth{};     ///< Depth of each prefetcher stream
   std::vector<uint64_t>                                      baseAddr{};  ///< Vector of base addresses for each stream
   std::vector<std::vector<uint32_t>>                         iStack{};    ///< Vector of instruction vectors
   std::shared_ptr<std::unordered_multimap<uint64_t, MemReq>> LSQueue{};

--- a/include/RevRand.h
+++ b/include/RevRand.h
@@ -66,9 +66,9 @@ inline auto RevRand( T min, U max ) {
   thread_local RevRNG RNG;
   using TU = std::common_type_t<T, U>;
   if constexpr( std::is_floating_point_v<TU> ) {
-    return std::uniform_real_distribution<TU>( min, max )( RNG );
+    return std::uniform_real_distribution<TU>( TU( min ), TU( max ) )( RNG );
   } else {
-    return std::uniform_int_distribution<TU>( min, max )( RNG );
+    return std::uniform_int_distribution<TU>( TU( min ), TU( max ) )( RNG );
   }
 }
 

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -135,7 +135,7 @@ class RevRegFile final : public RevCSR {
   const bool     IsRV64_v;   ///< RevRegFile: Cached copy of Features->IsRV64()
   const bool     HasD_v;     ///< RevRegFile: Cached copy of Features->HasD()
   bool           trigger{};  ///< RevRegFile: Has the instruction been triggered?
-  unsigned       Entry{};    ///< RevRegFile: Instruction entry
+  uint32_t       Entry{};    ///< RevRegFile: Instruction entry
   uint32_t       cost{};     ///< RevRegFile: Cost of the instruction
   RevTracer*     Tracer{};   ///< RegRegFile: Tracer object
 
@@ -220,10 +220,10 @@ public:
   void SetTrigger( bool t ) { trigger = t; }
 
   /// Get the instruction entry
-  unsigned GetEntry() const { return Entry; }
+  uint32_t GetEntry() const { return Entry; }
 
   /// Set the instruction entry
-  void SetEntry( unsigned e ) { Entry = e; }
+  void SetEntry( uint32_t e ) { Entry = e; }
 
   /// Get the Load/Store Queue
   const auto& GetLSQueue() const { return LSQueue; }

--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -257,9 +257,9 @@ public:
   template<typename T>
   void SetSTVAL( T val ) {
     if( IsRV64() ) {
-      RV64_STVAL = val;
+      RV64_STVAL = uint64_t( val );
     } else {
-      RV32_STVAL = val;
+      RV32_STVAL = uint32_t( val );
     }
   }
 

--- a/include/RevTracer.h
+++ b/include/RevTracer.h
@@ -89,7 +89,7 @@ const std::string TRC_OP_DEFAULT = "slli";
 const int         TRC_OP_POS     = 20;
 
 // Position of fully formed instruction in 'nops' array
-enum class TRC_CMD_IDX : unsigned {
+enum class TRC_CMD_IDX : uint32_t {
   TRACE_OFF      = 0,
   TRACE_ON       = 1,
   TRACE_PUSH_OFF = 2,
@@ -97,9 +97,9 @@ enum class TRC_CMD_IDX : unsigned {
   TRACE_POP      = 4,
 };
 
-constexpr unsigned NOP_COUNT = 5;  // must match TRC_CMD_IDX size
+constexpr uint32_t NOP_COUNT = 5;  // must match TRC_CMD_IDX size
 
-enum class EVENT_SYMBOL : unsigned {
+enum class EVENT_SYMBOL : uint32_t {
   OK        = 0x0,
   STALL     = 0x1,
   FLUSH     = 0x2,
@@ -154,14 +154,14 @@ struct TraceRec_t {
 
 struct InstHeader_t {
   size_t       cycle{};
-  unsigned     id{};
-  unsigned     hart{};
-  unsigned     tid{};
+  uint32_t     id{};
+  uint32_t     hart{};
+  uint32_t     tid{};
   std::string  defaultMnem      = "?";
   std::string& fallbackMnemonic = defaultMnem;
   bool         valid            = false;
 
-  void set( size_t _cycle, unsigned _id, unsigned _hart, unsigned _tid, const std::string& _fallback ) {
+  void set( size_t _cycle, uint32_t _id, uint32_t _hart, uint32_t _tid, const std::string& _fallback ) {
     cycle            = _cycle;
     id               = _id;
     hart             = _hart;
@@ -175,15 +175,15 @@ struct InstHeader_t {
 
 // aggregate read completion (memh)
 struct CompletionRec_t {
-  unsigned int hart{};
-  uint16_t     destReg{};
-  size_t       len{};
-  uint64_t     addr{};
-  uint64_t     data{};  // first 8 bytes max
-  bool         isFloat{};
-  bool         wait4Completion{};
+  uint32_t hart{};
+  uint16_t destReg{};
+  size_t   len{};
+  uint64_t addr{};
+  uint64_t data{};  // first 8 bytes max
+  bool     isFloat{};
+  bool     wait4Completion{};
 
-  CompletionRec_t( unsigned int hart, uint16_t destReg, size_t len, uint64_t addr, void* data, RevRegClass regClass )
+  CompletionRec_t( uint32_t hart, uint16_t destReg, size_t len, uint64_t addr, void* data, RevRegClass regClass )
     : hart( hart ), destReg( destReg ), len( len ), addr( addr ), isFloat( regClass == RevRegClass::RegFLOAT ),
       wait4Completion( true ) {
     memcpy( &this->data, data, len > sizeof( this->data ) ? sizeof( this->data ) : len );
@@ -226,7 +226,7 @@ public:
   /// RevTracer: capture 64-bit program counter
   void pcWrite( uint64_t newpc );
   /// RevTracer: render instruction execution trace to output stream and update tracer state
-  void Exec( size_t cycle, unsigned id, unsigned hart, unsigned tid, const std::string& fallbackMnemonic );
+  void Exec( size_t cycle, uint32_t id, uint32_t hart, uint32_t tid, const std::string& fallbackMnemonic );
   /// RevTracer: Render captured states
   void Render( size_t cycle );
 
@@ -287,9 +287,9 @@ private:
   /// RevTracer: support for trace control push/pop
   std::vector<bool> enableQ{};
   /// RevTracer: current pointer into trace controls queue
-  unsigned enableQindex{};
+  uint32_t enableQindex{};
   /// RevTracer: wraparound limit for trace controls queue
-  const unsigned MAX_ENABLE_Q = 100;
+  const uint32_t MAX_ENABLE_Q = 100;
   /// RevTracer: count of lines rendered
   uint64_t traceCycles{};
   /// RevTracer: Hard disable for output

--- a/include/RevTracer.h
+++ b/include/RevTracer.h
@@ -35,7 +35,14 @@
 #ifdef __GNUC__
 #undef UNUSED
 #endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+
 #include "riscv/disasm.h"
+
+#pragma GCC diagnostic pop
+
 #endif
 
 // Tracing macros

--- a/include/RevTracer.h
+++ b/include/RevTracer.h
@@ -270,7 +270,7 @@ private:
   /// RevTracer: format register address for rendering
   std::string fmt_reg( uint8_t r );
   /// RevTracer: Format data associated with memory access
-  std::string fmt_data( unsigned len, uint64_t data );
+  std::string fmt_data( size_t len, uint64_t data );
   /// RevTracer: Generate string from captured state
   std::string RenderExec( const std::string& fallbackMnemonic );
   /// RevTracer: User setting: starting cycle of trace (overrides programmtic control)

--- a/include/RevZicntr.h
+++ b/include/RevZicntr.h
@@ -41,6 +41,7 @@ protected:
     return make_dependent<T>( GetCore() )->output->fatal( CALL_INFO, -1, msg, GetPC() );
   }
 
+protected:
   RevZicntr()                              = default;
   RevZicntr( const RevZicntr& )            = delete;
   RevZicntr( RevZicntr&& )                 = default;

--- a/include/SST.h
+++ b/include/SST.h
@@ -19,6 +19,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 
 #if defined( __GNUC__ ) && !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"

--- a/include/SST.h
+++ b/include/SST.h
@@ -20,6 +20,7 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wbuiltin-macro-redefined"
 
 #if defined( __GNUC__ ) && !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"

--- a/include/SST.h
+++ b/include/SST.h
@@ -20,7 +20,6 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
-#pragma GCC diagnostic ignored "-Wbuiltin-macro-redefined"
 
 #if defined( __GNUC__ ) && !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"

--- a/include/insns/RV32I.h
+++ b/include/insns/RV32I.h
@@ -35,20 +35,20 @@ class RV32I : public RevExt {
 
   static bool auipc( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     auto ui = static_cast<int32_t>( Inst.imm << 12 );
-    R->SetX( Inst.rd, ui + R->GetPC() );
+    R->SetX( Inst.rd, uint64_t( ui ) + R->GetPC() );
     R->AdvancePC( Inst );
     return true;
   }
 
   static bool jal( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     R->SetX( Inst.rd, R->GetPC() + Inst.instSize );
-    R->SetPC( R->GetPC() + Inst.ImmSignExt( 21 ) );
+    R->SetPC( R->GetPC() + uint64_t( Inst.ImmSignExt( 21 ) ) );
     return true;
   }
 
   static bool jalr( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     auto ret = R->GetPC() + Inst.instSize;
-    R->SetPC( ( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) & -2 );
+    R->SetPC( ( R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ) ) & ~uint64_t{ 1 } );
     R->SetX( Inst.rd, ret );
     return true;
   }

--- a/include/insns/RV64P.h
+++ b/include/insns/RV64P.h
@@ -20,19 +20,19 @@ namespace SST::RevCPU {
 class RV64P : public RevExt {
 
   static bool future( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetX( Inst.rd, !!M->SetFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
+    R->SetX( Inst.rd, !!M->SetFuture( R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ) ) );
     // R->AdvancePC(Inst);
     return true;
   }
 
   static bool rfuture( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetX( Inst.rd, !!M->RevokeFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
+    R->SetX( Inst.rd, !!M->RevokeFuture( R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ) ) );
     // R->AdvancePC(Inst);
     return true;
   }
 
   static bool sfuture( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    R->SetX( Inst.rd, !!M->StatusFuture( R->GetX<uint64_t>( Inst.rs1 ) + Inst.ImmSignExt( 12 ) ) );
+    R->SetX( Inst.rd, !!M->StatusFuture( R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ) ) );
     // R->AdvancePC(Inst);
     return true;
   }

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -675,7 +675,7 @@ bool RevCPU::ThreadCanProceed( const std::unique_ptr<RevThread>& Thread ) {
   // If the thread is waiting on another thread, check if that thread has completed
   if( WaitingOnTID != _INVALID_TID_ ) {
     // Check if WaitingOnTID has completed... if so, return = true, else return false
-    output.verbose( CALL_INFO, 6, 0, "Thread %" PRIu32 " is waiting on Thread %u\n", Thread->GetID(), WaitingOnTID );
+    output.verbose( CALL_INFO, 6, 0, "Thread %" PRIu32 " is waiting on Thread %" PRIu32 "\n", Thread->GetID(), WaitingOnTID );
 
     // Check if the WaitingOnTID has completed, if not, thread cannot proceed
     rtn = ( CompletedThreads.find( WaitingOnTID ) != CompletedThreads.end() ) ? true : false;

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -32,7 +32,7 @@ const char splash_msg[] = R"(
 
 RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Component( id ) {
 
-  const int Verbosity = params.find<int>( "verbose", 0 );
+  auto Verbosity = params.find<uint32_t>( "verbose", 0 );
 
   // Initialize the output handler
   output.init( "RevCPU[" + getName() + ":@p:@t]: ", Verbosity, 0, SST::Output::STDOUT );
@@ -338,7 +338,7 @@ void RevCPU::DecodeFaultWidth( const std::string& width ) {
   } else if( width == "word" ) {
     fault_width = 8;
   } else {
-    fault_width = std::stoi( width );
+    fault_width = std::stoul( width );
   }
 
   if( fault_width > 64 ) {
@@ -520,7 +520,7 @@ void RevCPU::HandleFaultInjection( SST::Cycle_t currentCycle ) {
 
   unsigned selector = 0;
   if( myfaults.size() != 1 ) {
-    selector = RevRand( 0, int( myfaults.size() ) - 1 );
+    selector = RevRand( 0u, int( myfaults.size() ) - 1 );
   }
 
   // handle the selected fault

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -230,12 +230,12 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
   // Initial thread setup
   uint32_t MainThreadID = id + 1;  // Prevents having MainThreadID == 0 which is reserved for INVALID
 
-  uint64_t    StartAddr = 0x00ull;
+  uint64_t    StartAddr = 0;
   std::string StartSymbol;
 
   bool     IsStartSymbolProvided   = Opts->GetStartSymbol( id, StartSymbol );
-  bool     IsStartAddrProvided     = Opts->GetStartAddr( id, StartAddr ) && StartAddr != 0x00ull;
-  uint64_t ResolvedStartSymbolAddr = ( IsStartSymbolProvided ) ? Loader->GetSymbolAddr( StartSymbol ) : 0x00ull;
+  bool     IsStartAddrProvided     = Opts->GetStartAddr( id, StartAddr ) && StartAddr != 0;
+  uint64_t ResolvedStartSymbolAddr = ( IsStartSymbolProvided ) ? Loader->GetSymbolAddr( StartSymbol ) : 0;
 
   // If no start address has been provided ...
   if( !IsStartAddrProvided ) {
@@ -243,7 +243,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
     if( !IsStartSymbolProvided ) {
       // ... no, try to default to 'main' ...
       StartAddr = Loader->GetSymbolAddr( "main" );
-      if( StartAddr == 0x00ull ) {
+      if( StartAddr == 0 ) {
         // ... no hope left!
         output.fatal(
           CALL_INFO,

--- a/src/RevCPU.cc
+++ b/src/RevCPU.cc
@@ -98,7 +98,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
     Nic->setMsgHandler( new Event::Handler<RevCPU>( this, &RevCPU::handleMessage ) );
 
     // record the number of injected messages per cycle
-    msgPerCycle = params.find<unsigned>( "msgPerCycle", 1 );
+    msgPerCycle = params.find<uint32_t>( "msgPerCycle", 1 );
   }
 
   // Look for the fault injection logic
@@ -116,7 +116,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
   }
 
   // Create the memory object
-  const uint64_t memSize = params.find<unsigned long>( "memSize", 1073741824 );
+  const uint64_t memSize = params.find<uint64_t>( "memSize", 1073741824 );
   EnableMemH             = params.find<bool>( "enableMemH", 0 );
   if( !EnableMemH ) {
     Mem = std::make_unique<RevMem>( memSize, Opts.get(), &output );
@@ -131,11 +131,11 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
   }
 
   // Set TLB Size
-  const uint64_t tlbSize = params.find<unsigned long>( "tlbSize", 512 );
+  const uint64_t tlbSize = params.find<uint64_t>( "tlbSize", 512 );
   Mem->SetTLBSize( tlbSize );
 
   // Set max heap size
-  const uint64_t maxHeapSize = params.find<unsigned long>( "maxHeapSize", memSize / 4 );
+  const uint64_t maxHeapSize = params.find<uint64_t>( "maxHeapSize", memSize / 4 );
   Mem->SetMaxHeapSize( maxHeapSize );
 
   // Load the binary into memory
@@ -143,14 +143,14 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
 
   // Create the processor objects
   Procs.reserve( Procs.size() + numCores );
-  for( unsigned i = 0; i < numCores; i++ ) {
+  for( uint32_t i = 0; i < numCores; i++ ) {
     Procs.push_back( std::make_unique<RevCore>( i, Opts.get(), numHarts, Mem.get(), Loader.get(), this->GetNewTID(), &output ) );
   }
 
   EnableCoProc = params.find<bool>( "enableCoProc", 0 );
   if( EnableCoProc ) {
     // Create the co-processor objects
-    for( unsigned i = 0; i < numCores; i++ ) {
+    for( uint32_t i = 0; i < numCores; i++ ) {
       RevCoProc* CoProc = loadUserSubComponent<RevCoProc>( "co_proc", SST::ComponentInfo::SHARE_NONE, Procs[i].get() );
       if( !CoProc ) {
         output.fatal( CALL_INFO, -1, "Error : failed to inintialize the co-processor subcomponent\n" );
@@ -197,7 +197,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
 #ifndef NO_REV_TRACER
   // Configure tracer and assign to each core
   if( output.getVerboseLevel() >= 5 ) {
-    for( unsigned i = 0; i < numCores; i++ ) {
+    for( uint32_t i = 0; i < numCores; i++ ) {
       // Each core gets its very own tracer
       RevTracer*  trc = new RevTracer( getName(), &output );
       std::string diasmType;
@@ -294,7 +294,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
   TLBHitsPerCore.reserve( numCores );
   TLBMissesPerCore.reserve( numCores );
 
-  for( unsigned s = 0; s < numCores; s++ ) {
+  for( uint32_t s = 0; s < numCores; s++ ) {
     auto core = "core_" + std::to_string( s );
     TotalCycles.push_back( registerStatistic<uint64_t>( "TotalCycles", core ) );
     CyclesWithIssue.push_back( registerStatistic<uint64_t>( "CyclesWithIssue", core ) );
@@ -315,7 +315,7 @@ RevCPU::RevCPU( SST::ComponentId_t id, const SST::Params& params ) : SST::Compon
   // Create the completion array
   Enabled               = std::vector<bool>( numCores );
 
-  const unsigned Splash = params.find<bool>( "splash", 0 );
+  const uint32_t Splash = params.find<bool>( "splash", 0 );
 
   if( Splash > 0 )
     output.verbose( CALL_INFO, 1, 0, splash_msg );
@@ -433,7 +433,7 @@ void RevCPU::setup() {
 
 void RevCPU::finish() {}
 
-void RevCPU::init( unsigned int phase ) {
+void RevCPU::init( uint32_t phase ) {
   if( EnableNIC )
     Nic->init( phase );
   if( EnableMemH )
@@ -460,7 +460,7 @@ void RevCPU::HandleCrackFault( SST::Cycle_t currentCycle ) {
   output.verbose( CALL_INFO, 4, 0, "FAULT: Crack fault injected at cycle: %" PRIu64 "\n", currentCycle );
 
   // select a random processor core
-  unsigned Core = 0;
+  uint32_t Core = 0;
   if( numCores > 1 ) {
     Core = RevRand( 0, numCores - 1 );
   }
@@ -477,7 +477,7 @@ void RevCPU::HandleRegFault( SST::Cycle_t currentCycle ) {
   output.verbose( CALL_INFO, 4, 0, "FAULT: Register fault injected at cycle: %" PRIu64 "\n", currentCycle );
 
   // select a random processor core
-  unsigned Core = 0;
+  uint32_t Core = 0;
   if( numCores > 1 ) {
     Core = RevRand( 0, numCores - 1 );
   }
@@ -489,7 +489,7 @@ void RevCPU::HandleALUFault( SST::Cycle_t currentCycle ) {
   output.verbose( CALL_INFO, 4, 0, "FAULT: ALU fault injected at cycle: %" PRIu64 "\n", currentCycle );
 
   // select a random processor core
-  unsigned Core = 0;
+  uint32_t Core = 0;
   if( numCores > 1 ) {
     Core = RevRand( 0, numCores - 1 );
   }
@@ -518,7 +518,7 @@ void RevCPU::HandleFaultInjection( SST::Cycle_t currentCycle ) {
     output.fatal( CALL_INFO, -1, "Error: no faults enabled; add a fault vector in the 'faults' param\n" );
   }
 
-  unsigned selector = 0;
+  uint32_t selector = 0;
   if( myfaults.size() != 1 ) {
     selector = RevRand( 0u, int( myfaults.size() ) - 1 );
   }
@@ -537,7 +537,7 @@ void RevCPU::HandleFaultInjection( SST::Cycle_t currentCycle ) {
   }
 }
 
-void RevCPU::UpdateCoreStatistics( unsigned coreNum ) {
+void RevCPU::UpdateCoreStatistics( uint32_t coreNum ) {
   auto [stats, memStats] = Procs[coreNum]->GetAndClearStats();
   TotalCycles[coreNum]->addData( stats.totalCycles );
   CyclesWithIssue[coreNum]->addData( stats.cyclesBusy );
@@ -618,7 +618,7 @@ bool RevCPU::clockTick( SST::Cycle_t currentCycle ) {
   }
 
   if( rtn && CompletedThreads.size() ) {
-    for( unsigned i = 0; i < numCores; i++ ) {
+    for( uint32_t i = 0; i < numCores; i++ ) {
       UpdateCoreStatistics( i );
       Procs[i]->PrintStatSummary();
     }
@@ -658,7 +658,7 @@ void RevCPU::InitThread( std::unique_ptr<RevThread>&& ThreadToInit ) {
 
 // Assigns a RevThred to a specific Proc which then loads it into a RevHart
 // This should not be called without first checking if the Proc has an IdleHart
-void RevCPU::AssignThread( std::unique_ptr<RevThread>&& ThreadToAssign, unsigned ProcID ) {
+void RevCPU::AssignThread( std::unique_ptr<RevThread>&& ThreadToAssign, uint32_t ProcID ) {
   output.verbose( CALL_INFO, 4, 0, "Assigning Thread %" PRIu32 " to Processor %" PRIu32 "\n", ThreadToAssign->GetID(), ProcID );
   Procs[ProcID]->AssignThread( std::move( ThreadToAssign ) );
   return;

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -454,14 +454,14 @@ RevInst RevCore::DecodeCIInst( uint16_t Inst, unsigned Entry ) const {
     CompInst.imm |= ( ( Inst & 0b1000000000000 ) >> 3 );  // bit 9
     CompInst.rs1 = 2;                                     // Force rs1 to be x2 (stack pointer)
     // sign extend
-    CompInst.imm = CompInst.ImmSignExt( 10 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 10 ) );
   } else if( ( CompInst.opcode == 0b01 ) && ( CompInst.funct3 == 0b011 ) && ( CompInst.rd != 0 ) && ( CompInst.rd != 2 ) ) {
     // c.lui
     CompInst.imm = 0;
     CompInst.imm = ( ( Inst & 0b1111100 ) << 10 );        // [16:12]
     CompInst.imm |= ( ( Inst & 0b1000000000000 ) << 5 );  // [17]
     // sign extend
-    CompInst.imm = CompInst.ImmSignExt( 18 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 18 ) );
     CompInst.imm >>= 12;  //immd value will be re-aligned on execution
   } else if( ( CompInst.opcode == 0b01 ) && ( CompInst.funct3 == 0b010 ) && ( CompInst.rd != 0 ) ) {
     // c.li
@@ -470,10 +470,10 @@ RevInst RevCore::DecodeCIInst( uint16_t Inst, unsigned Entry ) const {
     CompInst.imm |= ( ( Inst & 0b1000000000000 ) >> 7 );  // [5]
     CompInst.rs1 = 0;                                     // Force rs1 to be x0, expands to add rd, x0, imm
     // sign extend
-    CompInst.imm = CompInst.ImmSignExt( 6 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 6 ) );
   } else {
     // sign extend
-    CompInst.imm = CompInst.ImmSignExt( 6 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 6 ) );
   }
 
   //if c.addi, expands to addi %rd, %rd, $imm so set rs1 to rd -or-
@@ -761,11 +761,11 @@ RevInst RevCore::DecodeCBInst( uint16_t Inst, unsigned Entry ) const {
     //Set rs2 to x0 if c.beqz or c.bnez
     CompInst.rs2 = 0;
     CompInst.imm = CompInst.offset;
-    CompInst.imm = CompInst.ImmSignExt( 9 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 9 ) );
   } else {
     CompInst.imm = ( ( Inst & 0b01111100 ) >> 2 );
     CompInst.imm |= ( ( Inst & 0b01000000000000 ) >> 7 );
-    CompInst.imm = CompInst.ImmSignExt( 6 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 6 ) );
   }
 
   CompInst.instSize   = 2;
@@ -806,7 +806,7 @@ RevInst RevCore::DecodeCJInst( uint16_t Inst, unsigned Entry ) const {
     //Set rd to x1 if this is a c.jal, x0 if this is a c.j
     CompInst.rd  = ( 0b001 == CompInst.funct3 ) ? 1 : 0;
     CompInst.imm = CompInst.jumpTarget;
-    CompInst.imm = CompInst.ImmSignExt( 12 );
+    CompInst.imm = uint64_t( CompInst.ImmSignExt( 12 ) );
   }
 
   CompInst.instSize   = 2;
@@ -1486,7 +1486,7 @@ void RevCore::HandleRegFault( unsigned width ) {
   RevRegFile* regFile = GetRegFile( HartToExecID );
 
   // select a register
-  unsigned RegIdx     = RevRand( 0, _REV_NUM_REGS_ - 1 );
+  unsigned RegIdx     = RevRand( 0u, _REV_NUM_REGS_ - 1 );
 
   if( !feature->HasF() || RevRand( 0, 1 ) ) {
     // X registers

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -22,8 +22,8 @@ std::unique_ptr<RevFeature> RevCore::CreateFeature() {
   if( !opts->GetMachineModel( id, Machine ) )
     output->fatal( CALL_INFO, -1, "Error: failed to retrieve the machine model for core=%" PRIu32 "\n", id );
 
-  unsigned MinCost = 0;
-  unsigned MaxCost = 0;
+  uint32_t MinCost = 0;
+  uint32_t MaxCost = 0;
 
   opts->GetMemCost( id, MinCost, MaxCost );
 
@@ -31,9 +31,9 @@ std::unique_ptr<RevFeature> RevCore::CreateFeature() {
 }
 
 RevCore::RevCore(
-  unsigned                  id,
+  uint32_t                  id,
   RevOpts*                  opts,
-  unsigned                  numHarts,
+  uint32_t                  numHarts,
   RevMem*                   mem,
   RevLoader*                loader,
   std::function<uint32_t()> GetNewTID,
@@ -51,7 +51,7 @@ RevCore::RevCore(
     ValidHarts.set( i, true );
   }
 
-  unsigned Depth = 0;
+  uint32_t Depth = 0;
   opts->GetPrefetchDepth( id, Depth );
   if( Depth == 0 ) {
     Depth = 16;
@@ -127,10 +127,10 @@ bool RevCore::EnableExt( RevExt* Ext ) {
   // setup the mapping of InstTable to Ext objects
   auto load = [&]( const std::vector<RevInstEntry>& Table ) {
     InstTable.reserve( InstTable.size() + Table.size() );
-    for( unsigned i = 0; i < Table.size(); i++ ) {
+    for( uint32_t i = 0; i < Table.size(); i++ ) {
       InstTable.push_back( Table[i] );
-      auto ExtObj = std::pair<unsigned, unsigned>( Extensions.size() - 1, i );
-      EntryToExt.insert( std::pair<unsigned, std::pair<unsigned, unsigned>>( InstTable.size() - 1, ExtObj ) );
+      auto ExtObj = std::pair<uint32_t, uint32_t>( Extensions.size() - 1, i );
+      EntryToExt.insert( std::pair<uint32_t, std::pair<uint32_t, uint32_t>>( InstTable.size() - 1, ExtObj ) );
     }
   };
 
@@ -256,11 +256,11 @@ bool RevCore::InitTableMapping() {
     CALL_INFO, 6, 0, "Core %" PRIu32 " ; Initializing table mapping for machine model=%s\n", id, feature->GetMachineModel().data()
   );
 
-  for( unsigned i = 0; i < InstTable.size(); i++ ) {
-    NameToEntry.insert( std::pair<std::string, unsigned>( ExtractMnemonic( InstTable[i] ), i ) );
+  for( uint32_t i = 0; i < InstTable.size(); i++ ) {
+    NameToEntry.insert( std::pair<std::string, uint32_t>( ExtractMnemonic( InstTable[i] ), i ) );
     if( !InstTable[i].compressed ) {
       // map normal instruction
-      EncToEntry.insert( std::pair<uint64_t, unsigned>( CompressEncoding( InstTable[i] ), i ) );
+      EncToEntry.insert( std::pair<uint64_t, uint32_t>( CompressEncoding( InstTable[i] ), i ) );
       output->verbose(
         CALL_INFO,
         6,
@@ -272,7 +272,7 @@ bool RevCore::InitTableMapping() {
       );
     } else {
       // map compressed instruction
-      CEncToEntry.insert( std::pair<uint64_t, unsigned>( CompressCEncoding( InstTable[i] ), i ) );
+      CEncToEntry.insert( std::pair<uint64_t, uint32_t>( CompressCEncoding( InstTable[i] ), i ) );
       output->verbose(
         CALL_INFO,
         6,
@@ -308,14 +308,14 @@ bool RevCore::ReadOverrideTables() {
   // read all the values
   std::string Inst;
   std::string Cost;
-  unsigned    Entry;
+  uint32_t    Entry;
   while( infile >> Inst >> Cost ) {
     auto it = NameToEntry.find( Inst );
     if( it == NameToEntry.end() )
       output->fatal( CALL_INFO, -1, "Error: could not find instruction in table for map value=%s\n", Inst.data() );
 
     Entry                 = it->second;
-    InstTable[Entry].cost = (unsigned) ( std::stoi( Cost, nullptr, 0 ) );
+    InstTable[Entry].cost = (uint32_t) ( std::stoi( Cost, nullptr, 0 ) );
   }
 
   // close the file
@@ -345,7 +345,7 @@ bool RevCore::Reset() {
   IdleHarts.reset();
 
   // All harts are idle to start
-  for( unsigned i = 0; i < numHarts; i++ ) {
+  for( uint32_t i = 0; i < numHarts; i++ ) {
     IdleHarts[i]  = true;
     ValidHarts[i] = true;
   }
@@ -357,7 +357,7 @@ bool RevCore::Reset() {
   return true;
 }
 
-RevInst RevCore::DecodeCRInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCRInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -399,7 +399,7 @@ RevInst RevCore::DecodeCRInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCIInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCIInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -490,7 +490,7 @@ RevInst RevCore::DecodeCIInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCSSInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCSSInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -537,7 +537,7 @@ RevInst RevCore::DecodeCSSInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCIWInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCIWInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -579,7 +579,7 @@ RevInst RevCore::DecodeCIWInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCLInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCLInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -645,7 +645,7 @@ RevInst RevCore::DecodeCLInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCSInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCSInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -688,7 +688,7 @@ RevInst RevCore::DecodeCSInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCAInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCAInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -717,7 +717,7 @@ RevInst RevCore::DecodeCAInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCBInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCBInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -774,7 +774,7 @@ RevInst RevCore::DecodeCBInst( uint32_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCJInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCJInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -817,14 +817,14 @@ RevInst RevCore::DecodeCJInst( uint32_t Inst, unsigned Entry ) const {
 
 // Find the first matching encoding which satisfies a predicate, if any
 auto RevCore::matchInst(
-  const std::unordered_multimap<uint64_t, unsigned>& map,
+  const std::unordered_multimap<uint64_t, uint32_t>& map,
   uint64_t                                           encoding,
   const std::vector<RevInstEntry>&                   InstTable,
   uint32_t                                           Inst
 ) const {
   // Iterate through all entries which match the encoding
   for( auto [it, end] = map.equal_range( encoding ); it != end; ++it ) {
-    unsigned Entry = it->second;
+    uint32_t Entry = it->second;
     // If an entry is valid and has a satisfied predicate, return it
     if( Entry < InstTable.size() && InstTable[Entry].predicate( Inst ) )
       return it;
@@ -967,7 +967,7 @@ RevInst RevCore::DecodeCompressed( uint32_t Inst ) const {
   return ret;
 }
 
-RevInst RevCore::DecodeRInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeRInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   DInst.cost      = InstTable[Entry].cost;
@@ -1022,7 +1022,7 @@ RevInst RevCore::DecodeRInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeIInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeIInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1057,7 +1057,7 @@ RevInst RevCore::DecodeIInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeSInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeSInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1091,7 +1091,7 @@ RevInst RevCore::DecodeSInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeUInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeUInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1122,7 +1122,7 @@ RevInst RevCore::DecodeUInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeBInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeBInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1159,7 +1159,7 @@ RevInst RevCore::DecodeBInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeJInst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeJInst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1193,7 +1193,7 @@ RevInst RevCore::DecodeJInst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-RevInst RevCore::DecodeR4Inst( uint32_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeR4Inst( uint32_t Inst, uint32_t Entry ) const {
   RevInst DInst;
 
   // cost
@@ -1224,7 +1224,7 @@ RevInst RevCore::DecodeR4Inst( uint32_t Inst, unsigned Entry ) const {
   return DInst;
 }
 
-bool RevCore::DebugReadReg( unsigned Idx, uint64_t* Value ) const {
+bool RevCore::DebugReadReg( uint32_t Idx, uint64_t* Value ) const {
   if( !Halted )
     return false;
   if( Idx >= _REV_NUM_REGS_ ) {
@@ -1235,7 +1235,7 @@ bool RevCore::DebugReadReg( unsigned Idx, uint64_t* Value ) const {
   return true;
 }
 
-bool RevCore::DebugWriteReg( unsigned Idx, uint64_t Value ) const {
+bool RevCore::DebugWriteReg( uint32_t Idx, uint64_t Value ) const {
   RevRegFile* regFile = GetRegFile( HartToExecID );
   if( !Halted )
     return false;
@@ -1436,7 +1436,7 @@ RevInst RevCore::DecodeInst( uint32_t Inst ) const {
     output->fatal( CALL_INFO, -1, "Error: failed to decode instruction at PC=0x%" PRIx64 "; Enc=%" PRIu64 "\n", GetPC(), Enc );
   }
 
-  unsigned Entry = it->second;
+  uint32_t Entry = it->second;
   if( Entry >= InstTable.size() ) {
     if( coProc && coProc->IssueInst( feature, RegFile, mem, Inst ) ) {
       //Create NOP - ADDI x0, x0, 0
@@ -1481,12 +1481,12 @@ RevInst RevCore::DecodeInst( uint32_t Inst ) const {
   return ret;
 }
 
-void RevCore::HandleRegFault( unsigned width ) {
+void RevCore::HandleRegFault( uint32_t width ) {
   const char* RegPrefix;
   RevRegFile* regFile = GetRegFile( HartToExecID );
 
   // select a register
-  unsigned RegIdx     = RevRand( 0u, _REV_NUM_REGS_ - 1 );
+  uint32_t RegIdx     = RevRand( 0u, _REV_NUM_REGS_ - 1 );
 
   if( !feature->HasF() || RevRand( 0, 1 ) ) {
     // X registers
@@ -1517,19 +1517,19 @@ void RevCore::HandleRegFault( unsigned width ) {
   );
 }
 
-void RevCore::HandleCrackFault( unsigned width ) {
+void RevCore::HandleCrackFault( uint32_t width ) {
   CrackFault  = true;
   fault_width = width;
   output->verbose( CALL_INFO, 5, 0, "FAULT:CRACK: Crack+Decode fault injected into next decode cycle\n" );
 }
 
-void RevCore::HandleALUFault( unsigned width ) {
+void RevCore::HandleALUFault( uint32_t width ) {
   ALUFault    = true;
   fault_width = true;
   output->verbose( CALL_INFO, 5, 0, "FAULT:ALU: ALU fault injected into next retire cycle\n" );
 }
 
-bool RevCore::DependencyCheck( unsigned HartID, const RevInst* I ) const {
+bool RevCore::DependencyCheck( uint32_t HartID, const RevInst* I ) const {
   const RevRegFile*   regFile = GetRegFile( HartID );
   const RevInstEntry* E       = &InstTable[I->entry];
 
@@ -1574,12 +1574,12 @@ void RevCore::ExternalReleaseHart( RevCorePasskey<RevCoProc>, uint16_t HartID ) 
   }
 }
 
-unsigned RevCore::GetNextHartToDecodeID() const {
+uint32_t RevCore::GetNextHartToDecodeID() const {
   if( HartsClearToDecode.none() ) {
     return HartToDecodeID;
   };
 
-  unsigned nextID = HartToDecodeID;
+  uint32_t nextID = HartToDecodeID;
   if( HartsClearToDecode[HartToDecodeID] ) {
     nextID = HartToDecodeID;
   } else {
@@ -1713,7 +1713,7 @@ bool RevCore::ClockTick( SST::Cycle_t currentCycle ) {
     }
 
     // found the instruction extension
-    std::pair<unsigned, unsigned> EToE = it->second;
+    std::pair<uint32_t, uint32_t> EToE = it->second;
     RevExt*                       Ext  = Extensions[EToE.first].get();
 
     // -- BEGIN new pipelining implementation
@@ -1851,7 +1851,7 @@ bool RevCore::ClockTick( SST::Cycle_t currentCycle ) {
   return rtn;
 }
 
-std::unique_ptr<RevThread> RevCore::PopThreadFromHart( unsigned HartID ) {
+std::unique_ptr<RevThread> RevCore::PopThreadFromHart( uint32_t HartID ) {
   if( HartID >= numHarts ) {
     output->fatal(
       CALL_INFO, -1, "Error: tried to pop thread from hart %" PRIu32 " but there are only %" PRIu32 " hart(s)\n", HartID, numHarts
@@ -1895,7 +1895,7 @@ void RevCore::PrintStatSummary() {
   );
 }
 
-RevRegFile* RevCore::GetRegFile( unsigned HartID ) const {
+RevRegFile* RevCore::GetRegFile( uint32_t HartID ) const {
   if( HartID >= Harts.size() ) {
     output->fatal(
       CALL_INFO, -1, "Error: tried to get RegFile for Hart %" PRIu32 " but there are only %" PRIu32 " hart(s)\n", HartID, numHarts
@@ -1990,7 +1990,7 @@ bool RevCore::ExecEcall() {
 // so if for some reason we can't find a hart without a thread assigned
 // to it then we have a bug.
 void RevCore::AssignThread( std::unique_ptr<RevThread> Thread ) {
-  unsigned HartToAssign = FindIdleHartID();
+  uint32_t HartToAssign = FindIdleHartID();
 
   if( HartToAssign == _REV_INVALID_HART_ID_ ) {
     output->fatal(
@@ -2012,8 +2012,8 @@ void RevCore::AssignThread( std::unique_ptr<RevThread> Thread ) {
   return;
 }
 
-unsigned RevCore::FindIdleHartID() const {
-  unsigned IdleHartID = _REV_INVALID_HART_ID_;
+uint32_t RevCore::FindIdleHartID() const {
+  uint32_t IdleHartID = _REV_INVALID_HART_ID_;
   // Iterate over IdleHarts to find the first idle hart
   for( size_t i = 0; i < Harts.size(); i++ ) {
     if( IdleHarts[i] ) {
@@ -2028,7 +2028,7 @@ unsigned RevCore::FindIdleHartID() const {
   return IdleHartID;
 }
 
-void RevCore::InjectALUFault( std::pair<unsigned, unsigned> EToE, RevInst& Inst ) {
+void RevCore::InjectALUFault( std::pair<uint32_t, uint32_t> EToE, RevInst& Inst ) {
   // inject ALU fault
   RevExt* Ext = Extensions[EToE.first].get();
   if( ( Ext->GetName() == "RV64F" ) || ( Ext->GetName() == "RV64D" ) ) {

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -108,7 +108,7 @@ void RevCore::SetCoProc( RevCoProc* coproc ) {
     output->fatal(
       CALL_INFO,
       -1,
-      "CONFIG ERROR: Core %u : Attempting to assign a "
+      "CONFIG ERROR: Core %" PRIu32 " : Attempting to assign a "
       "co-processor when one is already present\n",
       id
     );
@@ -918,8 +918,8 @@ RevInst RevCore::DecodeCompressed( uint32_t Inst ) const {
     output->fatal(
       CALL_INFO,
       -1,
-      "Error: failed to decode instruction at PC=0x%" PRIx64 "; Enc=%" PRIu32
-      "\n opc=%x; funct2=%x, funct3=%x, funct4=%x, funct6=%x\n",
+      "Error: failed to decode instruction at PC=0x%" PRIx64 "; Enc=%" PRIx32 "\n opc=%" PRIx8 "; funct2=%" PRIx8 ", funct3=%" PRIx8
+      ", funct4=%" PRIx8 ", funct6=%" PRIx8 "\n",
       GetPC(),
       Enc,
       opc,
@@ -935,8 +935,8 @@ RevInst RevCore::DecodeCompressed( uint32_t Inst ) const {
     output->fatal(
       CALL_INFO,
       -1,
-      "Error: no entry in table for instruction at PC=0x%" PRIx64 " Opcode = %x Funct2 = %x Funct3 = %x Funct4 = %x Funct6 = "
-      "%x Enc = %x \n",
+      "Error: no entry in table for instruction at PC=0x%" PRIx64 " Opcode = %" PRIx8 " Funct2 = %" PRIx8 " Funct3 = %" PRIx8
+      " Funct4 = %" PRIx8 " Funct6 = %" PRIx8 " Enc = %" PRIx32 "\n",
       GetPC(),
       opc,
       funct2,
@@ -1452,8 +1452,8 @@ RevInst RevCore::DecodeInst( uint32_t Inst ) const {
     output->fatal(
       CALL_INFO,
       -1,
-      "Error: no entry in table for instruction at PC=0x%" PRIx64
-      " Opcode = %x Funct3 = %x Funct2or7 = %x Imm12 = %x Enc = %" PRIx64 "\n",
+      "Error: no entry in table for instruction at PC=0x%" PRIx64 " Opcode = 0x%" PRIx32 " Funct3 = %" PRIx32
+      " Funct2or7 = %" PRIx32 " Imm12 = %" PRIx32 " Enc = %" PRIx64 "\n",
       GetPC(),
       Opcode,
       Funct3,
@@ -1558,7 +1558,9 @@ void RevCore::ExternalStallHart( RevCorePasskey<RevCoProc>, uint16_t HartID ) {
   if( HartID < Harts.size() ) {
     CoProcStallReq.set( HartID );
   } else {
-    output->fatal( CALL_INFO, -1, "Core %u ; CoProc Request: Cannot stall Hart %" PRIu32 " as the ID is invalid\n", id, HartID );
+    output->fatal(
+      CALL_INFO, -1, "Core %" PRIu32 " ; CoProc Request: Cannot stall Hart %" PRIu32 " as the ID is invalid\n", id, HartID
+    );
   }
 }
 
@@ -1566,7 +1568,9 @@ void RevCore::ExternalReleaseHart( RevCorePasskey<RevCoProc>, uint16_t HartID ) 
   if( HartID < Harts.size() ) {
     CoProcStallReq.reset( HartID );
   } else {
-    output->fatal( CALL_INFO, -1, "Core %u ; CoProc Request: Cannot release Hart %" PRIu32 " as the ID is invalid\n", id, HartID );
+    output->fatal(
+      CALL_INFO, -1, "Core %" PRIu32 " ; CoProc Request: Cannot release Hart %" PRIu32 " as the ID is invalid\n", id, HartID
+    );
   }
 }
 
@@ -1866,7 +1870,7 @@ void RevCore::PrintStatSummary() {
     2,
     0,
     "Program execution complete\n"
-    "Core %u Program Stats: Total Cycles: %" PRIu64 " Busy Cycles: %" PRIu64 " Idle Cycles: %" PRIu64 " Eff: %f\n",
+    "Core %" PRIu32 " Program Stats: Total Cycles: %" PRIu64 " Busy Cycles: %" PRIu64 " Idle Cycles: %" PRIu64 " Eff: %f\n",
     id,
     StatsTotal.totalCycles,
     StatsTotal.cyclesBusy,

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -841,7 +841,7 @@ RevInst RevCore::DecodeCompressed( uint32_t Inst ) const {
   uint8_t  funct4 = 0;
   uint8_t  funct6 = 0;
   uint8_t  l3     = 0;
-  uint32_t Enc    = 0x00ul;
+  uint32_t Enc    = 0;
 
   if( !feature->HasCompressed() ) {
     output->fatal(
@@ -1251,7 +1251,7 @@ bool RevCore::PrefetchInst() {
 
   // These are addresses that we can't decode
   // Return false back to the main program loop
-  if( PC == 0x00ull ) {
+  if( PC == 0 ) {
     return false;
   }
 
@@ -1259,7 +1259,7 @@ bool RevCore::PrefetchInst() {
 }
 
 RevInst RevCore::FetchAndDecodeInst() {
-  uint32_t Inst    = 0x00ul;
+  uint32_t Inst    = 0;
   uint64_t PC      = GetPC();
   bool     Fetched = false;
 
@@ -1326,26 +1326,26 @@ RevInst RevCore::DecodeInst( uint32_t Inst ) const {
   const uint32_t Opcode = Inst & 0b1111111;
 
   // Stage 3: Determine if we have a funct3 field
-  uint32_t       Funct3 = 0x00ul;
+  uint32_t       Funct3 = 0;
   const uint32_t inst42 = Opcode >> 2 & 0b111;
   const uint32_t inst65 = Opcode >> 5 & 0b11;
 
   if( ( inst42 == 0b011 ) && ( inst65 == 0b11 ) ) {
     // JAL
-    Funct3 = 0x00ul;
+    Funct3 = 0;
   } else if( ( inst42 == 0b101 ) && ( inst65 == 0b00 ) ) {
     // AUIPC
-    Funct3 = 0x00ul;
+    Funct3 = 0;
   } else if( ( inst42 == 0b101 ) && ( inst65 == 0b01 ) ) {
     // LUI
-    Funct3 = 0x00ul;
+    Funct3 = 0;
   } else {
     // Retrieve the field
     Funct3 = DECODE_FUNCT3( Inst );
   }
 
   // Stage 4: Determine if we have a funct7 field (R-Type and some specific I-Type)
-  uint32_t Funct2or7 = 0x00ul;
+  uint32_t Funct2or7 = 0;
   if( inst65 == 0b01 ) {
     if( ( inst42 == 0b011 ) || ( inst42 == 0b100 ) || ( inst42 == 0b110 ) ) {
       // R-Type encodings
@@ -1396,7 +1396,7 @@ RevInst RevCore::DecodeInst( uint32_t Inst ) const {
   }
 
   // Stage 5: Determine if we have an imm12 field (ECALL and EBREAK, CBO)
-  uint32_t Imm12 = 0x00ul;
+  uint32_t Imm12 = 0;
   if( ( inst42 == 0b100 && inst65 == 0b11 && Funct3 == 0b000 ) || ( inst42 == 0b011 && inst65 == 0b00 && Funct3 == 0b010 ) ) {
     Imm12 = DECODE_IMM12( Inst );
   }
@@ -1815,7 +1815,7 @@ bool RevCore::ClockTick( SST::Cycle_t currentCycle ) {
     }
   }
   // Check for completion states and new tasks
-  if( RegFile->GetPC() == 0x00ull ) {
+  if( RegFile->GetPC() == 0 ) {
     // look for more work on the execution queue
     // if no work is found, don't update the PC
     // just wait and spin

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -357,7 +357,7 @@ bool RevCore::Reset() {
   return true;
 }
 
-RevInst RevCore::DecodeCRInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCRInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -399,7 +399,7 @@ RevInst RevCore::DecodeCRInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCIInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCIInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -490,7 +490,7 @@ RevInst RevCore::DecodeCIInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCSSInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCSSInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -537,7 +537,7 @@ RevInst RevCore::DecodeCSSInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCIWInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCIWInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -579,7 +579,7 @@ RevInst RevCore::DecodeCIWInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCLInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCLInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -645,7 +645,7 @@ RevInst RevCore::DecodeCLInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCSInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCSInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -688,7 +688,7 @@ RevInst RevCore::DecodeCSInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCAInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCAInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -717,7 +717,7 @@ RevInst RevCore::DecodeCAInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCBInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCBInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost
@@ -774,7 +774,7 @@ RevInst RevCore::DecodeCBInst( uint16_t Inst, unsigned Entry ) const {
   return CompInst;
 }
 
-RevInst RevCore::DecodeCJInst( uint16_t Inst, unsigned Entry ) const {
+RevInst RevCore::DecodeCJInst( uint32_t Inst, unsigned Entry ) const {
   RevInst CompInst;
 
   // cost

--- a/src/RevExt.cc
+++ b/src/RevExt.cc
@@ -13,7 +13,7 @@
 namespace SST::RevCPU {
 
 /// Execute an instruction
-bool RevExt::Execute( unsigned Inst, const RevInst& payload, uint16_t HartID, RevRegFile* regFile ) const {
+bool RevExt::Execute( uint32_t Inst, const RevInst& payload, uint16_t HartID, RevRegFile* regFile ) const {
   bool ( *func )( const RevFeature*, RevRegFile*, RevMem*, const RevInst& );
 
   if( payload.compressed ) {
@@ -25,7 +25,7 @@ bool RevExt::Execute( unsigned Inst, const RevInst& payload, uint16_t HartID, Re
   }
 
   if( !func ) {
-    output->fatal( CALL_INFO, -1, "Error: instruction at index=%u does not exist in extension=%s", Inst, name.data() );
+    output->fatal( CALL_INFO, -1, "Error: instruction at index=%" PRIu32 " does not exist in extension=%s", Inst, name.data() );
     return false;
   }
 

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -16,9 +16,11 @@
 
 namespace SST::RevCPU {
 
-RevFeature::RevFeature( std::string Machine, SST::Output* Output, unsigned Min, unsigned Max, unsigned Id )
+RevFeature::RevFeature( std::string Machine, SST::Output* Output, uint32_t Min, uint32_t Max, uint32_t Id )
   : machine( std::move( Machine ) ), output( Output ), MinCost( Min ), MaxCost( Max ), ProcID( Id ) {
-  output->verbose( CALL_INFO, 6, 0, "Core %u ; Initializing feature set from machine string=%s\n", ProcID, machine.c_str() );
+  output->verbose(
+    CALL_INFO, 6, 0, "Core %" PRIu32 " ; Initializing feature set from machine string=%s\n", ProcID, machine.c_str()
+  );
   if( !ParseMachineModel() )
     output->fatal( CALL_INFO, -1, "Error: failed to parse the machine model: %s\n", machine.c_str() );
 }
@@ -36,8 +38,8 @@ bool RevFeature::ParseMachineModel() {
     return false;
   mac += 4;
 
-  output->verbose( CALL_INFO, 6, 0, "Core %u ; Setting XLEN to %u\n", ProcID, xlen );
-  output->verbose( CALL_INFO, 6, 0, "Core %u ; Architecture string=%s\n", ProcID, mac );
+  output->verbose( CALL_INFO, 6, 0, "Core %" PRIu32 " ; Setting XLEN to %" PRIu32 "\n", ProcID, xlen );
+  output->verbose( CALL_INFO, 6, 0, "Core %" PRIu32 " ; Architecture string=%s\n", ProcID, mac );
 
   // clang-format off
   ///< List of architecture extensions. These must listed in canonical order

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -599,7 +599,7 @@ bool RevLoader::LoadElf( const std::string& exe, const std::vector<std::string>&
 }
 
 uint64_t RevLoader::GetSymbolAddr( std::string Symbol ) {
-  uint64_t tmp = 0x00ull;
+  uint64_t tmp = 0;
   if( symtable.find( Symbol ) != symtable.end() ) {
     tmp = symtable[Symbol];
   }

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -54,7 +54,7 @@ bool RevLoader::WriteCacheLine( uint64_t Addr, size_t Len, const void* Data ) {
   }
 
   // calculate the cache line size
-  unsigned lineSize = mem->getLineSize();
+  uint32_t lineSize = mem->getLineSize();
   if( lineSize == 0 ) {
     // default to 64byte cache lines
     lineSize = 64;
@@ -239,8 +239,8 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   if( sz < sh[eh->e_shstrndx].sh_offset + sh[eh->e_shstrndx].sh_size )
     output->fatal( CALL_INFO, -1, "Error: RV32 Elf is unrecognizable\n" );
 
-  unsigned strtabidx = 0;
-  unsigned symtabidx = 0;
+  uint32_t strtabidx = 0;
+  uint32_t symtabidx = 0;
 
   // Iterate over every section header
   for( size_t i = 0; i < eh->e_shnum; i++ ) {
@@ -266,7 +266,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
     // Iterate over every symbol in the symbol table
     for( size_t i = 0; i < sh[symtabidx].sh_size / sizeof( Elf32_Sym ); i++ ) {
       // Calculate the maximum length of the symbol
-      unsigned maxlen = sh[strtabidx].sh_size - sym[i].st_name;
+      uint32_t maxlen = sh[strtabidx].sh_size - sym[i].st_name;
       if( sym[i].st_name >= sh[strtabidx].sh_size )
         output->fatal( CALL_INFO, -1, "Error: RV32 Elf is unrecognizable\n" );
       if( strnlen( strtab + sym[i].st_name, maxlen ) >= maxlen )
@@ -393,8 +393,8 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
   if( sz < sh[eh->e_shstrndx].sh_offset + sh[eh->e_shstrndx].sh_size )
     output->fatal( CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
 
-  unsigned strtabidx = 0;
-  unsigned symtabidx = 0;
+  uint32_t strtabidx = 0;
+  uint32_t symtabidx = 0;
 
   // Iterate over every section header
   for( size_t i = 0; i < eh->e_shnum; i++ ) {
@@ -421,7 +421,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
     // Iterate over every symbol in the symbol table
     for( size_t i = 0; i < sh[symtabidx].sh_size / sizeof( Elf64_Sym ); i++ ) {
       // Calculate the maximum length of the symbol
-      unsigned maxlen = sh[strtabidx].sh_size - sym[i].st_name;
+      uint32_t maxlen = sh[strtabidx].sh_size - sym[i].st_name;
       if( sym[i].st_name >= sh[strtabidx].sh_size )
         output->fatal( CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
       if( strnlen( strtab + sym[i].st_name, maxlen ) >= maxlen )

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -133,7 +133,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   RV32Entry            = eh->e_entry;
 
   // Add memory segments for each program header
-  for( unsigned i = 0; i < eh->e_phnum; i++ ) {
+  for( size_t i = 0; i < eh->e_phnum; i++ ) {
     if( sz < ph[i].p_offset + ph[i].p_filesz ) {
       output->fatal( CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
     }
@@ -154,7 +154,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   (void) mem->AddThreadMem();
 
   // Add memory segments for each program header
-  for( unsigned i = 0; i < eh->e_phnum; i++ ) {
+  for( size_t i = 0; i < eh->e_phnum; i++ ) {
     if( sz < ph[i].p_offset + ph[i].p_filesz ) {
       output->fatal( CALL_INFO, -1, "Error: RV32 Elf is unrecognizable\n" );
     }
@@ -168,7 +168,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   uint64_t BSSEnd        = 0;
   uint64_t DataEnd       = 0;
   uint64_t TextEnd       = 0;
-  for( unsigned i = 0; i < eh->e_shnum; i++ ) {
+  for( size_t i = 0; i < eh->e_shnum; i++ ) {
     // check if the section header name is bss
     if( strcmp( shstrtab + sh[i].sh_name, ".bss" ) == 0 ) {
       BSSEnd = sh[i].sh_addr + sh[i].sh_size;
@@ -215,7 +215,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   mem->SetStackTop( sp );
 
   // iterate over the program headers
-  for( unsigned i = 0; i < eh->e_phnum; i++ ) {
+  for( size_t i = 0; i < eh->e_phnum; i++ ) {
     // Look for the loadable program headers
     if( ph[i].p_type == PT_LOAD && ph[i].p_memsz ) {
       if( ph[i].p_filesz ) {
@@ -243,7 +243,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
   unsigned symtabidx = 0;
 
   // Iterate over every section header
-  for( unsigned i = 0; i < eh->e_shnum; i++ ) {
+  for( size_t i = 0; i < eh->e_shnum; i++ ) {
     // If the section header is empty, skip it
     if( sh[i].sh_type & SHT_NOBITS )
       continue;
@@ -264,7 +264,7 @@ bool RevLoader::LoadElf32( char* membuf, size_t sz ) {
     char*      strtab = membuf + sh[strtabidx].sh_offset;
     Elf32_Sym* sym    = (Elf32_Sym*) ( membuf + sh[symtabidx].sh_offset );
     // Iterate over every symbol in the symbol table
-    for( unsigned i = 0; i < sh[symtabidx].sh_size / sizeof( Elf32_Sym ); i++ ) {
+    for( size_t i = 0; i < sh[symtabidx].sh_size / sizeof( Elf32_Sym ); i++ ) {
       // Calculate the maximum length of the symbol
       unsigned maxlen = sh[strtabidx].sh_size - sym[i].st_name;
       if( sym[i].st_name >= sh[strtabidx].sh_size )
@@ -297,7 +297,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
   RV64Entry            = eh->e_entry;
 
   // Add memory segments for each program header
-  for( unsigned i = 0; i < eh->e_phnum; i++ ) {
+  for( size_t i = 0; i < eh->e_phnum; i++ ) {
     if( sz < ph[i].p_offset + ph[i].p_filesz ) {
       output->fatal( CALL_INFO, -1, "Error: RV64 Elf is unrecognizable\n" );
     }
@@ -322,7 +322,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
   uint64_t BSSEnd        = 0;
   uint64_t DataEnd       = 0;
   uint64_t TextEnd       = 0;
-  for( unsigned i = 0; i < eh->e_shnum; i++ ) {
+  for( size_t i = 0; i < eh->e_shnum; i++ ) {
     // check if the section header name is bss
     if( strcmp( shstrtab + sh[i].sh_name, ".bss" ) == 0 ) {
       BSSEnd = sh[i].sh_addr + sh[i].sh_size;
@@ -369,7 +369,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
   mem->SetStackTop( sp );
 
   // iterate over the program headers
-  for( unsigned i = 0; i < eh->e_phnum; i++ ) {
+  for( size_t i = 0; i < eh->e_phnum; i++ ) {
     // Look for the loadable headers
     if( ph[i].p_type == PT_LOAD && ph[i].p_memsz ) {
       if( ph[i].p_filesz ) {
@@ -397,7 +397,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
   unsigned symtabidx = 0;
 
   // Iterate over every section header
-  for( unsigned i = 0; i < eh->e_shnum; i++ ) {
+  for( size_t i = 0; i < eh->e_shnum; i++ ) {
     // If the section header is empty, skip it
     if( sh[i].sh_type & SHT_NOBITS ) {
       continue;
@@ -419,7 +419,7 @@ bool RevLoader::LoadElf64( char* membuf, size_t sz ) {
     char*      strtab = membuf + sh[strtabidx].sh_offset;
     Elf64_Sym* sym    = (Elf64_Sym*) ( membuf + sh[symtabidx].sh_offset );
     // Iterate over every symbol in the symbol table
-    for( unsigned i = 0; i < sh[symtabidx].sh_size / sizeof( Elf64_Sym ); i++ ) {
+    for( size_t i = 0; i < sh[symtabidx].sh_size / sizeof( Elf64_Sym ); i++ ) {
       // Calculate the maximum length of the symbol
       unsigned maxlen = sh[strtabidx].sh_size - sym[i].st_name;
       if( sym[i].st_name >= sh[strtabidx].sh_size )
@@ -544,10 +544,10 @@ bool RevLoader::LoadElf( const std::string& exe, const std::vector<std::string>&
   if( fstat( fd, &FileStats ) < 0 )
     output->fatal( CALL_INFO, -1, "Error: failed to stat executable file: %s\n", exe.c_str() );
 
-  size_t FileSize = FileStats.st_size;
+  size_t FileSize = static_cast<size_t>( FileStats.st_size );
 
   // map the executable into memory
-  char* membuf    = (char*) ( mmap( NULL, FileSize, PROT_READ, MAP_PRIVATE, fd, 0 ) );
+  char* membuf    = static_cast<char*>( mmap( NULL, FileSize, PROT_READ, MAP_PRIVATE, fd, 0 ) );
   if( membuf == MAP_FAILED )
     output->fatal( CALL_INFO, -1, "Error: failed to map executable file: %s\n", exe.c_str() );
 

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -774,7 +774,7 @@ uint64_t RevMem::DeallocMem( uint64_t BaseAddr, uint64_t Size ) {
 /// @brief This function is called from the loader to initialize the heap
 /// @param EndOfStaticData: The address of the end of the static data section (ie. end of .bss section)
 void RevMem::InitHeap( const uint64_t& EndOfStaticData ) {
-  if( EndOfStaticData == 0x00ull ) {
+  if( EndOfStaticData == 0 ) {
     // Program didn't contain .text, .data, or .bss sections
     output->fatal(
       CALL_INFO,

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -410,7 +410,7 @@ uint64_t RevMem::AllocMemAt( const uint64_t& BaseAddr, const uint64_t& SegSize )
   output->verbose( CALL_INFO, 10, 99, "Attempting to allocate %" PRIu64 " bytes on the heap", SegSize );
 
   // Check if this range exists in the FreeMemSegs vector
-  for( unsigned i = 0; i < FreeMemSegs.size(); i++ ) {
+  for( uint32_t i = 0; i < FreeMemSegs.size(); i++ ) {
     auto FreeSeg = FreeMemSegs[i];
     if( FreeSeg->contains( BaseAddr, SegSize ) ) {
       // Check if were allocating on a boundary of FreeSeg
@@ -483,14 +483,14 @@ uint64_t RevMem::AllocMemAt( const uint64_t& BaseAddr, const uint64_t& SegSize )
   return ret;
 }
 
-bool RevMem::FenceMem( unsigned Hart ) {
+bool RevMem::FenceMem( uint32_t Hart ) {
   if( ctrl ) {
     return ctrl->sendFENCE( Hart );
   }
   return true;  // base RevMem support does nothing here
 }
 
-bool RevMem::AMOMem( unsigned Hart, uint64_t Addr, size_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags ) {
+bool RevMem::AMOMem( uint32_t Hart, uint64_t Addr, size_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags ) {
 #ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -542,7 +542,7 @@ bool RevMem::AMOMem( unsigned Hart, uint64_t Addr, size_t Len, void* Data, void*
   return true;
 }
 
-bool RevMem::WriteMem( unsigned Hart, uint64_t Addr, size_t Len, const void* Data, RevFlag flags ) {
+bool RevMem::WriteMem( uint32_t Hart, uint64_t Addr, size_t Len, const void* Data, RevFlag flags ) {
 #ifdef _REV_DEBUG_
   std::cout << "Writing " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -595,7 +595,7 @@ std::tuple<uint64_t, uint64_t, uint64_t> RevMem::AdjPageAddr( uint64_t Addr, uin
   return { remainder, physAddr, adjPhysAddr };
 }
 
-bool RevMem::ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void* Target, const MemReq& req, RevFlag flags ) {
+bool RevMem::ReadMem( uint32_t Hart, uint64_t Addr, size_t Len, void* Target, const MemReq& req, RevFlag flags ) {
 #ifdef _REV_DEBUG_
   std::cout << "NEW READMEM: Reading " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
 #endif
@@ -626,7 +626,7 @@ bool RevMem::ReadMem( unsigned Hart, uint64_t Addr, size_t Len, void* Target, co
   return true;
 }
 
-bool RevMem::FlushLine( unsigned Hart, uint64_t Addr ) {
+bool RevMem::FlushLine( uint32_t Hart, uint64_t Addr ) {
   uint64_t pageNum  = Addr >> addrShift;
   uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
   if( ctrl ) {
@@ -636,7 +636,7 @@ bool RevMem::FlushLine( unsigned Hart, uint64_t Addr ) {
   return true;
 }
 
-bool RevMem::InvLine( unsigned Hart, uint64_t Addr ) {
+bool RevMem::InvLine( uint32_t Hart, uint64_t Addr ) {
   uint64_t pageNum  = Addr >> addrShift;
   uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
   if( ctrl ) {
@@ -646,7 +646,7 @@ bool RevMem::InvLine( unsigned Hart, uint64_t Addr ) {
   return true;
 }
 
-bool RevMem::CleanLine( unsigned Hart, uint64_t Addr ) {
+bool RevMem::CleanLine( uint32_t Hart, uint64_t Addr ) {
   uint64_t pageNum  = Addr >> addrShift;
   uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
   if( ctrl ) {
@@ -689,7 +689,7 @@ uint64_t RevMem::DeallocMem( uint64_t BaseAddr, uint64_t Size ) {
 
   uint64_t ret = -uint64_t{ 1 };
   // Search through allocated segments for the segment that begins on the baseAddr
-  for( unsigned i = 0; i < MemSegs.size(); i++ ) {
+  for( uint32_t i = 0; i < MemSegs.size(); i++ ) {
     auto AllocedSeg = MemSegs[i];
     // We don't allow memory to be deallocated if it's not on a segment boundary
     if( AllocedSeg->getBaseAddr() != BaseAddr ) {
@@ -856,7 +856,7 @@ void RevMem::DumpValidMem( const uint64_t bytesPerRow, std::ostream& outputStrea
 
   std::sort( MemSegs.begin(), MemSegs.end() );
   outputStream << "Memory Segments:" << std::endl;
-  for( unsigned i = 0; i < MemSegs.size(); i++ ) {
+  for( uint32_t i = 0; i < MemSegs.size(); i++ ) {
     outputStream << "// SEGMENT #" << i << *MemSegs[i] << std::endl;
     DumpMemSeg( MemSegs[i], bytesPerRow, outputStream );
   }

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -108,8 +108,8 @@ RevMemCtrl::~RevMemCtrl() {
 RevBasicMemCtrl::RevBasicMemCtrl( ComponentId_t id, const Params& params )
   : RevMemCtrl( id, params ), memIface( nullptr ), stdMemHandlers( nullptr ), hasCache( false ), lineSize( 0 ), max_loads( 64 ),
     max_stores( 64 ), max_flush( 64 ), max_llsc( 64 ), max_readlock( 64 ), max_writeunlock( 64 ), max_custom( 64 ), max_ops( 2 ),
-    num_read( 0x00ull ), num_write( 0x00ull ), num_flush( 0x00ull ), num_llsc( 0x00ull ), num_readlock( 0x00ull ),
-    num_writeunlock( 0x00ull ), num_custom( 0x00ull ), num_fence( 0x00ull ) {
+    num_read( 0 ), num_write( 0 ), num_flush( 0 ), num_llsc( 0 ), num_readlock( 0 ), num_writeunlock( 0 ), num_custom( 0 ),
+    num_fence( 0 ) {
 
   stdMemHandlers        = new RevBasicMemCtrl::RevStdMemHandlers( this, output );
 
@@ -325,7 +325,7 @@ bool RevBasicMemCtrl::sendCUSTOMWRITERequest(
 }
 
 bool RevBasicMemCtrl::sendFENCE( unsigned Hart ) {
-  RevMemOp* Op = new RevMemOp( Hart, 0x00ull, 0x00ull, 0x00, MemOp::MemOpFENCE, RevFlag::F_NONE );
+  RevMemOp* Op = new RevMemOp( Hart, 0, 0, 0, MemOp::MemOpFENCE, RevFlag::F_NONE );
   rqstQ.push_back( Op );
   recordStat( RevBasicMemCtrl::MemCtrlStats::FencePending, 1 );
   return true;
@@ -698,7 +698,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
   newBuf.clear();
   uint64_t newBase   = op->getAddr() + BaseCacheLineSize;
   uint64_t bytesLeft = (uint64_t) ( op->getSize() ) - BaseCacheLineSize;
-  uint64_t newSize   = 0x00ull;
+  uint64_t newSize   = 0;
 
   for( unsigned i = 1; i < NumLines; i++ ) {
     // setup the adjusted size of the request

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -43,7 +43,7 @@ RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( target ), procReq() {}
 
-RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, MemOp Op, RevFlag flags )
+RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( nullptr ), procReq() {
   for( uint32_t i = 0; i < Size; i++ ) {
@@ -52,7 +52,7 @@ RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 }
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, MemOp Op, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( target ), procReq() {
@@ -74,7 +74,7 @@ RevMemOp::RevMemOp(
     flags( flags ), target( target ), procReq() {}
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( CustomOpc ), SplitRqst( 1 ),
     flags( flags ), target( nullptr ), procReq() {
@@ -194,7 +194,9 @@ bool RevBasicMemCtrl::sendREADRequest(
   return true;
 }
 
-bool RevBasicMemCtrl::sendWRITERequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags ) {
+bool RevBasicMemCtrl::sendWRITERequest(
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
+) {
   if( Size == 0 )
     return true;
   RevMemOp* Op = new RevMemOp( Hart, Addr, PAddr, Size, buffer, MemOp::MemOpWRITE, flags );
@@ -204,7 +206,7 @@ bool RevBasicMemCtrl::sendWRITERequest( unsigned Hart, uint64_t Addr, uint64_t P
 }
 
 bool RevBasicMemCtrl::sendAMORequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, void* target, const MemReq& req, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, const MemReq& req, RevFlag flags
 ) {
 
   if( Size == 0 )
@@ -270,7 +272,7 @@ bool RevBasicMemCtrl::sendREADLOCKRequest(
 }
 
 bool RevBasicMemCtrl::sendWRITELOCKRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -290,7 +292,7 @@ bool RevBasicMemCtrl::sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_
 }
 
 bool RevBasicMemCtrl::sendSTORECONDRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -312,7 +314,7 @@ bool RevBasicMemCtrl::sendCUSTOMREADRequest(
 }
 
 bool RevBasicMemCtrl::sendCUSTOMWRITERequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, char* buffer, unsigned Opc, RevFlag flags
+  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -1217,7 +1219,7 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
   num_read--;
 }
 
-void RevBasicMemCtrl::performAMO( std::tuple<unsigned, char*, void*, RevFlag, RevMemOp*, bool> Entry ) {
+void RevBasicMemCtrl::performAMO( std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry ) {
   RevMemOp* Tmp = std::get<AMOTABLE_MEMOP>( Entry );
   if( Tmp == nullptr ) {
     output->fatal( CALL_INFO, -1, "Error : AMOTable entry is null\n" );

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -35,15 +35,15 @@ std::ostream& operator<<( std::ostream& os, MemOp op ) {
 // ---------------------------------------------------------------
 // RevMemOp
 // ---------------------------------------------------------------
-RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, MemOp Op, RevFlag flags )
+RevMemOp::RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, MemOp Op, RevFlag flags )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( nullptr ), procReq() {}
 
-RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, MemOp Op, RevFlag flags )
+RevMemOp::RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, MemOp Op, RevFlag flags )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( target ), procReq() {}
 
-RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags )
+RevMemOp::RevMemOp( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, MemOp Op, RevFlag flags )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( nullptr ), procReq() {
   for( uint32_t i = 0; i < Size; i++ ) {
@@ -52,7 +52,7 @@ RevMemOp::RevMemOp( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size,
 }
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     flags( flags ), target( target ), procReq() {
@@ -62,19 +62,19 @@ RevMemOp::RevMemOp(
 }
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
     membuf( buffer ), flags( flags ), target( nullptr ), procReq() {}
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned CustomOpc, MemOp Op, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t CustomOpc, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( CustomOpc ), SplitRqst( 1 ),
     flags( flags ), target( target ), procReq() {}
 
 RevMemOp::RevMemOp(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned CustomOpc, MemOp Op, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, uint32_t CustomOpc, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( CustomOpc ), SplitRqst( 1 ),
     flags( flags ), target( nullptr ), procReq() {
@@ -115,14 +115,14 @@ RevBasicMemCtrl::RevBasicMemCtrl( ComponentId_t id, const Params& params )
 
   std::string ClockFreq = params.find<std::string>( "clock", "1Ghz" );
 
-  max_loads             = params.find<unsigned>( "max_loads", 64 );
-  max_stores            = params.find<unsigned>( "max_stores", 64 );
-  max_flush             = params.find<unsigned>( "max_flush", 64 );
-  max_llsc              = params.find<unsigned>( "max_llsc", 64 );
-  max_readlock          = params.find<unsigned>( "max_readlock", 64 );
-  max_writeunlock       = params.find<unsigned>( "max_writeunlock", 64 );
-  max_custom            = params.find<unsigned>( "max_custom", 64 );
-  max_ops               = params.find<unsigned>( "ops_per_cycle", 2 );
+  max_loads             = params.find<uint32_t>( "max_loads", 64 );
+  max_stores            = params.find<uint32_t>( "max_stores", 64 );
+  max_flush             = params.find<uint32_t>( "max_flush", 64 );
+  max_llsc              = params.find<uint32_t>( "max_llsc", 64 );
+  max_readlock          = params.find<uint32_t>( "max_readlock", 64 );
+  max_writeunlock       = params.find<uint32_t>( "max_writeunlock", 64 );
+  max_custom            = params.find<uint32_t>( "max_custom", 64 );
+  max_ops               = params.find<uint32_t>( "ops_per_cycle", 2 );
 
   rqstQ.reserve( max_ops );
 
@@ -172,7 +172,7 @@ void RevBasicMemCtrl::recordStat( RevBasicMemCtrl::MemCtrlStats Stat, uint64_t D
   stats[Stat]->addData( Data );
 }
 
-bool RevBasicMemCtrl::sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, bool Inv, RevFlag flags ) {
+bool RevBasicMemCtrl::sendFLUSHRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, bool Inv, RevFlag flags ) {
   if( Size == 0 )
     return true;
   RevMemOp* Op = new RevMemOp( Hart, Addr, PAddr, Size, MemOp::MemOpFLUSH, flags );
@@ -183,7 +183,7 @@ bool RevBasicMemCtrl::sendFLUSHRequest( unsigned Hart, uint64_t Addr, uint64_t P
 }
 
 bool RevBasicMemCtrl::sendREADRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -195,7 +195,7 @@ bool RevBasicMemCtrl::sendREADRequest(
 }
 
 bool RevBasicMemCtrl::sendWRITERequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -206,7 +206,7 @@ bool RevBasicMemCtrl::sendWRITERequest(
 }
 
 bool RevBasicMemCtrl::sendAMORequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, const MemReq& req, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, void* target, const MemReq& req, RevFlag flags
 ) {
 
   if( Size == 0 )
@@ -260,7 +260,7 @@ bool RevBasicMemCtrl::sendAMORequest(
 }
 
 bool RevBasicMemCtrl::sendREADLOCKRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, const MemReq& req, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -272,7 +272,7 @@ bool RevBasicMemCtrl::sendREADLOCKRequest(
 }
 
 bool RevBasicMemCtrl::sendWRITELOCKRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -282,7 +282,7 @@ bool RevBasicMemCtrl::sendWRITELOCKRequest(
   return true;
 }
 
-bool RevBasicMemCtrl::sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) {
+bool RevBasicMemCtrl::sendLOADLINKRequest( uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, RevFlag flags ) {
   if( Size == 0 )
     return true;
   RevMemOp* Op = new RevMemOp( Hart, Addr, PAddr, Size, MemOp::MemOpLOADLINK, flags );
@@ -292,7 +292,7 @@ bool RevBasicMemCtrl::sendLOADLINKRequest( unsigned Hart, uint64_t Addr, uint64_
 }
 
 bool RevBasicMemCtrl::sendSTORECONDRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -303,7 +303,7 @@ bool RevBasicMemCtrl::sendSTORECONDRequest(
 }
 
 bool RevBasicMemCtrl::sendCUSTOMREADRequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, unsigned Opc, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t Opc, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -314,7 +314,7 @@ bool RevBasicMemCtrl::sendCUSTOMREADRequest(
 }
 
 bool RevBasicMemCtrl::sendCUSTOMWRITERequest(
-  unsigned Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, unsigned Opc, RevFlag flags
+  uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, unsigned char* buffer, uint32_t Opc, RevFlag flags
 ) {
   if( Size == 0 )
     return true;
@@ -324,7 +324,7 @@ bool RevBasicMemCtrl::sendCUSTOMWRITERequest(
   return true;
 }
 
-bool RevBasicMemCtrl::sendFENCE( unsigned Hart ) {
+bool RevBasicMemCtrl::sendFENCE( uint32_t Hart ) {
   RevMemOp* Op = new RevMemOp( Hart, 0, 0, 0, MemOp::MemOpFENCE, RevFlag::F_NONE );
   rqstQ.push_back( Op );
   recordStat( RevBasicMemCtrl::MemCtrlStats::FencePending, 1 );
@@ -363,13 +363,13 @@ void RevBasicMemCtrl::finish() {}
 
 bool RevBasicMemCtrl::isMemOpAvail(
   RevMemOp* Op,
-  unsigned& t_max_loads,
-  unsigned& t_max_stores,
-  unsigned& t_max_flush,
-  unsigned& t_max_llsc,
-  unsigned& t_max_readlock,
-  unsigned& t_max_writeunlock,
-  unsigned& t_max_custom
+  uint32_t& t_max_loads,
+  uint32_t& t_max_stores,
+  uint32_t& t_max_flush,
+  uint32_t& t_max_llsc,
+  uint32_t& t_max_readlock,
+  uint32_t& t_max_writeunlock,
+  uint32_t& t_max_custom
 ) {
 
   switch( Op->getOp() ) {
@@ -438,7 +438,7 @@ bool RevBasicMemCtrl::isMemOpAvail(
   return false;
 }
 
-unsigned RevBasicMemCtrl::getBaseCacheLineSize( uint64_t Addr, uint32_t Size ) {
+uint32_t RevBasicMemCtrl::getBaseCacheLineSize( uint64_t Addr, uint32_t Size ) {
 
   bool     done          = false;
   uint64_t BaseCacheAddr = Addr;
@@ -471,7 +471,7 @@ unsigned RevBasicMemCtrl::getBaseCacheLineSize( uint64_t Addr, uint32_t Size ) {
   }
 }
 
-unsigned RevBasicMemCtrl::getNumCacheLines( uint64_t Addr, uint32_t Size ) {
+uint32_t RevBasicMemCtrl::getNumCacheLines( uint64_t Addr, uint32_t Size ) {
   // if the cache is disabled, then return 1
   // eg, there is a 1-to-1 mapping of CPU memops to memory requests
   if( !hasCache )
@@ -499,7 +499,7 @@ unsigned RevBasicMemCtrl::getNumCacheLines( uint64_t Addr, uint32_t Size ) {
 
 bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
   Interfaces::StandardMem::Request* rqst     = nullptr;
-  unsigned                          NumLines = getNumCacheLines( op->getAddr(), op->getSize() );
+  uint32_t                          NumLines = getNumCacheLines( op->getAddr(), op->getSize() );
   RevFlag                           TmpFlags = op->getStdFlags();
 
 #ifdef _REV_DEBUG_
@@ -575,7 +575,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
 
   std::vector<uint8_t> tmpBuf = op->getBuf();
   std::vector<uint8_t> newBuf;
-  unsigned             BaseCacheLineSize = 0;
+  uint32_t             BaseCacheLineSize = 0;
   if( NumLines > 1 ) {
     BaseCacheLineSize = getBaseCacheLineSize( op->getAddr(), op->getSize() );
   } else {
@@ -584,7 +584,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
 #ifdef _REV_DEBUG_
   std::cout << "base cache line request size = " << BaseCacheLineSize << std::endl;
 #endif
-  unsigned curByte = 0;
+  uint32_t curByte = 0;
 
   switch( op->getOp() ) {
   case MemOp::MemOpREAD:
@@ -604,7 +604,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
 #ifdef _REV_DEBUG_
     std::cout << "<<<< WRITE REQUEST >>>>" << std::endl;
 #endif
-    for( unsigned i = 0; i < BaseCacheLineSize; i++ ) {
+    for( uint32_t i = 0; i < BaseCacheLineSize; i++ ) {
       newBuf.push_back( tmpBuf[i] );
     }
     curByte = BaseCacheLineSize;
@@ -642,7 +642,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
     num_readlock++;
     break;
   case MemOp::MemOpWRITEUNLOCK:
-    for( unsigned i = 0; i < BaseCacheLineSize; i++ ) {
+    for( uint32_t i = 0; i < BaseCacheLineSize; i++ ) {
       newBuf.push_back( tmpBuf[i] );
     }
     curByte = BaseCacheLineSize;
@@ -666,7 +666,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
     num_llsc++;
     break;
   case MemOp::MemOpSTORECOND:
-    for( unsigned i = 0; i < BaseCacheLineSize; i++ ) {
+    for( uint32_t i = 0; i < BaseCacheLineSize; i++ ) {
       newBuf.push_back( tmpBuf[i] );
     }
     curByte = BaseCacheLineSize;
@@ -700,7 +700,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
   uint64_t bytesLeft = (uint64_t) ( op->getSize() ) - BaseCacheLineSize;
   uint64_t newSize   = 0;
 
-  for( unsigned i = 1; i < NumLines; i++ ) {
+  for( uint32_t i = 1; i < NumLines; i++ ) {
     // setup the adjusted size of the request
     if( bytesLeft < lineSize ) {
       newSize = bytesLeft;
@@ -721,7 +721,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
       num_read++;
       break;
     case MemOp::MemOpWRITE:
-      for( unsigned j = curByte; j < ( curByte + newSize ); j++ ) {
+      for( uint32_t j = curByte; j < ( curByte + newSize ); j++ ) {
         newBuf.push_back( tmpBuf[j] );
       }
       curByte += newSize;
@@ -750,7 +750,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
       num_readlock++;
       break;
     case MemOp::MemOpWRITEUNLOCK:
-      for( unsigned j = curByte; j < ( curByte + newSize ); j++ ) {
+      for( uint32_t j = curByte; j < ( curByte + newSize ); j++ ) {
         newBuf.push_back( tmpBuf[j] );
       }
       curByte += newSize;
@@ -770,7 +770,7 @@ bool RevBasicMemCtrl::buildCacheMemRqst( RevMemOp* op, bool& Success ) {
       num_llsc++;
       break;
     case MemOp::MemOpSTORECOND:
-      for( unsigned j = curByte; j < ( curByte + newSize ); j++ ) {
+      for( uint32_t j = curByte; j < ( curByte + newSize ); j++ ) {
         newBuf.push_back( tmpBuf[j] );
       }
       curByte += newSize;
@@ -951,7 +951,7 @@ bool RevBasicMemCtrl::buildStandardMemRqst( RevMemOp* op, bool& Success ) {
   }
 }
 
-bool RevBasicMemCtrl::isAQ( unsigned Slot, unsigned Hart ) {
+bool RevBasicMemCtrl::isAQ( uint32_t Slot, uint32_t Hart ) {
   if( AMOTable.size() == 0 ) {
     return false;
   } else if( Slot == 0 ) {
@@ -959,7 +959,7 @@ bool RevBasicMemCtrl::isAQ( unsigned Slot, unsigned Hart ) {
   }
 
   // search all preceding slots for an AMO from the same Hart
-  for( unsigned i = 0; i < Slot; i++ ) {
+  for( uint32_t i = 0; i < Slot; i++ ) {
     if( RevFlagHas( rqstQ[i]->getFlags(), RevFlag::F_ATOMIC ) && rqstQ[i]->getHart() == rqstQ[Slot]->getHart() ) {
       if( RevFlagHas( rqstQ[i]->getFlags(), RevFlag::F_AQ ) ) {
         // this implies that we found a preceding request in the request queue
@@ -974,7 +974,7 @@ bool RevBasicMemCtrl::isAQ( unsigned Slot, unsigned Hart ) {
   return false;
 }
 
-bool RevBasicMemCtrl::isRL( unsigned Slot, unsigned Hart ) {
+bool RevBasicMemCtrl::isRL( uint32_t Slot, uint32_t Hart ) {
   if( AMOTable.size() == 0 ) {
     return false;
   } else if( Slot == 0 ) {
@@ -984,7 +984,7 @@ bool RevBasicMemCtrl::isRL( unsigned Slot, unsigned Hart ) {
   if( RevFlagHas( rqstQ[Slot]->getFlags(), RevFlag::F_ATOMIC ) && RevFlagHas( rqstQ[Slot]->getFlags(), RevFlag::F_RL ) ) {
     // this is an AMO, check to see if there are other ops from the same
     // HART in flight
-    for( unsigned i = 0; i < Slot; i++ ) {
+    for( uint32_t i = 0; i < Slot; i++ ) {
       if( rqstQ[i]->getHart() == rqstQ[Slot]->getHart() ) {
         // this implies that the same Hart has preceding memory ops
         // in which case, we can't dispatch this AMO until they clear
@@ -995,19 +995,19 @@ bool RevBasicMemCtrl::isRL( unsigned Slot, unsigned Hart ) {
   return false;
 }
 
-bool RevBasicMemCtrl::isPendingAMO( unsigned Slot ) {
+bool RevBasicMemCtrl::isPendingAMO( uint32_t Slot ) {
   return ( isAQ( Slot, rqstQ[Slot]->getHart() ) || isRL( Slot, rqstQ[Slot]->getHart() ) );
 }
 
 bool RevBasicMemCtrl::processNextRqst(
-  unsigned& t_max_loads,
-  unsigned& t_max_stores,
-  unsigned& t_max_flush,
-  unsigned& t_max_llsc,
-  unsigned& t_max_readlock,
-  unsigned& t_max_writeunlock,
-  unsigned& t_max_custom,
-  unsigned& t_max_ops
+  uint32_t& t_max_loads,
+  uint32_t& t_max_stores,
+  uint32_t& t_max_flush,
+  uint32_t& t_max_llsc,
+  uint32_t& t_max_readlock,
+  uint32_t& t_max_writeunlock,
+  uint32_t& t_max_custom,
+  uint32_t& t_max_ops
 ) {
   if( rqstQ.size() == 0 ) {
     // nothing to do, saturate and exit this cycle
@@ -1018,7 +1018,7 @@ bool RevBasicMemCtrl::processNextRqst(
   bool success = false;
 
   // retrieve the next candidate memory operation
-  for( unsigned i = 0; i < rqstQ.size(); i++ ) {
+  for( uint32_t i = 0; i < rqstQ.size(); i++ ) {
     RevMemOp* op = rqstQ[i];
     if( isMemOpAvail( op, t_max_loads, t_max_stores, t_max_flush, t_max_llsc, t_max_readlock, t_max_writeunlock, t_max_custom ) ) {
 
@@ -1071,7 +1071,7 @@ bool RevBasicMemCtrl::processNextRqst(
   t_max_ops = max_ops;
 
 #ifdef _REV_DEBUG_
-  for( unsigned i = 0; i < rqstQ.size(); i++ ) {
+  for( uint32_t i = 0; i < rqstQ.size(); i++ ) {
     std::cout << "rqstQ[" << i << "] = " << rqstQ[i]->getOp() << " @ 0x" << std::hex << rqstQ[i]->getAddr() << std::dec
               << "; physAddr = 0x" << std::hex << rqstQ[i]->getPhysAddr() << std::dec << std::endl;
   }
@@ -1127,8 +1127,8 @@ void RevHandleFlagResp( void* target, size_t size, RevFlag flags ) {
   }
 }
 
-unsigned RevBasicMemCtrl::getNumSplitRqsts( RevMemOp* op ) {
-  unsigned count = 0;
+uint32_t RevBasicMemCtrl::getNumSplitRqsts( RevMemOp* op ) {
+  uint32_t count = 0;
   for( const auto& n : outstanding ) {
     if( n.second == op ) {
       count++;
@@ -1145,8 +1145,8 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
       output->fatal( CALL_INFO, -1, "RevMemOp is null in handleReadResp\n" );
 #ifdef _REV_DEBUG_
     std::cout << "handleReadResp : id=" << ev->getID() << " @Addr= 0x" << std::hex << op->getAddr() << std::dec << std::endl;
-    for( unsigned i = 0; i < op->getSize(); i++ ) {
-      std::cout << "               : data[" << i << "] = " << (unsigned) ( ev->data[i] ) << std::endl;
+    for( uint32_t i = 0; i < op->getSize(); i++ ) {
+      std::cout << "               : data[" << i << "] = " << (uint32_t) ( ev->data[i] ) << std::endl;
     }
     std::cout << "isOutstanding val = 0x" << std::hex << op->getMemReq().isOutstanding << std::dec << std::endl;
     std::cout << "Address of the target register = 0x" << std::hex << (uint64_t*) ( op->getTarget() ) << std::dec << std::endl;
@@ -1168,9 +1168,9 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
       // split request exists, determine how to handle it
 
       uint8_t* target    = static_cast<uint8_t*>( op->getTarget() );
-      unsigned startByte = (unsigned) ( ev->pAddr - op->getAddr() );
+      uint32_t startByte = (uint32_t) ( ev->pAddr - op->getAddr() );
       target += uint8_t( startByte );
-      for( unsigned i = 0; i < (unsigned) ( ev->size ); i++ ) {
+      for( uint32_t i = 0; i < (uint32_t) ( ev->size ); i++ ) {
         *target = ev->data[i];
         target++;
       }
@@ -1195,7 +1195,7 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
 
     // no split request exists; handle as normal
     uint8_t* target = (uint8_t*) ( op->getTarget() );
-    for( unsigned i = 0; i < op->getSize(); i++ ) {
+    for( uint32_t i = 0; i < op->getSize(); i++ ) {
       *target = ev->data[i];
       target++;
     }
@@ -1219,7 +1219,7 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
   num_read--;
 }
 
-void RevBasicMemCtrl::performAMO( std::tuple<unsigned, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry ) {
+void RevBasicMemCtrl::performAMO( std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry ) {
   RevMemOp* Tmp = std::get<AMOTABLE_MEMOP>( Entry );
   if( Tmp == nullptr ) {
     output->fatal( CALL_INFO, -1, "Error : AMOTable entry is null\n" );
@@ -1261,7 +1261,7 @@ void RevBasicMemCtrl::performAMO( std::tuple<unsigned, unsigned char*, void*, Re
   RevMemOp* Op =
     new RevMemOp( Tmp->getHart(), Tmp->getAddr(), Tmp->getPhysAddr(), Tmp->getSize(), buffer, MemOp::MemOpWRITE, Tmp->getFlags() );
   Op->setTempT( tempT );
-  for( unsigned i = 0; i < Op->getSize(); i++ ) {
+  for( uint32_t i = 0; i < Op->getSize(); i++ ) {
     TmpBuf8[i] = tempT[i];
   }
 
@@ -1470,14 +1470,14 @@ bool RevBasicMemCtrl::clockTick( Cycle_t cycle ) {
 
   // process the memory queue
   bool     done              = false;
-  unsigned t_max_ops         = 0;
-  unsigned t_max_loads       = 0;
-  unsigned t_max_stores      = 0;
-  unsigned t_max_flush       = 0;
-  unsigned t_max_llsc        = 0;
-  unsigned t_max_readlock    = 0;
-  unsigned t_max_writeunlock = 0;
-  unsigned t_max_custom      = 0;
+  uint32_t t_max_ops         = 0;
+  uint32_t t_max_loads       = 0;
+  uint32_t t_max_stores      = 0;
+  uint32_t t_max_flush       = 0;
+  uint32_t t_max_llsc        = 0;
+  uint32_t t_max_readlock    = 0;
+  uint32_t t_max_writeunlock = 0;
+  uint32_t t_max_custom      = 0;
 
   while( !done ) {
     if( !processNextRqst(

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -339,14 +339,14 @@ void RevBasicMemCtrl::processMemEvent( StandardMem::Request* ev ) {
   ev->handle( stdMemHandlers );
 }
 
-void RevBasicMemCtrl::init( unsigned int phase ) {
+void RevBasicMemCtrl::init( uint32_t phase ) {
   memIface->init( phase );
 
   // query the caching infrastructure
   if( phase == 1 ) {
     lineSize = memIface->getLineSize();
     if( lineSize > 0 ) {
-      output->verbose( CALL_INFO, 5, 0, "Detected cache layers; default line size=%u\n", lineSize );
+      output->verbose( CALL_INFO, 5, 0, "Detected cache layers; default line size=%" PRIu64 "\n", lineSize );
       hasCache = true;
     } else {
       output->verbose( CALL_INFO, 5, 0, "No cache detected; disabling caching\n" );

--- a/src/RevNIC.cc
+++ b/src/RevNIC.cc
@@ -14,7 +14,7 @@ namespace SST::RevCPU {
 
 RevNIC::RevNIC( ComponentId_t id, Params& params ) : nicAPI( id, params ) {
   // setup the initial logging functions
-  int verbosity              = params.find<int>( "verbose", 0 );
+  auto verbosity             = params.find<uint32_t>( "verbose", 0 );
   output                     = new SST::Output( "", verbosity, 0, SST::Output::STDOUT );
 
   const std::string nicClock = params.find<std::string>( "clock", "1GHz" );

--- a/src/RevNIC.cc
+++ b/src/RevNIC.cc
@@ -51,7 +51,7 @@ void RevNIC::setMsgHandler( Event::HandlerBase* handler ) {
   msgHandler = handler;
 }
 
-void RevNIC::init( unsigned int phase ) {
+void RevNIC::init( uint32_t phase ) {
   iFace->init( phase );
 
   if( iFace->isNetworkInitialized() ) {

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -12,10 +12,10 @@
 
 namespace SST::RevCPU {
 
-RevOpts::RevOpts( unsigned NumCores, unsigned NumHarts, const int Verbosity )
+RevOpts::RevOpts( uint32_t NumCores, uint32_t NumHarts, const int Verbosity )
   : numCores( NumCores ), numHarts( NumHarts ), verbosity( Verbosity ) {
 
-  std::pair<unsigned, unsigned> InitialPair;
+  std::pair<uint32_t, uint32_t> InitialPair;
   InitialPair.first  = 0;
   InitialPair.second = 10;
 
@@ -26,12 +26,12 @@ RevOpts::RevOpts( unsigned NumCores, unsigned NumHarts, const int Verbosity )
   // -- table = internal
   // -- memCosts[core] = 0:10
   // -- prefetch depth = 16
-  for( unsigned i = 0; i < numCores; i++ ) {
-    startAddr.insert( std::pair<unsigned, uint64_t>( i, 0 ) );
-    machine.insert( std::pair<unsigned, std::string>( i, "G" ) );
-    table.insert( std::pair<unsigned, std::string>( i, "_REV_INTERNAL_" ) );
+  for( uint32_t i = 0; i < numCores; i++ ) {
+    startAddr.insert( std::pair<uint32_t, uint64_t>( i, 0 ) );
+    machine.insert( std::pair<uint32_t, std::string>( i, "G" ) );
+    table.insert( std::pair<uint32_t, std::string>( i, "_REV_INTERNAL_" ) );
     memCosts.push_back( InitialPair );
-    prefetchDepth.insert( std::pair<unsigned, unsigned>( i, 16 ) );
+    prefetchDepth.insert( std::pair<uint32_t, uint32_t>( i, 16 ) );
   }
 }
 
@@ -51,18 +51,18 @@ void RevOpts::SetArgs( const SST::Params& params ) {
 
 bool RevOpts::InitPrefetchDepth( const std::vector<std::string>& Depths ) {
   std::vector<std::string> vstr;
-  for( unsigned i = 0; i < Depths.size(); i++ ) {
+  for( uint32_t i = 0; i < Depths.size(); i++ ) {
     std::string s = Depths[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
     std::string::size_type sz          = 0;
-    unsigned               Depth       = std::stoul( vstr[1], &sz, 0 );
+    uint32_t               Depth       = std::stoul( vstr[1], &sz, 0 );
 
     prefetchDepth.find( Core )->second = Depth;
     vstr.clear();
@@ -84,20 +84,20 @@ bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ) {
       // set all cores to the target machine model
       std::string::size_type sz   = 0;
       uint64_t               Addr = std::stoull( vstr[1], &sz, 0 );
-      for( unsigned i = 0; i < numCores; i++ ) {
+      for( uint32_t i = 0; i < numCores; i++ ) {
         startAddr.find( i )->second = Addr;
       }
       return true;
     }
   }
 
-  for( unsigned i = 0; i < StartAddrs.size(); i++ ) {
+  for( uint32_t i = 0; i < StartAddrs.size(); i++ ) {
     std::string s = StartAddrs[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -112,17 +112,17 @@ bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ) {
 
 bool RevOpts::InitStartSymbols( const std::vector<std::string>& StartSymbols ) {
   std::vector<std::string> vstr;
-  for( unsigned i = 0; i < StartSymbols.size(); i++ ) {
+  for( uint32_t i = 0; i < StartSymbols.size(); i++ ) {
     std::string s = StartSymbols[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
-    startSym.insert( std::pair<unsigned, std::string>( Core, vstr[1] ) );
+    startSym.insert( std::pair<uint32_t, std::string>( Core, vstr[1] ) );
     vstr.clear();
   }
   return true;
@@ -140,7 +140,7 @@ bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
 
     if( vstr[0] == "CORES" ) {
       // set all cores to the target machine model
-      for( unsigned i = 0; i < numCores; i++ ) {
+      for( uint32_t i = 0; i < numCores; i++ ) {
         machine.at( i ) = vstr[1];
       }
       return true;
@@ -148,13 +148,13 @@ bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
   }
 
   // parse individual core configs
-  for( unsigned i = 0; i < Machines.size(); i++ ) {
+  for( uint32_t i = 0; i < Machines.size(); i++ ) {
     std::string s = Machines[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -166,13 +166,13 @@ bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
 
 bool RevOpts::InitInstTables( const std::vector<std::string>& InstTables ) {
   std::vector<std::string> vstr;
-  for( unsigned i = 0; i < InstTables.size(); i++ ) {
+  for( uint32_t i = 0; i < InstTables.size(); i++ ) {
     std::string s = InstTables[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -185,15 +185,15 @@ bool RevOpts::InitInstTables( const std::vector<std::string>& InstTables ) {
 bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
   std::vector<std::string> vstr;
 
-  for( unsigned i = 0; i < MemCosts.size(); i++ ) {
+  for( uint32_t i = 0; i < MemCosts.size(); i++ ) {
     std::string s = MemCosts[i];
     splitStr( s, ":", vstr );
     if( vstr.size() != 3 )
       return false;
 
-    unsigned Core         = std::stoul( vstr[0], nullptr, 0 );
-    unsigned Min          = std::stoul( vstr[1], nullptr, 0 );
-    unsigned Max          = std::stoul( vstr[2], nullptr, 0 );
+    uint32_t Core         = std::stoul( vstr[0], nullptr, 0 );
+    uint32_t Min          = std::stoul( vstr[1], nullptr, 0 );
+    uint32_t Max          = std::stoul( vstr[2], nullptr, 0 );
     memCosts[Core].first  = Min;
     memCosts[Core].second = Max;
     if( ( Min == 0 ) || ( Max == 0 ) ) {
@@ -205,7 +205,7 @@ bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
   return true;
 }
 
-bool RevOpts::GetPrefetchDepth( unsigned Core, unsigned& Depth ) {
+bool RevOpts::GetPrefetchDepth( uint32_t Core, uint32_t& Depth ) {
   if( Core > numCores )
     return false;
 
@@ -216,7 +216,7 @@ bool RevOpts::GetPrefetchDepth( unsigned Core, unsigned& Depth ) {
   return true;
 }
 
-bool RevOpts::GetStartAddr( unsigned Core, uint64_t& StartAddr ) {
+bool RevOpts::GetStartAddr( uint32_t Core, uint64_t& StartAddr ) {
   if( Core > numCores )
     return false;
 
@@ -227,7 +227,7 @@ bool RevOpts::GetStartAddr( unsigned Core, uint64_t& StartAddr ) {
   return true;
 }
 
-bool RevOpts::GetStartSymbol( unsigned Core, std::string& Symbol ) {
+bool RevOpts::GetStartSymbol( uint32_t Core, std::string& Symbol ) {
   if( Core > numCores )
     return false;
 
@@ -238,7 +238,7 @@ bool RevOpts::GetStartSymbol( unsigned Core, std::string& Symbol ) {
   return true;
 }
 
-bool RevOpts::GetMachineModel( unsigned Core, std::string& MachModel ) {
+bool RevOpts::GetMachineModel( uint32_t Core, std::string& MachModel ) {
   if( Core > numCores )
     return false;
 
@@ -246,7 +246,7 @@ bool RevOpts::GetMachineModel( unsigned Core, std::string& MachModel ) {
   return true;
 }
 
-bool RevOpts::GetInstTable( unsigned Core, std::string& Table ) {
+bool RevOpts::GetInstTable( uint32_t Core, std::string& Table ) {
   if( Core > numCores )
     return false;
 
@@ -254,7 +254,7 @@ bool RevOpts::GetInstTable( unsigned Core, std::string& Table ) {
   return true;
 }
 
-bool RevOpts::GetMemCost( unsigned Core, unsigned& Min, unsigned& Max ) {
+bool RevOpts::GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max ) {
   if( Core > numCores )
     return false;
 

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -97,7 +97,7 @@ bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ) {
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoi( vstr[0], nullptr, 0 );
+    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -118,7 +118,7 @@ bool RevOpts::InitStartSymbols( const std::vector<std::string>& StartSymbols ) {
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoi( vstr[0], nullptr, 0 );
+    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -154,7 +154,7 @@ bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoi( vstr[0], nullptr, 0 );
+    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -172,7 +172,7 @@ bool RevOpts::InitInstTables( const std::vector<std::string>& InstTables ) {
     if( vstr.size() != 2 )
       return false;
 
-    unsigned Core = std::stoi( vstr[0], nullptr, 0 );
+    unsigned Core = std::stoul( vstr[0], nullptr, 0 );
     if( Core > numCores )
       return false;
 
@@ -191,9 +191,9 @@ bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
     if( vstr.size() != 3 )
       return false;
 
-    unsigned Core         = std::stoi( vstr[0], nullptr, 0 );
-    unsigned Min          = std::stoi( vstr[1], nullptr, 0 );
-    unsigned Max          = std::stoi( vstr[2], nullptr, 0 );
+    unsigned Core         = std::stoul( vstr[0], nullptr, 0 );
+    unsigned Min          = std::stoul( vstr[1], nullptr, 0 );
+    unsigned Max          = std::stoul( vstr[2], nullptr, 0 );
     memCosts[Core].first  = Min;
     memCosts[Core].second = Max;
     if( ( Min == 0 ) || ( Max == 0 ) ) {

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -21,7 +21,7 @@ delete[] s;
 bool RevPrefetcher::IsAvail( uint64_t Addr ) {
 
   // note: this logic now considers compressed instructions
-  uint64_t lastAddr = 0x00ull;
+  uint64_t lastAddr = 0;
   for( unsigned i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {
@@ -87,7 +87,7 @@ void RevPrefetcher::MarkInstructionLoadComplete( const MemReq& req ) {
 }
 
 bool RevPrefetcher::FetchUpper( uint64_t Addr, bool& Fetched, uint32_t& UInst ) {
-  uint64_t lastAddr = 0x00ull;
+  uint64_t lastAddr = 0;
   for( unsigned i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {
@@ -121,7 +121,7 @@ bool RevPrefetcher::FetchUpper( uint64_t Addr, bool& Fetched, uint32_t& UInst ) 
 
 bool RevPrefetcher::InstFetch( uint64_t Addr, bool& Fetched, uint32_t& Inst ) {
   // scan the baseAddr vector to see if the address is cached
-  uint64_t lastAddr = 0x00ull;
+  uint64_t lastAddr = 0;
   for( unsigned i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -22,7 +22,7 @@ bool RevPrefetcher::IsAvail( uint64_t Addr ) {
 
   // note: this logic now considers compressed instructions
   uint64_t lastAddr = 0;
-  for( unsigned i = 0; i < baseAddr.size(); i++ ) {
+  for( uint32_t i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {
       // found it, fetch the address
@@ -88,7 +88,7 @@ void RevPrefetcher::MarkInstructionLoadComplete( const MemReq& req ) {
 
 bool RevPrefetcher::FetchUpper( uint64_t Addr, bool& Fetched, uint32_t& UInst ) {
   uint64_t lastAddr = 0;
-  for( unsigned i = 0; i < baseAddr.size(); i++ ) {
+  for( uint32_t i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {
       uint32_t Off = static_cast<uint32_t>( ( Addr - baseAddr[i] ) / 4 );
@@ -122,7 +122,7 @@ bool RevPrefetcher::FetchUpper( uint64_t Addr, bool& Fetched, uint32_t& UInst ) 
 bool RevPrefetcher::InstFetch( uint64_t Addr, bool& Fetched, uint32_t& Inst ) {
   // scan the baseAddr vector to see if the address is cached
   uint64_t lastAddr = 0;
-  for( unsigned i = 0; i < baseAddr.size(); i++ ) {
+  for( uint32_t i = 0; i < baseAddr.size(); i++ ) {
     lastAddr = baseAddr[i] + ( depth * 4 );
     if( ( Addr >= baseAddr[i] ) && ( Addr < lastAddr ) ) {
       // found it, fetch the address

--- a/src/RevPrefetcher.cc
+++ b/src/RevPrefetcher.cc
@@ -205,8 +205,8 @@ void RevPrefetcher::Fill( uint64_t Addr ) {
 void RevPrefetcher::DeleteStream( size_t i ) {
   // delete the target stream as we no longer need it
   if( i < baseAddr.size() ) {
-    iStack.erase( iStack.begin() + i );
-    baseAddr.erase( baseAddr.begin() + i );
+    iStack.erase( iStack.begin() + ptrdiff_t( i ) );
+    baseAddr.erase( baseAddr.begin() + ptrdiff_t( i ) );
   }
 }
 

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1217,8 +1217,8 @@ EcallStatus RevCore::ECALL_clock_gettime() {
   }
   memset( &src, 0, sizeof( *tp ) );
   SimTime_t x = timeConverter->convertToCoreTime( Stats.totalCycles );
-  src.tv_sec  = x / 1000000000000ull;
-  src.tv_nsec = ( x / 1000 ) % 1000000000ull;
+  src.tv_sec  = time_t( x / 1000000000000 );
+  src.tv_nsec = long( ( x / 1000 ) % 1000000000 );
   mem->WriteMem( HartToExecID, (size_t) tp, sizeof( *tp ), &src );
   RegFile->SetX( RevReg::a0, 0 );
   return EcallStatus::SUCCESS;
@@ -3165,7 +3165,7 @@ EcallStatus RevCore::ECALL_cpuinfo() {
   auto               addr = RegFile->GetX<int>( RevReg::a0 );
   info.cores              = opts->GetNumCores();
   info.harts_per_core     = opts->GetNumHarts();
-  mem->WriteMem( HartToExecID, addr, sizeof( info ), &info );
+  mem->WriteMem( HartToExecID, uint64_t( addr ), sizeof( info ), &info );
   RegFile->SetX( RevReg::a0, 0 );
   return EcallStatus::SUCCESS;
 }
@@ -3253,7 +3253,7 @@ EcallStatus RevCore::ECALL_dump_mem_range() {
   return EcallStatus::SUCCESS;
 }
 
-// 9001, rev_dump_mem_range(const char* outputFile, uint64_t addr, uint64_t size)
+// 9001, rev_dump_mem_range(const unsigned char* outputFile, uint64_t addr, uint64_t size)
 EcallStatus RevCore::ECALL_dump_mem_range_to_file() {
   auto& EcallState = Harts.at( HartToExecID )->GetEcallState();
   if( EcallState.bytesRead == 0 ) {
@@ -3288,7 +3288,7 @@ EcallStatus RevCore::ECALL_dump_stack() {
   return EcallStatus::SUCCESS;
 }
 
-// 9003, rev_dump_stck_to_file(const char* outputFile)
+// 9003, rev_dump_stck_to_file(const unsigned char* outputFile)
 EcallStatus RevCore::ECALL_dump_stack_to_file() {
   auto& EcallState = Harts.at( HartToExecID )->GetEcallState();
   if( EcallState.bytesRead == 0 ) {
@@ -3753,13 +3753,13 @@ const std::unordered_map<uint32_t, EcallStatus(RevCore::*)()> RevCore::Ecalls = 
     { 1000, &RevCore::ECALL_pthread_create },           //
     { 1001, &RevCore::ECALL_pthread_join },             //
     { 9000, &RevCore::ECALL_dump_mem_range },           // rev_dump_mem_range(uint64_t addr, uint64_t size)
-    { 9001, &RevCore::ECALL_dump_mem_range_to_file },   // rev_dump_mem_range_to_file(const char* outputFile, uint64_t addr, uint64_t size)
+    { 9001, &RevCore::ECALL_dump_mem_range_to_file },   // rev_dump_mem_range_to_file(const unsigned char* outputFile, uint64_t addr, uint64_t size)
     { 9002, &RevCore::ECALL_dump_stack },               // rev_dump_stack()
-    { 9003, &RevCore::ECALL_dump_stack_to_file },       // rev_dump_stack(const char* outputFile)
+    { 9003, &RevCore::ECALL_dump_stack_to_file },       // rev_dump_stack(const unsigned char* outputFile)
     { 9004, &RevCore::ECALL_dump_valid_mem },           // rev_dump_valid_mem()
-    { 9005, &RevCore::ECALL_dump_valid_mem_to_file },   // rev_dump_valid_mem_to_file(const char* filename)
+    { 9005, &RevCore::ECALL_dump_valid_mem_to_file },   // rev_dump_valid_mem_to_file(const unsigned char* filename)
     { 9004, &RevCore::ECALL_dump_thread_mem },          // rev_dump_thread_mem()
-    { 9005, &RevCore::ECALL_dump_thread_mem_to_file },  // rev_dump_thread_mem_to_file(const char* filename)
+    { 9005, &RevCore::ECALL_dump_thread_mem_to_file },  // rev_dump_thread_mem_to_file(const unsigned char* filename)
     { 9110, &RevCore::ECALL_fast_printf },              // rev_fast_printf(const char *, ...)
 };
 // clang-format on

--- a/src/RevThread.cc
+++ b/src/RevThread.cc
@@ -17,7 +17,7 @@ std::ostream& operator<<( std::ostream& os, const RevThread& Thread ) {
   os << "\n";
 
   // Calculate total width of the table
-  int tableWidth = 6 /*Reg*/ + 7 /*Alias*/ + 16 /*Value*/ + 23 /*Info*/ + 9 /*Separators*/;
+  size_t tableWidth = 6 /*Reg*/ + 7 /*Alias*/ + 16 /*Value*/ + 23 /*Info*/ + 9 /*Separators*/;
 
   // Print a top border
   os << "|" << std::string( tableWidth - 1, '=' ) << "|" << '\n';

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -25,7 +25,7 @@ RevTracer::RevTracer( std::string Name, SST::Output* o ) : name( Name ), pOutput
 
   // Initialize NOP trace controls
   uint32_t cmd_template = s2op.at( TRC_OP_DEFAULT );
-  for( unsigned i = 0; i < NOP_COUNT; i++ )
+  for( uint32_t i = 0; i < NOP_COUNT; i++ )
     nops[i] = cmd_template | ( i << TRC_OP_POS );
 
 #if 1
@@ -87,8 +87,8 @@ void RevTracer::SetCmdTemplate( std::string cmd ) {
     pOutput->fatal( CALL_INFO, -1, "Unsupported parameter [trcCmd=%s]. Supported values are: %s\n", cmd.c_str(), s.str().c_str() );
   }
 
-  unsigned cmd_template = s2op.at( cmd );
-  for( unsigned i = 0; i < NOP_COUNT; i++ )
+  uint32_t cmd_template = s2op.at( cmd );
+  for( uint32_t i = 0; i < NOP_COUNT; i++ )
     nops[i] = cmd_template | ( i << TRC_OP_POS );
 }
 
@@ -117,19 +117,19 @@ void RevTracer::CheckUserControls( uint64_t cycle ) {
 
   // programatic controls
   bool nextState = outputEnabled;
-  if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_OFF )] ) {
+  if( insn == nops[safe_static_cast<uint32_t>( TRC_CMD_IDX::TRACE_OFF )] ) {
     nextState = false;
-  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_ON )] ) {
+  } else if( insn == nops[safe_static_cast<uint32_t>( TRC_CMD_IDX::TRACE_ON )] ) {
     nextState = true;
-  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_OFF )] ) {
+  } else if( insn == nops[safe_static_cast<uint32_t>( TRC_CMD_IDX::TRACE_PUSH_OFF )] ) {
     enableQ[enableQindex] = outputEnabled;
     enableQindex          = ( enableQindex + 1 ) % MAX_ENABLE_Q;
     nextState             = false;
-  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_PUSH_ON )] ) {
+  } else if( insn == nops[safe_static_cast<uint32_t>( TRC_CMD_IDX::TRACE_PUSH_ON )] ) {
     enableQ[enableQindex] = outputEnabled;
     enableQindex          = ( enableQindex + 1 ) % MAX_ENABLE_Q;
     nextState             = true;
-  } else if( insn == nops[safe_static_cast<unsigned>( TRC_CMD_IDX::TRACE_POP )] ) {
+  } else if( insn == nops[safe_static_cast<uint32_t>( TRC_CMD_IDX::TRACE_POP )] ) {
     enableQindex = ( enableQindex - 1 ) % MAX_ENABLE_Q;
     nextState    = enableQ[enableQindex];
   }
@@ -189,7 +189,7 @@ void RevTracer::pcWrite( uint64_t newpc ) {
   traceRecs.emplace_back( TraceRec_t( PcWrite, newpc, 0, 0 ) );
 }
 
-void RevTracer::Exec( size_t cycle, unsigned id, unsigned hart, unsigned tid, const std::string& fallbackMnemonic ) {
+void RevTracer::Exec( size_t cycle, uint32_t id, uint32_t hart, uint32_t tid, const std::string& fallbackMnemonic ) {
   instHeader.set( cycle, id, hart, tid, fallbackMnemonic );
 }
 
@@ -361,7 +361,7 @@ std::string RevTracer::fmt_reg( uint8_t r ) {
     s << xpr_name[r];  // defined in disasm.h
     return s.str();
   }
-  s << "?" << (unsigned) r;
+  s << "?" << (uint32_t) r;
 #else
   s << "x" << std::dec << (uint16_t) r;  // Use SST::RevCPU::RevReg?
 #endif

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -368,19 +368,15 @@ std::string RevTracer::fmt_reg( uint8_t r ) {
   return s.str();
 }
 
-std::string RevTracer::fmt_data( unsigned len, uint64_t d ) {
+std::string RevTracer::fmt_data( size_t len, uint64_t d ) {
   std::stringstream s;
   if( len == 0 )
     return "";
   s << "0x" << std::hex << std::setfill( '0' );
-  if( len > 8 )
-    s << std::setw( 8 * 2 ) << d << "..+" << std::dec << ( 8 - len );
-  else if( len == 8 )
-    s << std::setw( 8 * 2 ) << d;
+  if( len > sizeof( d ) )
+    s << std::setw( sizeof( d ) * 2 ) << d << "..+" << std::dec << len - sizeof( d );
   else {
-    unsigned shift = ( 8 - len ) * 8;
-    uint64_t mask  = ( ~0ULL ) >> shift;
-    s << std::setw( len * 2 ) << ( d & mask );
+    s << std::setw( len * 2 ) << ( d & ~( ~uint64_t{} << len * 8 ) );
   }
   return s.str();
 }


### PR DESCRIPTION
Three new bit manipulation functions are added:

- `BitExtract<pos, width>( T x )` returns bits `[ pos + width - 1 : pos ]` of `x` and is zero-extended or sign-extended depending on the signedness of `x`. You can also use `BitExtract<pos, width, type>( x )` to coerce the return type and signedness to `type` in case `X` has a different size or signedness as the desired result.

- `BitDeposit<pos, width>( T &x, U y )` deposits the lower `width` bits of `y` into bits `[ pos + width - 1 : pos ]` of `x`. It returns a reference to `x` so that multiple calls can be chained, e.g. `BitDeposit<7, 1>( BitDeposit<0, 3>( Vtype, vlmul ), vma ) )`.

Those instructions are analogous to the PA-RISC extract and deposit instructions.

- `BitShift( T x, int shift )` returns `x` shifted left `shift` bits, or shifted right `-shift` bits if `shift` is negative. This effectively returns `x * 2 ^ shift`.

Add `-Wsign-conversion` to the compiler warning flags, which warns whenever the signedness of an integer is implicitly changed. This can occur, for example, when `uint8_t` (unsigned) or `uint16_t` (unsigned) is implicitly promoted to `int` (signed).  In C/C++ arithmetic expressions, any type smaller than `int` is implicitly promoted to `int`, which can change an 8- or 16-bit unsigned value into a 32-bit signed `int` value. This warning prevents this silent conversion, requiring explicit casts to suppress it.

`unsigned char*` is used instead of `char*` when using pointers to bytes in the Rev functions such as memory instructions. `char*` is still used when it involves calling standard library routines such as `c_str()` which returns `const char*`, or when the pointer is initialized from a `"string literal"`.
