### PR TITLE
Fix Zfa FLI instructions

### DIFF
--- a/include/insns/Zfa.h
+++ b/include/insns/Zfa.h
@@ -60,10 +60,7 @@ class Zfa : public RevExt {
   static bool fminmaxm( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
     T x   = R->GetFP<T>( Inst.rs1 );
     T y   = R->GetFP<T>( Inst.rs2 );
-    T res = MINMAX()( x, y );
-    if( std::isnan( x ) || std::isnan( y ) ) {
-      res = std::numeric_limits<T>::quiet_NaN();
-    }
+    T res = std::isunordered( x, y ) ? std::numeric_limits<T>::quiet_NaN() : MINMAX()( x, y );
     R->SetFP( Inst.rd, res );
     R->AdvancePC( Inst );
     return true;
@@ -163,15 +160,14 @@ class Zfa : public RevExt {
   };
 
   // Macro to generate FLI entries
-#define FLI( index, mnemonic, value )                                                  \
-  ( RevZfaInstDefaults()                                                               \
-      .SetMnemonic( #mnemonic " %rd, " #value )                                        \
-      .SetPredicate( []( uint32_t Inst ) { return DECODE_RS1( Inst ) == ( index ); } ) \
-      .SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ) {                          \
-        R->SetFP( Inst.rd, ( value ) );                                                \
-        R->AdvancePC( Inst );                                                          \
-        return true;                                                                   \
-      } ) )
+#define FLI( index, mnemonic, value )                                                \
+  SetMnemonic( #mnemonic " %rd, " #value )                                           \
+    .SetPredicate( []( uint32_t Inst ) { return DECODE_RS1( Inst ) == ( index ); } ) \
+    .SetImplFunc( []( auto*, auto* R, auto*, auto& Inst ) {                          \
+      R->SetFP( Inst.rd, value );                                                    \
+      R->AdvancePC( Inst );                                                          \
+      return true;                                                                   \
+    } )
 
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   // Single-Precision Instructions
@@ -187,38 +183,38 @@ class Zfa : public RevExt {
   // clang-format off
   std::vector<RevInstEntry> ZfaTable = {
     // Load Immediates
-    FLI(  0, fli.s, -0x1p+0f  ),
-    FLI(  1, fli.s, min       ),
-    FLI(  2, fli.s, 0x1p-16f  ),
-    FLI(  3, fli.s, 0x1p-15f  ),
-    FLI(  4, fli.s, 0x1p-8f   ),
-    FLI(  5, fli.s, 0x1p-7f   ),
-    FLI(  6, fli.s, 0x1p-4f   ),
-    FLI(  7, fli.s, 0x1p-3f   ),
-    FLI(  8, fli.s, 0x1p-2f   ),
-    FLI(  9, fli.s, 0x1.4p-2f ),
-    FLI( 10, fli.s, 0x1.8p-2f ),
-    FLI( 11, fli.s, 0x1.cp-2f ),
-    FLI( 12, fli.s, 0x1p-1f   ),
-    FLI( 13, fli.s, 0x1.4p-1f ),
-    FLI( 14, fli.s, 0x1.8p-1f ),
-    FLI( 15, fli.s, 0x1.cp-1f ),
-    FLI( 16, fli.s, 0x1p+0f   ),
-    FLI( 17, fli.s, 0x1.4p+0f ),
-    FLI( 18, fli.s, 0x1.8p+0f ),
-    FLI( 19, fli.s, 0x1.cp+0f ),
-    FLI( 20, fli.s, 0x1p+1f   ),
-    FLI( 21, fli.s, 0x1.4p+1f ),
-    FLI( 22, fli.s, 0x1.8p+1f ),
-    FLI( 23, fli.s, 0x1p+2f   ),
-    FLI( 24, fli.s, 0x1p+3f   ),
-    FLI( 25, fli.s, 0x1p+4f   ),
-    FLI( 26, fli.s, 0x1p+7f   ),
-    FLI( 27, fli.s, 0x1p+8f   ),
-    FLI( 28, fli.s, 0x1p+15f  ),
-    FLI( 29, fli.s, 0x1p+16f  ),
-    FLI( 30, fli.s, inf       ),
-    FLI( 31, fli.s, nan       ),
+    RevZfaInstDefaults().FLI(  0, fli.s, -0x1p+0f  ),
+    RevZfaInstDefaults().FLI(  1, fli.s, min       ),
+    RevZfaInstDefaults().FLI(  2, fli.s, 0x1p-16f  ),
+    RevZfaInstDefaults().FLI(  3, fli.s, 0x1p-15f  ),
+    RevZfaInstDefaults().FLI(  4, fli.s, 0x1p-8f   ),
+    RevZfaInstDefaults().FLI(  5, fli.s, 0x1p-7f   ),
+    RevZfaInstDefaults().FLI(  6, fli.s, 0x1p-4f   ),
+    RevZfaInstDefaults().FLI(  7, fli.s, 0x1p-3f   ),
+    RevZfaInstDefaults().FLI(  8, fli.s, 0x1p-2f   ),
+    RevZfaInstDefaults().FLI(  9, fli.s, 0x1.4p-2f ),
+    RevZfaInstDefaults().FLI( 10, fli.s, 0x1.8p-2f ),
+    RevZfaInstDefaults().FLI( 11, fli.s, 0x1.cp-2f ),
+    RevZfaInstDefaults().FLI( 12, fli.s, 0x1p-1f   ),
+    RevZfaInstDefaults().FLI( 13, fli.s, 0x1.4p-1f ),
+    RevZfaInstDefaults().FLI( 14, fli.s, 0x1.8p-1f ),
+    RevZfaInstDefaults().FLI( 15, fli.s, 0x1.cp-1f ),
+    RevZfaInstDefaults().FLI( 16, fli.s, 0x1p+0f   ),
+    RevZfaInstDefaults().FLI( 17, fli.s, 0x1.4p+0f ),
+    RevZfaInstDefaults().FLI( 18, fli.s, 0x1.8p+0f ),
+    RevZfaInstDefaults().FLI( 19, fli.s, 0x1.cp+0f ),
+    RevZfaInstDefaults().FLI( 20, fli.s, 0x1p+1f   ),
+    RevZfaInstDefaults().FLI( 21, fli.s, 0x1.4p+1f ),
+    RevZfaInstDefaults().FLI( 22, fli.s, 0x1.8p+1f ),
+    RevZfaInstDefaults().FLI( 23, fli.s, 0x1p+2f   ),
+    RevZfaInstDefaults().FLI( 24, fli.s, 0x1p+3f   ),
+    RevZfaInstDefaults().FLI( 25, fli.s, 0x1p+4f   ),
+    RevZfaInstDefaults().FLI( 26, fli.s, 0x1p+7f   ),
+    RevZfaInstDefaults().FLI( 27, fli.s, 0x1p+8f   ),
+    RevZfaInstDefaults().FLI( 28, fli.s, 0x1p+15f  ),
+    RevZfaInstDefaults().FLI( 29, fli.s, 0x1p+16f  ),
+    RevZfaInstDefaults().FLI( 30, fli.s, inf       ),
+    RevZfaInstDefaults().FLI( 31, fli.s, nan       ),
 
     // FP Minimum and Maximum with NaN returned if any argument is NaN
     RevZfaInstDefaults().SetMnemonic( "fminm.s %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b010 ).SetFunct2or7( 0b0010100 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fminms ),
@@ -254,38 +250,38 @@ class Zfa : public RevExt {
   // clang-format off
   static std::vector<RevInstEntry> ZfaTableD() { return {
       // Load Immediates
-      FLI(  0, fli.d, -0x1p+0  ),
-      FLI(  1, fli.d, min      ),
-      FLI(  2, fli.d, 0x1p-16  ),
-      FLI(  3, fli.d, 0x1p-15  ),
-      FLI(  4, fli.d, 0x1p-8   ),
-      FLI(  5, fli.d, 0x1p-7   ),
-      FLI(  6, fli.d, 0x1p-4   ),
-      FLI(  7, fli.d, 0x1p-3   ),
-      FLI(  8, fli.d, 0x1p-2   ),
-      FLI(  9, fli.d, 0x1.4p-2 ),
-      FLI( 10, fli.d, 0x1.8p-2 ),
-      FLI( 11, fli.d, 0x1.cp-2 ),
-      FLI( 12, fli.d, 0x1p-1   ),
-      FLI( 13, fli.d, 0x1.4p-1 ),
-      FLI( 14, fli.d, 0x1.8p-1 ),
-      FLI( 15, fli.d, 0x1.cp-1 ),
-      FLI( 16, fli.d, 0x1p+0   ),
-      FLI( 17, fli.d, 0x1.4p+0 ),
-      FLI( 18, fli.d, 0x1.8p+0 ),
-      FLI( 19, fli.d, 0x1.cp+0 ),
-      FLI( 20, fli.d, 0x1p+1   ),
-      FLI( 21, fli.d, 0x1.4p+1 ),
-      FLI( 22, fli.d, 0x1.8p+1 ),
-      FLI( 23, fli.d, 0x1p+2   ),
-      FLI( 24, fli.d, 0x1p+3   ),
-      FLI( 25, fli.d, 0x1p+4   ),
-      FLI( 26, fli.d, 0x1p+7   ),
-      FLI( 27, fli.d, 0x1p+8   ),
-      FLI( 28, fli.d, 0x1p+15  ),
-      FLI( 29, fli.d, 0x1p+16  ),
-      FLI( 30, fli.d, inf      ),
-      FLI( 31, fli.d, nan      ),
+       RevZfaDInstDefaults().FLI(  0, fli.d, -0x1p+0  ),
+       RevZfaDInstDefaults().FLI(  1, fli.d, min      ),
+       RevZfaDInstDefaults().FLI(  2, fli.d, 0x1p-16  ),
+       RevZfaDInstDefaults().FLI(  3, fli.d, 0x1p-15  ),
+       RevZfaDInstDefaults().FLI(  4, fli.d, 0x1p-8   ),
+       RevZfaDInstDefaults().FLI(  5, fli.d, 0x1p-7   ),
+       RevZfaDInstDefaults().FLI(  6, fli.d, 0x1p-4   ),
+       RevZfaDInstDefaults().FLI(  7, fli.d, 0x1p-3   ),
+       RevZfaDInstDefaults().FLI(  8, fli.d, 0x1p-2   ),
+       RevZfaDInstDefaults().FLI(  9, fli.d, 0x1.4p-2 ),
+       RevZfaDInstDefaults().FLI( 10, fli.d, 0x1.8p-2 ),
+       RevZfaDInstDefaults().FLI( 11, fli.d, 0x1.cp-2 ),
+       RevZfaDInstDefaults().FLI( 12, fli.d, 0x1p-1   ),
+       RevZfaDInstDefaults().FLI( 13, fli.d, 0x1.4p-1 ),
+       RevZfaDInstDefaults().FLI( 14, fli.d, 0x1.8p-1 ),
+       RevZfaDInstDefaults().FLI( 15, fli.d, 0x1.cp-1 ),
+       RevZfaDInstDefaults().FLI( 16, fli.d, 0x1p+0   ),
+       RevZfaDInstDefaults().FLI( 17, fli.d, 0x1.4p+0 ),
+       RevZfaDInstDefaults().FLI( 18, fli.d, 0x1.8p+0 ),
+       RevZfaDInstDefaults().FLI( 19, fli.d, 0x1.cp+0 ),
+       RevZfaDInstDefaults().FLI( 20, fli.d, 0x1p+1   ),
+       RevZfaDInstDefaults().FLI( 21, fli.d, 0x1.4p+1 ),
+       RevZfaDInstDefaults().FLI( 22, fli.d, 0x1.8p+1 ),
+       RevZfaDInstDefaults().FLI( 23, fli.d, 0x1p+2   ),
+       RevZfaDInstDefaults().FLI( 24, fli.d, 0x1p+3   ),
+       RevZfaDInstDefaults().FLI( 25, fli.d, 0x1p+4   ),
+       RevZfaDInstDefaults().FLI( 26, fli.d, 0x1p+7   ),
+       RevZfaDInstDefaults().FLI( 27, fli.d, 0x1p+8   ),
+       RevZfaDInstDefaults().FLI( 28, fli.d, 0x1p+15  ),
+       RevZfaDInstDefaults().FLI( 29, fli.d, 0x1p+16  ),
+       RevZfaDInstDefaults().FLI( 30, fli.d, inf      ),
+       RevZfaDInstDefaults().FLI( 31, fli.d, nan      ),
 
       // FP Minimum and Maximum with NaN returned if any argument is NaN
       RevZfaDInstDefaults().SetMnemonic( "fminm.d %rd, %rs1, %rs2" ).Setrs1Class( RevRegClass::RegFLOAT ).Setrs2Class( RevRegClass::RegFLOAT ).SetRaiseFPE( true ).SetFunct3( 0b010 ).SetFunct2or7( 0b0010101 ).Setrs2fcvtOp( 0b00000 ).SetImplFunc( fminmd ),

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -77,7 +77,7 @@ bool RevFeature::ParseMachineModel() {
     { "Zmmul",      1, 0,  1, 1, RV_ZMMUL                               },
     { "Zaamo",      2, 1,  2, 2, RV_ZAAMO                               },
     { "Zalrsc",     2, 1,  2, 2, RV_ZALRSC                              },
-    { "Zfa",        1, 0,  1, 1, RV_ZFA | RV_F | RV_ZICSR               }, // Unsupported
+    { "Zfa",        1, 0,  1, 1, RV_ZFA | RV_F | RV_ZICSR               },
     { "Zfh",        1, 0, -1, 0, RV_ZFH | RV_ZFHMIN | RV_F | RV_ZICSR   }, // Unsupported
     { "Zfhmin",     1, 0, -1, 0, RV_ZFHMIN | RV_F | RV_ZICSR            }, // Unsupported
     { "Ztso",       1, 0, -1, 0, RV_ZTSO                                }, // Unsupported


### PR DESCRIPTION
 Fix double-precision FLI instructions which were mixing single- and double-precision instruction formats and expressions.

The double-precision `fli.d` instruction table was decoding `fli.s` instructions as `fli.d` then setting single-precision registers to `double` values, messing up the NaN-boxing logic which applies when setting double-precision registers to `float` values.

Change one of the functions to use `std::isunordered()` instead of testing for NaN separately.

Remove an old comment which said that `Zfa` is not supported.
