### PR TITLE
Compress RevFlag so that atomic operations take fewer bits

### DIFF
--- a/include/insns/Zaamo.h
+++ b/include/insns/Zaamo.h
@@ -1,7 +1,7 @@
 //
 // _Zaamo_h_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -24,10 +24,10 @@ class Zaamo : public RevExt {
     RevFlag flags{ F_AMO };
 
     if( Inst.aq ) {
-      flags = RevFlag{ uint32_t( flags ) | uint32_t( RevFlag::F_AQ ) };
+      RevFlagSet( flags, RevFlag::F_AQ );
     }
     if( Inst.rl ) {
-      flags = RevFlag{ uint32_t( flags ) | uint32_t( RevFlag::F_RL ) };
+      RevFlagSet( flags, RevFlag::F_RL );
     }
 
     if( !F->IsRV64() ) {


### PR DESCRIPTION
Since atomic instruction operations are mutually exclusive, change their `RevFlag` flags to use consecutive integers instead of consecutive powers of 2, so that fewer bits are used in `RevFlag`. They are still ORed with other `RevFlag` values, but now take up only 4 bits instead of 9.