### PR TITLE
RVV compile option to enable decoding vector instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # RevCPU Top-Level CMake
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 # See LICENSE in the top level directory for licensing details
@@ -72,6 +72,13 @@ if(REV_TRACER)
 else()
   # requires cmake 3.12
   add_compile_definitions(NO_REV_TRACER)
+endif()
+
+# Vector decoding
+option(RVV "Enable vector decoding (requires r2v2 coprocessor)" OFF)
+if (RVV)
+  message(RVV=ON)
+  add_compile_definitions("RVV")
 endif()
 
 # Compiler Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,6 @@ else()
   add_compile_definitions(NO_REV_TRACER)
 endif()
 
-# Vector decoding
-option(RVV "Enable vector decoding (requires r2v2 coprocessor)" OFF)
-if (RVV)
-  message(RVV=ON)
-  add_compile_definitions("RVV")
-endif()
-
 # Compiler Options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(FP_MODE_FLAG "-ffp-model=strict -frounding-math -ftrapping-math")

--- a/include/AllRevInstTables.h
+++ b/include/AllRevInstTables.h
@@ -1,7 +1,7 @@
 //
 // _RevInstTables_h_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -28,9 +28,6 @@
 #include "insns/RV64I.h"
 #include "insns/RV64M.h"
 #include "insns/RV64P.h"
-#ifdef REVVEC
-#include "insns/RVVec.h"
-#endif
 #include "insns/Zaamo.h"
 #include "insns/Zalrsc.h"
 #include "insns/Zfa.h"

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -1,7 +1,7 @@
 //
 // _RevFeature_cc_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -68,7 +68,11 @@ bool RevFeature::ParseMachineModel() {
     { "C",          2, 0,  2, 2, RV_C                                   },
     { "B",          1, 0, -1, 0, RV_B                                   }, // Unsupported
     { "P",          0, 2, -1, 0, RV_P                                   }, // Unsupported
+#ifdef RVV
+    { "V",          1, 0,  1, 1, RV_V | RV_D | RV_F | RV_ZICSR          },
+#else
     { "V",          1, 0, -1, 0, RV_V | RV_D | RV_F | RV_ZICSR          },
+#endif
     { "H",          1, 0, -1, 0, RV_H                                   }, // Unsupported
     { "Zicbom",     1, 0,  1, 1, RV_ZICBOM                              },
     { "Zicntr",     2, 0,  2, 2, RV_ZICNTR | RV_ZICSR                   },

--- a/src/RevFeature.cc
+++ b/src/RevFeature.cc
@@ -68,11 +68,7 @@ bool RevFeature::ParseMachineModel() {
     { "C",          2, 0,  2, 2, RV_C                                   },
     { "B",          1, 0, -1, 0, RV_B                                   }, // Unsupported
     { "P",          0, 2, -1, 0, RV_P                                   }, // Unsupported
-#ifdef RVV
     { "V",          1, 0,  1, 1, RV_V | RV_D | RV_F | RV_ZICSR          },
-#else
-    { "V",          1, 0, -1, 0, RV_V | RV_D | RV_F | RV_ZICSR          },
-#endif
     { "H",          1, 0, -1, 0, RV_H                                   }, // Unsupported
     { "Zicbom",     1, 0,  1, 1, RV_ZICBOM                              },
     { "Zicntr",     2, 0,  2, 2, RV_ZICNTR | RV_ZICSR                   },


### PR DESCRIPTION
This PR adds a compile option, RVV, to allow REV to be built to support the vector coprocessor. This PR is required for a forthcoming PR in the R2V2 repository that decouples that design from the REV source tree.
