### PR TITLE
remove stray characters generated by emacs xterm-extra-capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.so
-77;30704;0c*.dylib
+*.dylib
 *.exe
 *.csv
 .cache/clangd/index

--- a/test/isa/fcvt_w.c
+++ b/test/isa/fcvt_w.c
@@ -1,9 +1,9 @@
 /*
-77;30700;0c * fcvt_w.c
+ * fcvt_w.c
  *
  * RISC-V ISA: RV32I
  *
- * Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+ * Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
  * All Rights Reserved
  * contact@tactcomplabs.com
  *


### PR DESCRIPTION
Emacs `xterm-extra-capabilities` sometimes causes stray characters to creep into editor buffers on startup if keys are typed before `emacs` starts.

This can be avoided by adding `(setq xterm-extra-capabilities nil)` in `~/.emacs`.
