### PR TITLE
Adds new CI scripts for updated test system

### DIFF
--- a/scripts/slurm/build-ci-gcc13.2.0-sst13.1.0.sh
+++ b/scripts/slurm/build-ci-gcc13.2.0-sst13.1.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-gcc13.2.0-sst13.1.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/13.1.0
+export CC=gcc
+export CXX=g++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/build-ci-gcc13.2.0-sst14.0.0.sh
+++ b/scripts/slurm/build-ci-gcc13.2.0-sst14.0.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-gcc13.2.0-sst14.0.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/14.0.0
+export CC=gcc
+export CXX=g++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/build-ci-gcc13.2.0-sst14.1.0.sh
+++ b/scripts/slurm/build-ci-gcc13.2.0-sst14.1.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-gcc13.2.0-sst14.1.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/14.1.0
+export CC=gcc
+export CXX=g++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/build-ci-llvm18.1.3-sst13.1.0.sh
+++ b/scripts/slurm/build-ci-llvm18.1.3-sst13.1.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-llvm18.1.3-sst13.1.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/13.1.0 llvm/18.1.3-gcc-13.2.0-vrx5w3g
+export CC=clang
+export CXX=clang++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/build-ci-llvm18.1.3-sst14.0.0.sh
+++ b/scripts/slurm/build-ci-llvm18.1.3-sst14.0.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-llvm18.1.3-sst14.0.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/14.0.0 llvm/18.1.3-gcc-13.2.0-vrx5w3g
+export CC=clang
+export CXX=clang++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/build-ci-llvm18.1.3-sst14.1.0.sh
+++ b/scripts/slurm/build-ci-llvm18.1.3-sst14.1.0.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# scripts/slurm/build-ci-llvm18.1.3-sst14.1.0.sh
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# This file is a part of the Rev package.  For license
+# information, see the LICENSE file in the top level directory of
+# this distribution.
+#
+#
+# Sample SLURM batch script
+#
+# Usage: sbatch -N1 build.sh
+#
+# This command requests 1 nodes for execution
+#
+
+#-- Stage 1: load the necessary modules
+source /etc/qlustar/common/skel/bash/bashrc
+module load riscv/14.2.0 sst/14.1.0 llvm/18.1.3-gcc-13.2.0-vrx5w3g
+export CC=clang
+export CXX=clang++
+export RVCC=riscv64-unknown-elf-gcc
+
+exec >> "rev.jenkins.${SLURM_JOB_ID}.out" 2>&1
+sst --version
+sst-info revcpu
+
+#-- Stage 2: setup the build directories
+mkdir -p build
+cd build || exit
+rm -Rf ./*
+
+#-- Stage 3: initiate the build
+cmake -DCMAKE_BUILD_TYPE=Debug -DRVCC=${RVCC} ../
+make clean
+make uninstall
+make -j
+#make install
+
+#-- Stage 4: test everything
+make test
+
+#-- EOF

--- a/scripts/slurm/exec_build.sh
+++ b/scripts/slurm/exec_build.sh
@@ -2,7 +2,7 @@
 #
 # scripts/slurm/exec_build.sh
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -14,7 +14,7 @@ USER=$(id -un)
 
 #-- execute the job
 SCRIPT=$1
-SLURM_ID=$(sbatch -N1 --export=ALL "$SCRIPT" | awk '{print $4}')
+SLURM_ID=$(sbatch -N1 --exclusive --export=ALL "$SCRIPT" | awk '{print $4}')
 
 #-- wait for completion
 COMPLETE=$(squeue -u "$USER" | grep "${SLURM_ID}")


### PR DESCRIPTION
Note: squashed 8 commits into a single commit + PR in order to avoid poisoning the git history.  This only **ADDS** new scripts, it does not remove the current set of scripts.  New scripts verified to be functional on `nosferatu`

adding llvm 18.1.3 ci scripts
increasing node-level test resource limits
forcing ntasks to 56
fixing test harness script line
reducing parallelism
back to sequential execution
reverting to sequential testing