### PR TITLE
Simplify rev opts

### DIFF
--- a/common/include/RevCommon.h
+++ b/common/include/RevCommon.h
@@ -44,7 +44,7 @@ constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_enum_v<ENUM>, INT>
   return static_cast<INT>( e );
 }
 
-/// Allow non-narrowing int->int cast with enum_int_cast
+/// Allow non-narrowing integer->integer cast with safe_static_cast
 template<typename INT, typename ENUM, typename = decltype( INT{ std::declval<ENUM>() } )>
 constexpr std::enable_if_t<std::is_integral_v<INT> && std::is_integral_v<ENUM>, INT> safe_static_cast( ENUM e ) {
   return static_cast<INT>( e );

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -52,7 +52,7 @@ class RevOpts {
   bool InitPropertyMap( const std::vector<std::string>& Opts, VEC& map );
 
   template<typename VEC>
-  std::pair<bool, bool> InitPropertyMapCores( const std::vector<std::string>& Opts, VEC& map );
+  bool InitPropertyMapCores( const std::vector<std::string>& Opts, VEC& map );
 
 public:
   /// RevOpts: options constructor

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -60,17 +60,23 @@ public:
   RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity )
     : numCores( NumCores ), numHarts( NumHarts ), verbosity( Verbosity ) {}
 
+  /// RevOpts: Disallow copying and assignment
+  RevOpts( const RevOpts& )            = delete;
+  RevOpts( RevOpts&& )                 = delete;
+  RevOpts& operator=( const RevOpts& ) = delete;
+  RevOpts& operator=( RevOpts&& )      = delete;
+
   /// RevOpts: options destructor
-  ~RevOpts() = default;
+  ~RevOpts()                           = default;
 
   /// RevOpts: retrieve the number of configured cores
-  uint32_t GetNumCores() { return numCores; }
+  uint32_t GetNumCores() const { return numCores; }
 
   /// RevOpts: retrieve the number of configured harts per core
-  uint32_t GetNumHarts() { return numHarts; }
+  uint32_t GetNumHarts() const { return numHarts; }
 
   /// RevOpts: retrieve the verbosity level
-  int GetVerbosity() { return verbosity; }
+  int GetVerbosity() const { return verbosity; }
 
   /// RevOpts: initialize the set of starting addresses
   bool InitStartAddrs( const std::vector<std::string>& StartAddrs );
@@ -108,7 +114,7 @@ public:
   }
 
   /// RevOpts: retrieve the prefetch depth for the target core
-  bool GetPrefetchDepth( uint32_t Core, uint32_t& Depth ) { return GetProperty( Core, prefetchDepth, Depth ); }
+  bool GetPrefetchDepth( uint32_t Core, uint32_t& Depth ) const { return GetProperty( Core, prefetchDepth, Depth ); }
 
   /// RevOpts: set the argv array
   void SetArgs( const SST::Params& params );
@@ -120,7 +126,7 @@ public:
   static void splitStr( std::string s, const char* delim, std::vector<std::string>& v ) {
     char* ptr     = s.data();
     char* saveptr = nullptr;
-    for( v.clear(); auto token = strtok_r( ptr, delim, &saveptr ); ptr = nullptr )
+    for( v.clear(); char* token = strtok_r( ptr, delim, &saveptr ); ptr = nullptr )
       v.push_back( token );
   }
 

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -18,15 +18,31 @@
 #include <cinttypes>
 #include <map>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace SST::RevCPU {
 
 class RevOpts {
+  template<typename VAL>
+  bool GetProperty( uint32_t Core, const std::vector<VAL>& Vec, VAL& Val ) const {
+    if( Core >= Vec.size() )
+      return false;
+
+    Val = Vec[Core];
+    return true;
+  }
+
+  template<typename MAP>
+  bool InitPropertyMap( const std::vector<std::string>& Opts, MAP& map );
+
+  template<typename MAP>
+  std::pair<bool, bool> InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map );
+
 public:
   /// RevOpts: options constructor
-  RevOpts( uint32_t NumCores, uint32_t NumHarts, const int Verbosity );
+  RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity );
 
   /// RevOpts: options destructor
   ~RevOpts() = default;
@@ -59,22 +75,27 @@ public:
   bool InitPrefetchDepth( const std::vector<std::string>& Depths );
 
   /// RevOpts: retrieve the start address for the target core
-  bool GetStartAddr( uint32_t Core, uint64_t& StartAddr );
+  bool GetStartAddr( uint32_t Core, uint64_t& StartAddr ) const { return GetProperty( Core, startAddr, StartAddr ); }
 
   /// RevOpts: retrieve the start symbol for the target core
-  bool GetStartSymbol( uint32_t Core, std::string& Symbol );
+  bool GetStartSymbol( uint32_t Core, std::string& Symbol ) const { return GetProperty( Core, startSym, Symbol ); }
 
   /// RevOpts: retrieve the machine model string for the target core
-  bool GetMachineModel( uint32_t Core, std::string& MachModel );
+  bool GetMachineModel( uint32_t Core, std::string& MachModel ) const { return GetProperty( Core, machine, MachModel ); }
 
   /// RevOpts: retrieve instruction table for the target core
-  bool GetInstTable( uint32_t Core, std::string& Table );
+  bool GetInstTable( uint32_t Core, std::string& Table ) const { return GetProperty( Core, table, Table ); }
 
   /// RevOpts: retrieve the memory cost range for the target core
-  bool GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max );
+  bool GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max ) const {
+    if( Core >= memCosts.size() )
+      return false;
+    std::tie( Min, Max ) = memCosts[Core];
+    return true;
+  }
 
   /// RevOpts: retrieve the prefetch depth for the target core
-  bool GetPrefetchDepth( uint32_t Core, uint32_t& Depth );
+  bool GetPrefetchDepth( uint32_t Core, uint32_t& Depth ) { return GetProperty( Core, prefetchDepth, Depth ); }
 
   /// RevOpts: set the argv array
   void SetArgs( const SST::Params& params );
@@ -91,18 +112,19 @@ public:
   }
 
 private:
-  uint32_t numCores{};   ///< RevOpts: number of initialized cores
-  uint32_t numHarts{};   ///< RevOpts: number of harts per core
-  int      verbosity{};  ///< RevOpts: verbosity level
+  uint32_t const numCores;   ///< RevOpts: number of initialized cores
+  uint32_t const numHarts;   ///< RevOpts: number of harts per core
+  int const      verbosity;  ///< RevOpts: verbosity level
 
-  std::unordered_map<uint32_t, uint64_t>     startAddr{};      ///< RevOpts: map of core id to starting address
-  std::unordered_map<uint32_t, std::string>  startSym{};       ///< RevOpts: map of core id to starting symbol
-  std::unordered_map<uint32_t, std::string>  machine{};        ///< RevOpts: map of core id to machine model
-  std::unordered_map<uint32_t, std::string>  table{};          ///< RevOpts: map of core id to inst table
-  std::unordered_map<uint32_t, uint32_t>     prefetchDepth{};  ///< RevOpts: map of core id to prefretch depth
-  std::vector<std::pair<uint32_t, uint32_t>> memCosts{};       ///< RevOpts: vector of memory cost ranges
-  std::vector<std::string>                   Argv{};           ///< RevOpts: vector of function arguments
-  std::vector<std::string>                   MemDumpRanges{};  ///< RevOpts: vector of function arguments
+  std::vector<uint64_t>    startAddr     = std::vector<uint64_t>( numCores );     ///< RevOpts: core id to starting address
+  std::vector<std::string> startSym      = std::vector<std::string>( numCores );  ///< RevOpts: core id to starting symbol
+  std::vector<std::string> machine       = std::vector<std::string>( numCores );  ///< RevOpts: core id to machine model
+  std::vector<std::string> table         = std::vector<std::string>( numCores );  ///< RevOpts: core id to inst table
+  std::vector<uint32_t>    prefetchDepth = std::vector<uint32_t>( numCores );     ///< RevOpts: core id to prefretch depth
+  std::vector<std::pair<uint32_t, uint32_t>> memCosts =
+    std::vector<std::pair<uint32_t, uint32_t>>( numCores );  ///< RevOpts: core id to memory cost range
+  std::vector<std::string> Argv;                             ///< RevOpts: vector of function arguments
+  std::vector<std::string> MemDumpRanges;                    ///< RevOpts: vector of function arguments
 
 };  // class RevOpts
 

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -18,6 +18,7 @@
 #include <cinttypes>
 #include <map>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -25,24 +26,38 @@
 namespace SST::RevCPU {
 
 class RevOpts {
-  template<typename VAL>
-  bool GetProperty( uint32_t Core, const std::vector<VAL>& Vec, VAL& Val ) const {
-    if( Core >= Vec.size() )
-      return false;
 
-    Val = Vec[Core];
-    return true;
+  // Queries whether type is a std::vector type
+  template<typename T>
+  struct is_vector : std::false_type {};
+
+  template<typename T>
+  struct is_vector<std::vector<T>> : std::true_type {};
+
+  // Return a property by looking up its table
+  // VAL is a universal reference so that either an lvalue reference or an assignable rvalue reference such as std::tie can be used
+  template<typename MAP, typename VAL>
+  bool GetProperty( uint32_t Core, const MAP& Map, VAL&& Val ) const {
+    if constexpr( is_vector<MAP>::value ) {
+      // If MAP is a vector
+      return Core < numCores ? Val = Map[Core], true : false;
+    } else {
+      // If MAP is a map/unordered_map
+      auto it                      = Map.find( Core );
+      return it != Map.end() ? Val = it->second, true : false;
+    }
   }
 
-  template<typename MAP>
-  bool InitPropertyMap( const std::vector<std::string>& Opts, MAP& map );
+  template<typename VEC>
+  bool InitPropertyMap( const std::vector<std::string>& Opts, VEC& map );
 
-  template<typename MAP>
-  std::pair<bool, bool> InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map );
+  template<typename VEC>
+  std::pair<bool, bool> InitPropertyMapCores( const std::vector<std::string>& Opts, VEC& map );
 
 public:
   /// RevOpts: options constructor
-  RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity );
+  RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity )
+    : numCores( NumCores ), numHarts( NumHarts ), verbosity( Verbosity ) {}
 
   /// RevOpts: options destructor
   ~RevOpts() = default;
@@ -88,10 +103,7 @@ public:
 
   /// RevOpts: retrieve the memory cost range for the target core
   bool GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max ) const {
-    if( Core >= memCosts.size() )
-      return false;
-    std::tie( Min, Max ) = memCosts[Core];
-    return true;
+    return GetProperty( Core, memCosts, std::tie( Min, Max ) );
   }
 
   /// RevOpts: retrieve the prefetch depth for the target core
@@ -116,15 +128,25 @@ private:
   uint32_t const numHarts;   ///< RevOpts: number of harts per core
   int const      verbosity;  ///< RevOpts: verbosity level
 
-  std::vector<uint64_t>    startAddr     = std::vector<uint64_t>( numCores );     ///< RevOpts: core id to starting address
-  std::vector<std::string> startSym      = std::vector<std::string>( numCores );  ///< RevOpts: core id to starting symbol
-  std::vector<std::string> machine       = std::vector<std::string>( numCores );  ///< RevOpts: core id to machine model
-  std::vector<std::string> table         = std::vector<std::string>( numCores );  ///< RevOpts: core id to inst table
-  std::vector<uint32_t>    prefetchDepth = std::vector<uint32_t>( numCores );     ///< RevOpts: core id to prefretch depth
-  std::vector<std::pair<uint32_t, uint32_t>> memCosts =
-    std::vector<std::pair<uint32_t, uint32_t>>( numCores );  ///< RevOpts: core id to memory cost range
-  std::vector<std::string> Argv;                             ///< RevOpts: vector of function arguments
-  std::vector<std::string> MemDumpRanges;                    ///< RevOpts: vector of function arguments
+  // init all the standard options
+  // -- startAddr = 0x00000000
+  // -- machine = "G" aka, "IMAFD"
+  // -- table = internal
+  // -- memCosts[core] = 0:10
+  // -- prefetch depth = 16
+  // -- pipeLine = 5 ???
+
+  // clang-format off
+  std::vector<uint64_t>                     startAddr{decltype( startAddr     )( numCores, 0 )};                 ///< RevOpts: starting address
+  std::vector<std::string>                    machine{decltype( machine       )( numCores, "G" )};               ///< RevOpts: machine model
+  std::vector<std::string>                      table{decltype( table         )( numCores, "_REV_INTERNAL_" )};  ///< RevOpts: inst table
+  std::vector<std::pair<uint32_t, uint32_t>> memCosts{decltype( memCosts      )( numCores, {0, 10} )};           ///< RevOpts: memory cost range
+  std::vector<uint32_t>                 prefetchDepth{decltype( prefetchDepth )( numCores, 16 )};                ///< RevOpts: prefretch depth
+  // clang-format on
+
+  std::unordered_map<uint32_t, std::string> startSym;       ///< RevOpts: starting symbol
+  std::vector<std::string>                  Argv;           ///< RevOpts: vector of function arguments
+  std::vector<std::string>                  MemDumpRanges;  ///< RevOpts: vector of function arguments
 
 };  // class RevOpts
 

--- a/include/RevOpts.h
+++ b/include/RevOpts.h
@@ -15,6 +15,7 @@
 #include "SST.h"
 
 // -- Standard Headers
+#include "RevCommon.h"
 #include <cinttypes>
 #include <map>
 #include <string>

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -247,8 +247,7 @@ std::string RevCore::ExtractMnemonic( const RevInstEntry& Entry ) {
   std::string              Tmp = Entry.mnemonic;
   std::vector<std::string> vstr;
   RevOpts::splitStr( Tmp, " ", vstr );
-
-  return vstr[0];
+  return std::move( vstr[0] );
 }
 
 bool RevCore::InitTableMapping() {

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -74,10 +74,10 @@ bool RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& m
       auto parse = [&]( auto val ) {
         if constexpr( std::is_integral_v<decltype( val )> ) {
           auto Val = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
-          for( uint32_t i = 0; i < numCores; i++ )
+          for( size_t i = 0; i < numCores; i++ )
             map[i] = Val;
         } else {
-          for( uint32_t i = 0; i < numCores; i++ )
+          for( size_t i = 0; i < numCores; i++ )
             map[i] = vstr[1];
         }
       };

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -43,8 +43,10 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) 
     auto parse = [&]( auto val ) {
       if constexpr( std::is_integral_v<decltype( val )> ) {
         map[Core] = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
+      } else if constexpr( is_vector<MAP>::value ) {
+        map[Core] = std::move( vstr[1] );
       } else {
-        map[Core] = vstr[1];
+        map.insert_or_assign( Core, std::move( vstr[1] ) );
       }
     };
 

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -44,9 +44,9 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) 
       if constexpr( std::is_integral_v<decltype( val )> ) {
         map[Core] = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
       } else if constexpr( is_vector<MAP>::value ) {
-        map[Core] = make_dependent<MAP, decltype( val )>( std::move( vstr[1] ) );
+        map[Core] = make_dependent<decltype( val )>( std::move( vstr[1] ) );
       } else {
-        map.insert_or_assign( Core, make_dependent<MAP, decltype( val )>( std::move( vstr[1] ) ) );
+        map.insert_or_assign( Core, make_dependent<decltype( val )>( std::move( vstr[1] ) ) );
       }
     };
 

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -12,25 +12,6 @@
 
 namespace SST::RevCPU {
 
-RevOpts::RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity )
-  : numCores( NumCores ), numHarts( NumHarts ), verbosity( Verbosity ) {
-
-  // init all the standard options
-  // -- startAddr = 0x00000000
-  // -- machine = "G" aka, "IMAFD"
-  // -- pipeLine = 5
-  // -- table = internal
-  // -- memCosts[core] = 0:10
-  // -- prefetch depth = 16
-  for( uint32_t i = 0; i < numCores; i++ ) {
-    startAddr[i]     = 0;
-    machine[i]       = "G";
-    table[i]         = "_REV_INTERNAL_";
-    memCosts[i]      = { 0, 10 };
-    prefetchDepth[i] = 16;
-  }
-}
-
 void RevOpts::SetArgs( const SST::Params& params ) {
   static constexpr char delim[] = " \t\n";
 
@@ -45,8 +26,8 @@ void RevOpts::SetArgs( const SST::Params& params ) {
   }
 }
 
-template<typename VEC>
-bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, VEC& map ) {
+template<typename MAP>
+bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) {
   for( auto& s : Opts ) {
     std::vector<std::string> vstr;
 
@@ -59,20 +40,29 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, VEC& map ) 
       return false;
 
     // Store as cast integer if target is integer; otherwise store as string
-    if constexpr( std::is_integral_v<typename VEC::value_type> ) {
-      map[Core] = (typename VEC::value_type) std::stoull( vstr[1], nullptr, 0 );
+    auto parse = [&]( auto val ) {
+      if constexpr( std::is_integral_v<decltype( val )> ) {
+        map[Core] = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
+      } else {
+        map[Core] = vstr[1];
+      }
+    };
+
+    if constexpr( is_vector<MAP>::value ) {
+      parse( typename MAP::value_type{} );
     } else {
-      map[Core] = vstr[1];
+      parse( typename MAP::mapped_type{} );
     }
   }
+
   return true;
 }
 
-template<typename VEC>
-std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, VEC& map ) {
+template<typename MAP>
+std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map ) {
   // check to see if we expand into multiple cores
   if( Opts.size() == 1 ) {
-    std::string              s = Opts[0];
+    auto&                    s = Opts[0];
     std::vector<std::string> vstr;
 
     splitStr( s, ":", vstr );
@@ -80,15 +70,25 @@ std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::stri
       return { true, false };
 
     if( vstr[0] == "CORES" ) {
+
       // set all cores to the value, stored as cast integer or as string
-      if constexpr( std::is_integral_v<typename VEC::value_type> ) {
-        auto Val = (typename VEC::value_type) std::stoull( vstr[1], nullptr, 0 );
-        for( uint32_t i = 0; i < numCores; i++ )
-          map[i] = Val;
+      auto parse = [&]( auto val ) {
+        if constexpr( std::is_integral_v<decltype( val )> ) {
+          auto Val = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
+          for( uint32_t i = 0; i < numCores; i++ )
+            map[i] = Val;
+        } else {
+          for( uint32_t i = 0; i < numCores; i++ )
+            map[i] = vstr[1];
+        }
+      };
+
+      if constexpr( is_vector<MAP>::value ) {
+        parse( typename MAP::value_type{} );
       } else {
-        for( uint32_t i = 0; i < numCores; i++ )
-          map[i] = vstr[1];
+        parse( typename MAP::mapped_type{} );
       }
+
       return { true, true };
     }
   }
@@ -134,7 +134,7 @@ bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
     auto Max  = decltype( memCosts[Core].second )( std::stoull( vstr[2], nullptr, 0 ) );
     if( Core >= numCores || !Min || !Max )
       return false;
-    memCosts[Core] = { Min, Max };
+    memCosts[Core] = std::pair( Min, Max );
   }
   return true;
 }

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -13,7 +13,7 @@
 namespace SST::RevCPU {
 
 void RevOpts::SetArgs( const SST::Params& params ) {
-  static constexpr char delim[] = " \t\n";
+  static constexpr char delim[] = " \t\v\n\r\f";
 
   // If the "args" param does not start with a left bracket, split it up at whitespace
   // Otherwise interpet it as an array
@@ -28,9 +28,9 @@ void RevOpts::SetArgs( const SST::Params& params ) {
 
 template<typename MAP>
 bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) {
-  for( auto& s : Opts ) {
-    std::vector<std::string> vstr;
+  std::vector<std::string> vstr;
 
+  for( auto& s : Opts ) {
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
@@ -62,10 +62,9 @@ template<typename MAP>
 bool RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map ) {
   // check to see if we expand into multiple cores
   if( Opts.size() == 1 ) {
-    auto&                    s = Opts[0];
     std::vector<std::string> vstr;
 
-    splitStr( s, ":", vstr );
+    splitStr( Opts[0], ":", vstr );
     if( vstr.size() != 2 )
       return false;
 

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -44,9 +44,9 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) 
       if constexpr( std::is_integral_v<decltype( val )> ) {
         map[Core] = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
       } else if constexpr( is_vector<MAP>::value ) {
-        map[Core] = make_dependent<MAP>( std::move( vstr[1] ) );
+        map[Core] = make_dependent<MAP, decltype( val )>( std::move( vstr[1] ) );
       } else {
-        map.insert_or_assign( Core, make_dependent<MAP>( std::move( vstr[1] ) ) );
+        map.insert_or_assign( Core, make_dependent<MAP, decltype( val )>( std::move( vstr[1] ) ) );
       }
     };
 

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -12,12 +12,8 @@
 
 namespace SST::RevCPU {
 
-RevOpts::RevOpts( uint32_t NumCores, uint32_t NumHarts, const int Verbosity )
+RevOpts::RevOpts( uint32_t NumCores, uint32_t NumHarts, int Verbosity )
   : numCores( NumCores ), numHarts( NumHarts ), verbosity( Verbosity ) {
-
-  std::pair<uint32_t, uint32_t> InitialPair;
-  InitialPair.first  = 0;
-  InitialPair.second = 10;
 
   // init all the standard options
   // -- startAddr = 0x00000000
@@ -27,11 +23,11 @@ RevOpts::RevOpts( uint32_t NumCores, uint32_t NumHarts, const int Verbosity )
   // -- memCosts[core] = 0:10
   // -- prefetch depth = 16
   for( uint32_t i = 0; i < numCores; i++ ) {
-    startAddr.insert( std::pair<uint32_t, uint64_t>( i, 0 ) );
-    machine.insert( std::pair<uint32_t, std::string>( i, "G" ) );
-    table.insert( std::pair<uint32_t, std::string>( i, "_REV_INTERNAL_" ) );
-    memCosts.push_back( InitialPair );
-    prefetchDepth.insert( std::pair<uint32_t, uint32_t>( i, 16 ) );
+    startAddr[i]     = 0;
+    machine[i]       = "G";
+    table[i]         = "_REV_INTERNAL_";
+    memCosts[i]      = { 0, 10 };
+    prefetchDepth[i] = 16;
   }
 }
 
@@ -49,226 +45,98 @@ void RevOpts::SetArgs( const SST::Params& params ) {
   }
 }
 
-bool RevOpts::InitPrefetchDepth( const std::vector<std::string>& Depths ) {
-  std::vector<std::string> vstr;
-  for( uint32_t i = 0; i < Depths.size(); i++ ) {
-    std::string s = Depths[i];
+template<typename VEC>
+bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, VEC& map ) {
+  for( auto& s : Opts ) {
+    std::vector<std::string> vstr;
+
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
       return false;
 
-    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
-    if( Core > numCores )
+    auto Core = std::stoull( vstr[0], nullptr, 0 );
+    if( Core >= numCores )
       return false;
 
-    std::string::size_type sz          = 0;
-    uint32_t               Depth       = std::stoul( vstr[1], &sz, 0 );
-
-    prefetchDepth.find( Core )->second = Depth;
-    vstr.clear();
+    // Store as cast integer if target is integer; otherwise store as string
+    if constexpr( std::is_integral_v<typename VEC::value_type> ) {
+      map[Core] = (typename VEC::value_type) std::stoull( vstr[1], nullptr, 0 );
+    } else {
+      map[Core] = vstr[1];
+    }
   }
   return true;
 }
 
+template<typename VEC>
+std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, VEC& map ) {
+  // check to see if we expand into multiple cores
+  if( Opts.size() == 1 ) {
+    std::string              s = Opts[0];
+    std::vector<std::string> vstr;
+
+    splitStr( s, ":", vstr );
+    if( vstr.size() != 2 )
+      return { true, false };
+
+    if( vstr[0] == "CORES" ) {
+      // set all cores to the value, stored as cast integer or as string
+      if constexpr( std::is_integral_v<typename VEC::value_type> ) {
+        auto Val = (typename VEC::value_type) std::stoull( vstr[1], nullptr, 0 );
+        for( uint32_t i = 0; i < numCores; i++ )
+          map[i] = Val;
+      } else {
+        for( uint32_t i = 0; i < numCores; i++ )
+          map[i] = vstr[1];
+      }
+      return { true, true };
+    }
+  }
+  return { false, false };
+}
+
+/// RevOpts: initialize the set of starting addresses
 bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ) {
-  std::vector<std::string> vstr;
-
-  // check to see if we expand into multiple cores
-  if( StartAddrs.size() == 1 ) {
-    std::string s = StartAddrs[0];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    if( vstr[0] == "CORES" ) {
-      // set all cores to the target machine model
-      std::string::size_type sz   = 0;
-      uint64_t               Addr = std::stoull( vstr[1], &sz, 0 );
-      for( uint32_t i = 0; i < numCores; i++ ) {
-        startAddr.find( i )->second = Addr;
-      }
-      return true;
-    }
-  }
-
-  for( uint32_t i = 0; i < StartAddrs.size(); i++ ) {
-    std::string s = StartAddrs[i];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
-    if( Core > numCores )
-      return false;
-
-    std::string::size_type sz      = 0;
-    uint64_t               Addr    = std::stoull( vstr[1], &sz, 0 );
-
-    startAddr.find( Core )->second = Addr;
-    vstr.clear();
-  }
-  return true;
+  auto [ret, retval] = InitPropertyMapCores( StartAddrs, startAddr );
+  return ret ? retval : InitPropertyMap( StartAddrs, startAddr );
 }
 
+/// RevOpts: initialize the set of potential starting symbols
 bool RevOpts::InitStartSymbols( const std::vector<std::string>& StartSymbols ) {
-  std::vector<std::string> vstr;
-  for( uint32_t i = 0; i < StartSymbols.size(); i++ ) {
-    std::string s = StartSymbols[i];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
-    if( Core > numCores )
-      return false;
-
-    startSym.insert( std::pair<uint32_t, std::string>( Core, vstr[1] ) );
-    vstr.clear();
-  }
-  return true;
+  return InitPropertyMap( StartSymbols, startSym );
 }
 
+/// RevOpts: initialize the set of machine models
 bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
-  std::vector<std::string> vstr;
-
-  // check to see if we expand into multiple cores
-  if( Machines.size() == 1 ) {
-    std::string s = Machines[0];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    if( vstr[0] == "CORES" ) {
-      // set all cores to the target machine model
-      for( uint32_t i = 0; i < numCores; i++ ) {
-        machine.at( i ) = vstr[1];
-      }
-      return true;
-    }
-  }
-
-  // parse individual core configs
-  for( uint32_t i = 0; i < Machines.size(); i++ ) {
-    std::string s = Machines[i];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
-    if( Core > numCores )
-      return false;
-
-    machine.at( Core ) = vstr[1];
-    vstr.clear();
-  }
-  return true;
+  auto [ret, retval] = InitPropertyMapCores( Machines, machine );
+  return ret ? retval : InitPropertyMap( Machines, machine );
 }
 
+/// RevOpts: initalize the set of instruction tables
 bool RevOpts::InitInstTables( const std::vector<std::string>& InstTables ) {
-  std::vector<std::string> vstr;
-  for( uint32_t i = 0; i < InstTables.size(); i++ ) {
-    std::string s = InstTables[i];
-    splitStr( s, ":", vstr );
-    if( vstr.size() != 2 )
-      return false;
-
-    uint32_t Core = std::stoul( vstr[0], nullptr, 0 );
-    if( Core > numCores )
-      return false;
-
-    table.at( Core ) = vstr[1];
-    vstr.clear();
-  }
-  return true;
+  return InitPropertyMap( InstTables, table );
 }
 
-bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
-  std::vector<std::string> vstr;
+/// RevOpts: initialize the prefetch depths
+bool RevOpts::InitPrefetchDepth( const std::vector<std::string>& Depths ) {
+  return InitPropertyMap( Depths, prefetchDepth );
+}
 
-  for( uint32_t i = 0; i < MemCosts.size(); i++ ) {
-    std::string s = MemCosts[i];
+/// RevOpts: initialize the memory latency cost tables
+bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
+  for( auto& s : MemCosts ) {
+    std::vector<std::string> vstr;
     splitStr( s, ":", vstr );
     if( vstr.size() != 3 )
       return false;
-
-    uint32_t Core         = std::stoul( vstr[0], nullptr, 0 );
-    uint32_t Min          = std::stoul( vstr[1], nullptr, 0 );
-    uint32_t Max          = std::stoul( vstr[2], nullptr, 0 );
-    memCosts[Core].first  = Min;
-    memCosts[Core].second = Max;
-    if( ( Min == 0 ) || ( Max == 0 ) ) {
+    auto Core = std::stoull( vstr[0], nullptr, 0 );
+    auto Min  = decltype( memCosts[Core].first )( std::stoull( vstr[1], nullptr, 0 ) );
+    auto Max  = decltype( memCosts[Core].second )( std::stoull( vstr[2], nullptr, 0 ) );
+    if( Core >= numCores || !Min || !Max )
       return false;
-    }
-    vstr.clear();
+    memCosts[Core] = { Min, Max };
   }
-
   return true;
 }
-
-bool RevOpts::GetPrefetchDepth( uint32_t Core, uint32_t& Depth ) {
-  if( Core > numCores )
-    return false;
-
-  if( prefetchDepth.find( Core ) == prefetchDepth.end() )
-    return false;
-
-  Depth = prefetchDepth.at( Core );
-  return true;
-}
-
-bool RevOpts::GetStartAddr( uint32_t Core, uint64_t& StartAddr ) {
-  if( Core > numCores )
-    return false;
-
-  if( startAddr.find( Core ) == startAddr.end() )
-    return false;
-
-  StartAddr = startAddr.at( Core );
-  return true;
-}
-
-bool RevOpts::GetStartSymbol( uint32_t Core, std::string& Symbol ) {
-  if( Core > numCores )
-    return false;
-
-  if( startSym.find( Core ) == startSym.end() )
-    return false;
-
-  Symbol = startSym.at( Core );
-  return true;
-}
-
-bool RevOpts::GetMachineModel( uint32_t Core, std::string& MachModel ) {
-  if( Core > numCores )
-    return false;
-
-  MachModel = machine.at( Core );
-  return true;
-}
-
-bool RevOpts::GetInstTable( uint32_t Core, std::string& Table ) {
-  if( Core > numCores )
-    return false;
-
-  Table = table.at( Core );
-  return true;
-}
-
-bool RevOpts::GetMemCost( uint32_t Core, uint32_t& Min, uint32_t& Max ) {
-  if( Core > numCores )
-    return false;
-
-  Min = memCosts[Core].first;
-  Max = memCosts[Core].second;
-
-  return true;
-}
-
-// bool RevOpts::GetMemDumpRanges() {
-
-// return true;
-// }
 
 }  // namespace SST::RevCPU
-
-// EOF

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -59,7 +59,7 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) 
 }
 
 template<typename MAP>
-std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map ) {
+bool RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& map ) {
   // check to see if we expand into multiple cores
   if( Opts.size() == 1 ) {
     auto&                    s = Opts[0];
@@ -67,7 +67,7 @@ std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::stri
 
     splitStr( s, ":", vstr );
     if( vstr.size() != 2 )
-      return { true, false };
+      return false;
 
     if( vstr[0] == "CORES" ) {
 
@@ -89,16 +89,15 @@ std::pair<bool, bool> RevOpts::InitPropertyMapCores( const std::vector<std::stri
         parse( typename MAP::mapped_type{} );
       }
 
-      return { true, true };
+      return true;
     }
   }
-  return { false, false };
+  return InitPropertyMap( Opts, map );
 }
 
 /// RevOpts: initialize the set of starting addresses
 bool RevOpts::InitStartAddrs( const std::vector<std::string>& StartAddrs ) {
-  auto [ret, retval] = InitPropertyMapCores( StartAddrs, startAddr );
-  return ret ? retval : InitPropertyMap( StartAddrs, startAddr );
+  return InitPropertyMapCores( StartAddrs, startAddr );
 }
 
 /// RevOpts: initialize the set of potential starting symbols
@@ -108,8 +107,7 @@ bool RevOpts::InitStartSymbols( const std::vector<std::string>& StartSymbols ) {
 
 /// RevOpts: initialize the set of machine models
 bool RevOpts::InitMachineModels( const std::vector<std::string>& Machines ) {
-  auto [ret, retval] = InitPropertyMapCores( Machines, machine );
-  return ret ? retval : InitPropertyMap( Machines, machine );
+  return InitPropertyMapCores( Machines, machine );
 }
 
 /// RevOpts: initalize the set of instruction tables

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -123,8 +123,8 @@ bool RevOpts::InitPrefetchDepth( const std::vector<std::string>& Depths ) {
 
 /// RevOpts: initialize the memory latency cost tables
 bool RevOpts::InitMemCosts( const std::vector<std::string>& MemCosts ) {
+  std::vector<std::string> vstr;
   for( auto& s : MemCosts ) {
-    std::vector<std::string> vstr;
     splitStr( s, ":", vstr );
     if( vstr.size() != 3 )
       return false;

--- a/src/RevOpts.cc
+++ b/src/RevOpts.cc
@@ -44,9 +44,9 @@ bool RevOpts::InitPropertyMap( const std::vector<std::string>& Opts, MAP& map ) 
       if constexpr( std::is_integral_v<decltype( val )> ) {
         map[Core] = decltype( val )( std::stoull( vstr[1], nullptr, 0 ) );
       } else if constexpr( is_vector<MAP>::value ) {
-        map[Core] = std::move( vstr[1] );
+        map[Core] = make_dependent<MAP>( std::move( vstr[1] ) );
       } else {
-        map.insert_or_assign( Core, std::move( vstr[1] ) );
+        map.insert_or_assign( Core, make_dependent<MAP>( std::move( vstr[1] ) ) );
       }
     };
 
@@ -80,7 +80,7 @@ bool RevOpts::InitPropertyMapCores( const std::vector<std::string>& Opts, MAP& m
             map[i] = Val;
         } else {
           for( size_t i = 0; i < numCores; i++ )
-            map[i] = vstr[1];
+            map[i] = make_dependent<decltype( val )>( vstr[1] );
         }
       };
 

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -1,7 +1,7 @@
 //
 // _RevTracer_cc_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -200,7 +200,7 @@ void RevTracer::Render( size_t cycle ) {
   // memory completions
   if( completionRecs.size() > 0 ) {
     if( OutputOK() ) {
-      for( auto& r : completionRecs ) {
+      for( const auto& r : completionRecs ) {
         std::string       data_str = fmt_data( r.len, r.data );
         std::stringstream s;
         s << data_str << "<-[0x" << std::hex << r.addr << "," << std::dec << r.len << "] ";
@@ -296,7 +296,7 @@ std::string RevTracer::RenderExec( const std::string& fallbackMnemonic ) {
   bool squashNextSetX = false;
 
   std::stringstream ss_rw;
-  for( TraceRec_t& r : traceRecs ) {
+  for( const TraceRec_t& r : traceRecs ) {
     switch( r.key ) {
     case RegRead:
       // a:reg b:data

--- a/src/RevTracer.cc
+++ b/src/RevTracer.cc
@@ -200,7 +200,7 @@ void RevTracer::Render( size_t cycle ) {
   // memory completions
   if( completionRecs.size() > 0 ) {
     if( OutputOK() ) {
-      for( auto r : completionRecs ) {
+      for( auto& r : completionRecs ) {
         std::string       data_str = fmt_data( r.len, r.data );
         std::stringstream s;
         s << data_str << "<-[0x" << std::hex << r.addr << "," << std::dec << r.len << "] ";
@@ -296,7 +296,7 @@ std::string RevTracer::RenderExec( const std::string& fallbackMnemonic ) {
   bool squashNextSetX = false;
 
   std::stringstream ss_rw;
-  for( TraceRec_t r : traceRecs ) {
+  for( TraceRec_t& r : traceRecs ) {
     switch( r.key ) {
     case RegRead:
       // a:reg b:data


### PR DESCRIPTION
This change removes duplicate code in `RevOpts.h` and `RevOpts.cc` by templatizing the functions.

- The mappings are simplified to be `std::vector` instead of `std::unordered_map`, since the indices are integers and we know `numCores` in advance
- However, `startSym` must be a map rather than a vector of initialized elements, because of how it is constructed piecemeal
- Therefore the code has been made general, with templates, `if constexpr` and generic lambdas, to handle any `std::vector`, `std::unordered_map`, or `std::map`.
- The `std::vector` mapping members have default initializers which are based on the value of `numCores`, which is already initialized before them because it's declared before them. This initializes them the way they were initialized in a loop in the `RevOpts` constructor before.
- `numCores`, `numHarts` and `verbosity` have been marked as `const` members, so that failure to initialize them in the constructor is an error, and because they never change after construction
- A new `GetProperty()` template function returns the `Core -> Val` mappings. For `std::vector` it returns `true` iff `Core < numCores`, and for `std::unordered_map` it returns `true` iff a mapping entry for `Core` exists.
- It also is able to accept `std::tie()` as an assignable rvalue-reference argument for its destination, in order to unpack a pair or tuple into a set of destinations. This is how `GetMemCost()` extracts both the `Min` and `Max` values from a vector of pairs, by simply passing `std::tie( Min, Max )` to ` GetProperty()`.
- A new `InitPropertyMap()` template function parses the options, setting one for each `Core:Value` pair. It will work for both vector and map containers, using `templates`, `if constexpr`, and `lambdas` to make the code compact . 
- A new `InitPropertyMapCores()` template function allows an optional `CORES:value` and broadcasts the value to all cores. If it does not detect `CORES:value`, it falls back on `InitPropertyMap()` which requires per-element values.
- Instead of calling `map.insert(std::pair<type,type>(i, value))` in a loop to initialize the mappings, default member initialization is used to initialize the vectors with `numCores` copies of a value.
- Some mappings go from `Core` to an integer value, while others go from `Core` to a string. With `if constexpr()` both cases can be handled with an `if` which is resolved in the template at compile-time and whose `false` case is ignored so it cannot produce errors
- Some mappings are handed with `std::vector` while others are handled with `std::unordered_map`. With `if constexpr()` both cases can be similarly handled. To prevent source code explosion, generic lambdas are used to handle multiple cases with small code.
- The old code had an off-by-one error. It was only comparing `Core > numCores`, potentially allowing `Core == numCores` which is outside of the range of `[0, numCores-1]`. 
- The old code used the unsafe `map.find( Core )->second = value` which could crash if the key was not already in the map. Because all values were initialized with defaults, it `map.find( Core )` never returned `map.end()` which is not dereferenceable. I've replaced it with the simpler syntax `map[ Core] = value` which works for both `std::vector` and `std::unordered_map` and in the latter case, creates a new entry if one doesn't already exist.
- Because map keys and values might have different types, I've used explicit casting based on the underlying `decltype`s when calling `std::stoull` to avoid potential warnings. This way the declaration of the map variables is the only place where the underlying types need to be declared.