### PR TITLE
fix conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined -Werror ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wmissing-noreturn -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wconversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined -Werror ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS} ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall ${REVCPU_COMPILER_MACROS}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall ${REVCPU_COMPILER_MACROS}")
 

--- a/src/RevLoader.cc
+++ b/src/RevLoader.cc
@@ -496,7 +496,7 @@ bool RevLoader::LoadProgramArgs( const std::string& exe, const std::vector<std::
   ArgArraySize            = ( ( ArgArraySize - 1 ) | XLEN{ 15 } ) + 1;
 
   // OldStackTop is the current StackTop rounded down to a multiple of 16 bytes
-  const XLEN OldStackTop  = mem->GetStackTop() & ~XLEN{ 15 };
+  const XLEN OldStackTop  = XLEN( mem->GetStackTop() ) & ~XLEN{ 15 };
 
   // Allocate ArgArraySize elements at ArgArrayBase
   // Set the new StackTop to ArgArraySize bytes below OldStackTop


### PR DESCRIPTION
This is a one-liner fix for a conversion error which did not show up in earlier testing.

If you see errors like this again, it is probably due to compiler differences (different compiler, different compiler version, different host OS, different optimization level, etc.). My goal is to get zero errors like this.

These errors are trivial and are not showstoppers. They just indicate truncating conversions which need to be made explicit rather than implicit. Compilers raise these warnings differently depending on version and sometimes even optimization. There is no standard on which warnings are required, so every compiler behaves slightly differently.

