### PR TITLE
Rev flag

### DIFF
--- a/include/RevCoProc.h
+++ b/include/RevCoProc.h
@@ -1,7 +1,7 @@
 //
 // _RevCoProc_h_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -12,15 +12,11 @@
 #define _SST_REVCPU_REVCOPROC_H_
 
 // -- C++ Headers
-#include <algorithm>
-#include <ctime>
-#include <list>
+#include <functional>
 #include <queue>
-#include <random>
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 // -- SST Headers

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -99,6 +99,11 @@ constexpr RevFlag RevFlagResp( RevFlag flag ) {
   return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RESP ) };
 }
 
+// RevFlag: determine if the request is cache-able
+constexpr bool isCacheable( RevFlag flag ) {
+  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_NONCACHEABLE ) ) == 0;
+}
+
 }  // namespace SST::RevCPU
 
 #endif  // _SST_REVFLAG_H_

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -50,16 +50,14 @@ enum class RevFlag : flags_t {
   F_FORZAFADD          = 1u << 27,  /// XForza: AMO FADD
   F_FORZAFSUB          = 2u << 27,  /// XForza: AMO FSUB
   F_FORZAFSUBR         = 3u << 27,  /// XForza: AMO FSUBR
-  F_FORZAFMIN          = 3u << 27,  /// XForza: AMO FSUBR
-  F_FORZAFMAX          = 4u << 27,  /// XForza: AMO FSUBR
-  F_FORZA_ATOMIC_FLOAT = F_FORZAFADD | F_FORZAFSUB | F_FORZAFSUBR | F_FORZAFMIN | F_FORZAFMAX,
+  F_FORZA_ATOMIC_FLOAT = F_FORZAFADD | F_FORZAFSUB | F_FORZAFSUBR,
 
   F_ATOMIC = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP | F_FORZASUB |
              F_FORZATHRS | F_FORZA_ATOMIC_FLOAT,
 
-  F_FORZANN = 1u << 30,  /// XForza: AMO RETURN NN
-  F_FORZAON = 2u << 30,  /// XForza: AMO RETURN ON
-  F_FORZANO = 3u << 30,  /// XForza: AMO RETURN NO
+  F_FORZANN = 1u << 29,  /// XForza: AMO RETURN NN
+  F_FORZAON = 2u << 29,  /// XForza: AMO RETURN ON
+  F_FORZANO = 3u << 29,  /// XForza: AMO RETURN NO
   F_RETURN  = F_FORZANN | F_FORZAON | F_FORZANO,
 };
 

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -19,12 +19,12 @@
 
 namespace SST::RevCPU {
 
-using namespace SST::Interfaces;
-
 // ----------------------------------------
 // Extended StandardMem::Request::Flag enums
 // ----------------------------------------
-enum class RevFlag : uint32_t {
+using flags_t = StandardMem::Request::flags_t;
+
+enum class RevFlag : flags_t {
   F_NONE               = 0,        /// no special operation
   F_NONCACHEABLE       = 1u << 1,  /// non cacheable
 
@@ -66,42 +66,39 @@ enum class RevFlag : uint32_t {
   F_RETURN  = F_FORZANN | F_FORZAON | F_FORZANO,
 };
 
-// Ensure RevFlag is same underlying type as StandardMem::Request::flags_t
-static_assert( std::is_same_v<StandardMem::Request::flags_t, std::underlying_type_t<RevFlag>> );
-
 /// RevFlag: determine if the request has certain flags set
 constexpr bool RevFlagHas( RevFlag flag, RevFlag has ) {
-  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( has ) ) == safe_static_cast<uint32_t>( has );
+  return ( safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( has ) ) == safe_static_cast<flags_t>( has );
 }
 
 /// RevFlag: set certain flags
 constexpr void RevFlagSet( RevFlag& flag, RevFlag set ) {
-  flag = RevFlag{ safe_static_cast<uint32_t>( flag ) | safe_static_cast<uint32_t>( set ) };
+  flag = RevFlag{ safe_static_cast<flags_t>( flag ) | safe_static_cast<flags_t>( set ) };
 }
 
 /// RevFlag: determine if the request is an AMO, and if so, return the operation; otherwise return 0
 constexpr RevFlag RevFlagAtomic( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_ATOMIC ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_ATOMIC ) };
 }
 
 /// RevFlag: determine if the request is a float AMO, and if so, return the operation; otherwise return 0
 constexpr RevFlag RevFlagAtomicFloat( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_FORZA_ATOMIC_FLOAT ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_FORZA_ATOMIC_FLOAT ) };
 }
 
 /// RevFlag: determine the return flags
 constexpr RevFlag RevFlagReturn( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RETURN ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_RETURN ) };
 }
 
 /// RevFlag: determine which response flags are present
 constexpr RevFlag RevFlagResp( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RESP ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_RESP ) };
 }
 
 // RevFlag: determine if the request is cache-able
 constexpr bool isCacheable( RevFlag flag ) {
-  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_NONCACHEABLE ) ) == 0;
+  return ( safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_NONCACHEABLE ) ) == 0;
 }
 
 }  // namespace SST::RevCPU

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -1,0 +1,104 @@
+//
+// _RevFlag_h_
+//
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#ifndef _SST_REVFLAG_H_
+#define _SST_REVFLAG_H_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "RevCommon.h"
+#include "SST.h"
+
+namespace SST::RevCPU {
+
+using namespace SST::Interfaces;
+
+// ----------------------------------------
+// Extended StandardMem::Request::Flag enums
+// ----------------------------------------
+enum class RevFlag : uint32_t {
+  F_NONE               = 0,        /// no special operation
+  F_NONCACHEABLE       = 1u << 1,  /// non cacheable
+
+  F_BOXNAN             = 1u << 16,  /// NaN-box the 32-bit float
+  F_SEXT32             = 1u << 17,  /// sign extend the 32bit result
+  F_SEXT64             = 1u << 18,  /// sign extend the 64bit result
+  F_ZEXT32             = 1u << 19,  /// zero extend the 32bit result
+  F_ZEXT64             = 1u << 20,  /// zero extend the 64bit result
+  F_RESP               = F_BOXNAN | F_SEXT32 | F_SEXT64 | F_ZEXT32 | F_ZEXT64,
+
+  F_AQ                 = 1u << 21,  /// AMO AQ Flag
+  F_RL                 = 1u << 22,  /// AMO RL Flag
+
+  F_AMOADD             = 1u << 23,   /// AMO Add
+  F_AMOXOR             = 2u << 23,   /// AMO Xor
+  F_AMOAND             = 3u << 23,   /// AMO And
+  F_AMOOR              = 4u << 23,   /// AMO Or
+  F_AMOMIN             = 5u << 23,   /// AMO Min
+  F_AMOMAX             = 6u << 23,   /// AMO Max
+  F_AMOMINU            = 7u << 23,   /// AMO Minu
+  F_AMOMAXU            = 8u << 23,   /// AMO Maxu
+  F_AMOSWAP            = 9u << 23,   /// AMO Swap
+  F_FORZASUB           = 10u << 23,  /// XForza: AMO SUB
+  F_FORZATHRS          = 11u << 23,  /// XForza: AMO THRS
+
+  F_FORZAFADD          = 1u << 27,  /// XForza: AMO FADD
+  F_FORZAFSUB          = 2u << 27,  /// XForza: AMO FSUB
+  F_FORZAFSUBR         = 3u << 27,  /// XForza: AMO FSUBR
+  F_FORZAFMIN          = 3u << 27,  /// XForza: AMO FSUBR
+  F_FORZAFMAX          = 4u << 27,  /// XForza: AMO FSUBR
+  F_FORZA_ATOMIC_FLOAT = F_FORZAFADD | F_FORZAFSUB | F_FORZAFSUBR | F_FORZAFMIN | F_FORZAFMAX,
+
+  F_ATOMIC = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP | F_FORZASUB |
+             F_FORZATHRS | F_FORZA_ATOMIC_FLOAT,
+
+  F_FORZANN = 1u << 30,  /// XForza: AMO RETURN NN
+  F_FORZAON = 2u << 30,  /// XForza: AMO RETURN ON
+  F_FORZANO = 3u << 30,  /// XForza: AMO RETURN NO
+  F_RETURN  = F_FORZANN | F_FORZAON | F_FORZANO,
+};
+
+// Ensure RevFlag is same underlying type as StandardMem::Request::flags_t
+static_assert( std::is_same_v<StandardMem::Request::flags_t, std::underlying_type_t<RevFlag>> );
+
+/// RevFlag: determine if the request has certain flags set
+constexpr bool RevFlagHas( RevFlag flag, RevFlag has ) {
+  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( has ) ) == safe_static_cast<uint32_t>( has );
+}
+
+/// RevFlag: set certain flags
+constexpr void RevFlagSet( RevFlag& flag, RevFlag set ) {
+  flag = RevFlag{ safe_static_cast<uint32_t>( flag ) | safe_static_cast<uint32_t>( set ) };
+}
+
+/// RevFlag: determine if the request is an AMO, and if so, return the operation; otherwise return 0
+constexpr RevFlag RevFlagAtomic( RevFlag flag ) {
+  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_ATOMIC ) };
+}
+
+/// RevFlag: determine if the request is a float AMO, and if so, return the operation; otherwise return 0
+constexpr RevFlag RevFlagAtomicFloat( RevFlag flag ) {
+  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_FORZA_ATOMIC_FLOAT ) };
+}
+
+/// RevFlag: determine the return flags
+constexpr RevFlag RevFlagReturn( RevFlag flag ) {
+  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RETURN ) };
+}
+
+/// RevFlag: determine which response flags are present
+constexpr RevFlag RevFlagResp( RevFlag flag ) {
+  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RESP ) };
+}
+
+}  // namespace SST::RevCPU
+
+#endif  // _SST_REVFLAG_H_

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -22,43 +22,37 @@ namespace SST::RevCPU {
 using flags_t = StandardMem::Request::flags_t;
 
 enum class RevFlag : flags_t {
-  F_NONE               = 0,        /// no special operation
-  F_NONCACHEABLE       = 1u << 1,  /// non cacheable
-
-  F_BOXNAN             = 1u << 16,  /// NaN-box the 32-bit float
-  F_SEXT32             = 1u << 17,  /// sign extend the 32bit result
-  F_SEXT64             = 1u << 18,  /// sign extend the 64bit result
-  F_ZEXT32             = 1u << 19,  /// zero extend the 32bit result
-  F_ZEXT64             = 1u << 20,  /// zero extend the 64bit result
-  F_RESP               = F_BOXNAN | F_SEXT32 | F_SEXT64 | F_ZEXT32 | F_ZEXT64,
-
-  F_AQ                 = 1u << 21,  /// AMO AQ Flag
-  F_RL                 = 1u << 22,  /// AMO RL Flag
-
-  F_AMOADD             = 1u << 23,   /// AMO Add
-  F_AMOXOR             = 2u << 23,   /// AMO Xor
-  F_AMOAND             = 3u << 23,   /// AMO And
-  F_AMOOR              = 4u << 23,   /// AMO Or
-  F_AMOMIN             = 5u << 23,   /// AMO Min
-  F_AMOMAX             = 6u << 23,   /// AMO Max
-  F_AMOMINU            = 7u << 23,   /// AMO Minu
-  F_AMOMAXU            = 8u << 23,   /// AMO Maxu
-  F_AMOSWAP            = 9u << 23,   /// AMO Swap
-  F_FORZASUB           = 10u << 23,  /// XForza: AMO SUB
-  F_FORZATHRS          = 11u << 23,  /// XForza: AMO THRS
-
-  F_FORZAFADD          = 1u << 27,  /// XForza: AMO FADD
-  F_FORZAFSUB          = 2u << 27,  /// XForza: AMO FSUB
-  F_FORZAFSUBR         = 3u << 27,  /// XForza: AMO FSUBR
-  F_FORZA_ATOMIC_FLOAT = F_FORZAFADD | F_FORZAFSUB | F_FORZAFSUBR,
-
-  F_ATOMIC = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP | F_FORZASUB |
-             F_FORZATHRS | F_FORZA_ATOMIC_FLOAT,
-
-  F_FORZANN = 1u << 29,  /// XForza: AMO RETURN NN
-  F_FORZAON = 2u << 29,  /// XForza: AMO RETURN ON
-  F_FORZANO = 3u << 29,  /// XForza: AMO RETURN NO
-  F_RETURN  = F_FORZANN | F_FORZAON | F_FORZANO,
+  F_NONE         = 0,          /// no special operation
+  F_NONCACHEABLE = 1u << 1,    /// non cacheable
+  F_BOXNAN       = 1u << 16,   /// NaN-box the 32-bit float
+  F_SEXT32       = 1u << 17,   /// sign extend the 32bit result
+  F_SEXT64       = 1u << 18,   /// sign extend the 64bit result
+  F_ZEXT32       = 1u << 19,   /// zero extend the 32bit result
+  F_ZEXT64       = 1u << 20,   /// zero extend the 64bit result
+  F_AQ           = 1u << 21,   /// AMO AQ Flag
+  F_RL           = 1u << 22,   /// AMO RL Flag
+  F_AMOADD       = 1u << 23,   /// AMO Add
+  F_AMOXOR       = 2u << 23,   /// AMO Xor
+  F_AMOAND       = 3u << 23,   /// AMO And
+  F_AMOOR        = 4u << 23,   /// AMO Or
+  F_AMOMIN       = 5u << 23,   /// AMO Min
+  F_AMOMAX       = 6u << 23,   /// AMO Max
+  F_AMOMINU      = 7u << 23,   /// AMO Minu
+  F_AMOMAXU      = 8u << 23,   /// AMO Maxu
+  F_AMOSWAP      = 9u << 23,   /// AMO Swap
+  F_AMOSUB       = 10u << 23,  /// AMO Sub
+  F_AMOTHRES     = 11u << 23,  /// AMO Threshold
+  F_AMOFADD      = 1u << 27,   /// AMO Fadd
+  F_AMOFSUB      = 2u << 27,   /// AMO Fsub
+  F_AMOFSUBR     = 3u << 27,   /// AMO Fsubr
+  F_AMONN        = 1u << 29,   /// RevFlag: AMO RETURN NN
+  F_AMOON        = 2u << 29,   /// RevFlag: AMO RETURN ON
+  F_AMONO        = 3u << 29,   /// RevFlag: AMO RETURN NO
+  F_ATOMIC_RESP  = F_BOXNAN | F_SEXT32 | F_SEXT64 | F_ZEXT32 | F_ZEXT64,
+  F_ATOMIC_FLOAT = F_AMOFADD | F_AMOFSUB | F_AMOFSUBR,
+  F_ATOMIC       = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP | F_AMOSUB |
+             F_AMOTHRES | F_ATOMIC_FLOAT,
+  F_ATOMIC_RETURN = F_AMONN | F_AMOON | F_AMONO,
 };
 
 /// RevFlag: determine if the request has certain flags set
@@ -78,17 +72,17 @@ constexpr RevFlag RevFlagAtomic( RevFlag flag ) {
 
 /// RevFlag: determine if the request is a float AMO, and if so, return the operation; otherwise return 0
 constexpr RevFlag RevFlagAtomicFloat( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_FORZA_ATOMIC_FLOAT ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_ATOMIC_FLOAT ) };
 }
 
 /// RevFlag: determine the return flags
 constexpr RevFlag RevFlagReturn( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_RETURN ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_ATOMIC_RETURN ) };
 }
 
 /// RevFlag: determine which response flags are present
 constexpr RevFlag RevFlagResp( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_RESP ) };
+  return RevFlag{ safe_static_cast<flags_t>( flag ) & safe_static_cast<flags_t>( RevFlag::F_ATOMIC_RESP ) };
 }
 
 // RevFlag: determine if the request is cache-able

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -11,9 +11,6 @@
 #ifndef _SST_REVFLAG_H_
 #define _SST_REVFLAG_H_
 
-#include <cstdint>
-#include <type_traits>
-
 #include "RevCommon.h"
 #include "SST.h"
 

--- a/include/RevFlag.h
+++ b/include/RevFlag.h
@@ -42,6 +42,7 @@ enum class RevFlag : flags_t {
   F_AMOSWAP      = 9u << 23,   /// AMO Swap
   F_AMOSUB       = 10u << 23,  /// AMO Sub
   F_AMOTHRES     = 11u << 23,  /// AMO Threshold
+  F_AMOCAS       = 12u << 23,  /// AMO Compare and swap
   F_AMOFADD      = 1u << 27,   /// AMO Fadd
   F_AMOFSUB      = 2u << 27,   /// AMO Fsub
   F_AMOFSUBR     = 3u << 27,   /// AMO Fsubr
@@ -51,7 +52,7 @@ enum class RevFlag : flags_t {
   F_ATOMIC_RESP  = F_BOXNAN | F_SEXT32 | F_SEXT64 | F_ZEXT32 | F_ZEXT64,
   F_ATOMIC_FLOAT = F_AMOFADD | F_AMOFSUB | F_AMOFSUBR,
   F_ATOMIC       = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP | F_AMOSUB |
-             F_AMOTHRES | F_ATOMIC_FLOAT,
+             F_AMOTHRES | F_AMOCAS | F_ATOMIC_FLOAT,
   F_ATOMIC_RETURN = F_AMONN | F_AMOON | F_AMONO,
 };
 

--- a/include/RevInstHelpers.h
+++ b/include/RevInstHelpers.h
@@ -146,7 +146,7 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
       true,
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
-    M->ReadVal(
+    make_dependent<T>( M )->ReadVal(
       F->GetHartToExecID(),
       rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       reinterpret_cast<T*>( &R->RV32[Inst.rd] ),
@@ -166,7 +166,7 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
       true,
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
-    M->ReadVal(
+    make_dependent<T>( M )->ReadVal(
       F->GetHartToExecID(),
       rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       reinterpret_cast<T*>( &R->RV64[Inst.rd] ),
@@ -176,7 +176,7 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
   }
 
   // update the cost
-  R->cost += M->RandCost( F->GetMinCost(), F->GetMaxCost() );
+  R->cost += make_dependent<T>( M )->RandCost( F->GetMinCost(), F->GetMaxCost() );
   R->AdvancePC( Inst );
   return true;
 }
@@ -184,7 +184,9 @@ bool load( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) 
 /// Store template
 template<typename T>
 bool store( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), R->GetX<T>( Inst.rs2 ) );
+  make_dependent<T>( M )->Write(
+    F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), R->GetX<T>( Inst.rs2 )
+  );
   R->AdvancePC( Inst );
   return true;
 }
@@ -204,7 +206,7 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
       true,
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
-    M->ReadVal(
+    make_dependent<T>( M )->ReadVal(
       F->GetHartToExecID(),
       rs1 + uint64_t( Inst.ImmSignExt( 12 ) ),
       reinterpret_cast<T*>( &R->DPF[Inst.rd] ),
@@ -222,12 +224,12 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
       true,
       R->GetMarkLoadComplete() };
     R->LSQueue->insert( req.LSQHashPair() );
-    M->ReadVal(
+    make_dependent<T>( M )->ReadVal(
       F->GetHartToExecID(), rs1 + uint64_t( Inst.ImmSignExt( 12 ) ), &R->SPF[Inst.rd], std::move( req ), RevFlag::F_NONE
     );
   }
   // update the cost
-  R->cost += M->RandCost( F->GetMinCost(), F->GetMaxCost() );
+  R->cost += make_dependent<T>( M )->RandCost( F->GetMinCost(), F->GetMaxCost() );
   R->AdvancePC( Inst );
   return true;
 }
@@ -236,7 +238,7 @@ bool fload( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst )
 template<typename T>
 bool fstore( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
   T val = R->GetFP<T, true>( Inst.rs2 );
-  M->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), val );
+  make_dependent<T>( M )->Write( F->GetHartToExecID(), R->GetX<uint64_t>( Inst.rs1 ) + uint64_t( Inst.ImmSignExt( 12 ) ), val );
   R->AdvancePC( Inst );
   return true;
 }

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -206,6 +206,9 @@ public:
     return AMOMem( Hart, Addr, uint32_t{ sizeof( T ) }, Data, Target, req, flags );
   }
 
+  /// RevMem: Initiated an AMO request
+  bool AMOMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags );
+
   // ----------------------------------------------------
   // ---- Write Memory Interfaces
   // ----------------------------------------------------
@@ -231,8 +234,6 @@ public:
   // ----------------------------------------------------
   // ---- Atomic/Future/LRSC Interfaces
   // ----------------------------------------------------
-  /// RevMem: Initiated an AMO request
-  bool AMOMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags );
 
   /// RevMem: Invalidate Matching LR reservations
   bool InvalidateLRReservations( uint32_t hart, uint64_t addr, size_t len );

--- a/include/RevMem.h
+++ b/include/RevMem.h
@@ -131,7 +131,7 @@ public:
   };
 
   /// RevMem: determine if there are any outstanding requests
-  bool outstandingRqsts();
+  bool outstandingRqsts() const { return ctrl && ctrl->outstandingRqsts(); }
 
   /// RevMem: handle incoming memory event
   void handleEvent( Interfaces::StandardMem::Request* ev ) {}
@@ -155,7 +155,7 @@ public:
   uint64_t GetStackBottom() { return stacktop - _STACK_SIZE_; }
 
   /// RevMem: initiate a memory fence
-  bool FenceMem( uint32_t Hart );
+  bool FenceMem( uint32_t Hart ) { return !ctrl || ctrl->sendFENCE( Hart ); }
 
   /// RevMem: retrieves the cache line size.  Returns 0 if no cache is configured
   uint32_t getLineSize() { return ctrl ? ctrl->getLineSize() : 64; }
@@ -173,13 +173,17 @@ public:
   bool ReadMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Target, const MemReq& req, RevFlag flags = RevFlag::F_NONE );
 
   /// RevMem: flush a cache line
-  bool FlushLine( uint32_t Hart, uint64_t Addr );
+  bool FlushLine( uint32_t Hart, uint64_t Addr ) {
+    return !ctrl || ctrl->sendFLUSHRequest( Hart, Addr, 0, getLineSize(), false, RevFlag::F_NONE );
+  }
 
   /// RevMem: invalidate a cache line
-  bool InvLine( uint32_t Hart, uint64_t Addr );
+  bool InvLine( uint32_t Hart, uint64_t Addr ) {
+    return !ctrl || ctrl->sendFLUSHRequest( Hart, Addr, 0, getLineSize(), true, RevFlag::F_NONE );
+  }
 
   /// RevMem: clean a line
-  bool CleanLine( uint32_t Hart, uint64_t Addr );
+  bool CleanLine( uint32_t Hart, uint64_t Addr ) { return !ctrl || ( ctrl->sendFENCE( Hart ) && FlushLine( Hart, Addr ) ); }
 
   // ----------------------------------------------------
   // ---- Read Memory Interfaces

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -13,16 +13,14 @@
 
 // -- C++ Headers
 #include <algorithm>
-#include <cstdio>
-#include <cstdlib>
-#include <ctime>
+#include <cstddef>
 #include <functional>
-#include <list>
-#include <map>
 #include <memory>
 #include <random>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 // -- SST Headers
@@ -30,68 +28,10 @@
 
 // -- RevCPU Headers
 #include "RevCommon.h"
-#include "RevOpts.h"
-#include "RevTracer.h"
+#include "RevFlag.h"
+#include "RevInstHelpers.h"
 
 namespace SST::RevCPU {
-
-using namespace SST::Interfaces;
-
-// ----------------------------------------
-// Extended StandardMem::Request::Flag enums
-// ----------------------------------------
-enum class RevFlag : uint32_t {
-  F_NONE         = 0,        /// no special operation
-  F_NONCACHEABLE = 1u << 1,  /// non cacheable
-
-  F_BOXNAN       = 1u << 16,  /// NaN-box the 32-bit float
-  F_SEXT32       = 1u << 17,  /// sign extend the 32bit result
-  F_SEXT64       = 1u << 18,  /// sign extend the 64bit result
-  F_ZEXT32       = 1u << 19,  /// zero extend the 32bit result
-  F_ZEXT64       = 1u << 20,  /// zero extend the 64bit result
-  F_RESP         = F_BOXNAN | F_SEXT32 | F_SEXT64 | F_ZEXT32 | F_ZEXT64,
-
-  F_AQ           = 1u << 21,  /// AMO AQ Flag
-  F_RL           = 1u << 22,  /// AMO RL Flag
-
-  F_AMOADD       = 1u << 23,  /// AMO Add
-  F_AMOXOR       = 2u << 23,  /// AMO Xor
-  F_AMOAND       = 3u << 23,  /// AMO And
-  F_AMOOR        = 4u << 23,  /// AMO Or
-  F_AMOMIN       = 5u << 23,  /// AMO Min
-  F_AMOMAX       = 6u << 23,  /// AMO Max
-  F_AMOMINU      = 7u << 23,  /// AMO Minu
-  F_AMOMAXU      = 8u << 23,  /// AMO Maxu
-  F_AMOSWAP      = 9u << 23,  /// AMO Swap
-  F_ATOMIC       = F_AMOADD | F_AMOXOR | F_AMOAND | F_AMOOR | F_AMOMIN | F_AMOMAX | F_AMOMINU | F_AMOMAXU | F_AMOSWAP,
-
-};
-
-// Ensure RevFlag is same underlying type as StandardMem::Request::flags_t
-static_assert( std::is_same_v<StandardMem::Request::flags_t, std::underlying_type_t<RevFlag>> );
-
-/// RevFlag: determine if the request has certain flags set
-constexpr bool RevFlagHas( RevFlag flag, RevFlag has ) {
-  return ( safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( has ) ) == safe_static_cast<uint32_t>( has );
-}
-
-/// RevFlag: set certain flags
-constexpr void RevFlagSet( RevFlag& flag, RevFlag set ) {
-  flag = RevFlag{ safe_static_cast<uint32_t>( flag ) | safe_static_cast<uint32_t>( set ) };
-}
-
-/// RevFlag: determine if the request is an AMO, and if so, return the operation; otherwise return 0
-constexpr RevFlag RevFlagAtomic( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_ATOMIC ) };
-}
-
-/// RevFlag: determine which response flags are present
-constexpr RevFlag RevFlagResp( RevFlag flag ) {
-  return RevFlag{ safe_static_cast<uint32_t>( flag ) & safe_static_cast<uint32_t>( RevFlag::F_RESP ) };
-}
-
-/// RevFlag: Handle flag response
-void RevHandleFlagResp( void* target, size_t size, RevFlag flags );
 
 // ----------------------------------------
 // RevMemOp
@@ -148,10 +88,10 @@ public:
   uint32_t getSize() const { return Size; }
 
   /// RevMemOp: retrieve the memory buffer
-  std::vector<uint8_t> getBuf() const { return membuf; }
+  const std::vector<uint8_t>& getBuf() const { return membuf; }
 
   /// RevMemOp: retrieve the temporary target buffer
-  std::vector<uint8_t> getTempT() const { return tempT; }
+  const std::vector<uint8_t>& getTempT() const { return tempT; }
 
   /// RevMemOp: retrieve the memory operation flags
   RevFlag getFlags() const { return flags; }
@@ -175,7 +115,7 @@ public:
   void setMemReq( const MemReq& req ) { procReq = req; }
 
   /// RevMemOp: set the temporary target buffer
-  void setTempT( std::vector<uint8_t> T );
+  void setTempT( std::vector<uint8_t> T ) { tempT = std::move( T ); }
 
   /// RevMemOp: retrieve the invalidate flag
   bool getInv() const { return Inv; }
@@ -558,6 +498,18 @@ public:
   /// RevBasicMemCtrl: assign tracer pointer
   void setTracer( RevTracer* tracer ) final;
 
+  /// RevBasicMemCtrl: handle flag response
+  static void RevHandleFlagResp( void* target, size_t size, RevFlag flags );
+
+  /// RevFlag: Perform an integer conversion
+  template<typename SRC, typename DEST>
+  static void RevConvertInt( void* target ) {
+    SRC src;
+    memcpy( &src, target, sizeof( src ) );
+    DEST dest{ src };
+    memcpy( target, &dest, sizeof( dest ) );
+  }
+
 protected:
   // ----------------------------------------
   // RevStdMemHandlers
@@ -658,7 +610,7 @@ private:
   uint32_t getNumSplitRqsts( RevMemOp* op );
 
   /// RevBasicMemCtrl: perform the MODIFY portion of the AMO (READ+MODIFY+WRITE)
-  void performAMO( std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry );
+  void performAMO( RevMemOp* op );
 
   // -- private data members
   StandardMem*       memIface{};         ///< StandardMem memory interface
@@ -683,19 +635,12 @@ private:
   uint32_t num_custom{};       ///< number of outstanding custom requests
   uint32_t num_fence{};        ///< number of oustanding fence requests
 
-  std::vector<StandardMem::Request::id_t>         requests{};     ///< outstanding StandardMem requests
-  std::vector<RevMemOp*>                          rqstQ{};        ///< queued memory requests
-  std::map<StandardMem::Request::id_t, RevMemOp*> outstanding{};  ///< map of outstanding requests
-
-#define AMOTABLE_HART   0
-#define AMOTABLE_BUFFER 1
-#define AMOTABLE_TARGET 2
-#define AMOTABLE_FLAGS  3
-#define AMOTABLE_MEMOP  4
-#define AMOTABLE_IN     5
+  std::vector<StandardMem::Request::id_t>                   requests{};     ///< outstanding StandardMem requests
+  std::vector<RevMemOp*>                                    rqstQ{};        ///< queued memory requests
+  std::unordered_map<StandardMem::Request::id_t, RevMemOp*> outstanding{};  ///< map of outstanding requests
 
   /// RevBasicMemCtrl: map of amo operations to memory addresses
-  std::multimap<uint64_t, std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
+  std::unordered_multimap<uint64_t, std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool>> AMOTable{};
 
   std::vector<Statistic<uint64_t>*> stats{};  ///< statistics vector
 

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -132,11 +132,6 @@ public:
   /// RevMemOp: Get the originating proc memory request
   const MemReq& getMemReq() const { return procReq; }
 
-  // RevMemOp: determine if the request is cache-able
-  bool isCacheable() const {
-    return ( safe_static_cast<uint32_t>( flags ) & safe_static_cast<uint32_t>( RevFlag::F_NONCACHEABLE ) ) == 0;
-  }
-
 private:
   uint32_t             Hart{};       ///< RevMemOp: RISC-V Hart
   uint64_t             Addr{};       ///< RevMemOp: address

--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -90,9 +90,6 @@ public:
   /// RevMemOp: retrieve the memory buffer
   const std::vector<uint8_t>& getBuf() const { return membuf; }
 
-  /// RevMemOp: retrieve the temporary target buffer
-  const std::vector<uint8_t>& getTempT() const { return tempT; }
-
   /// RevMemOp: retrieve the memory operation flags
   RevFlag getFlags() const { return flags; }
 
@@ -113,9 +110,6 @@ public:
 
   /// RevMemOp: set the originating memory request
   void setMemReq( const MemReq& req ) { procReq = req; }
-
-  /// RevMemOp: set the temporary target buffer
-  void setTempT( std::vector<uint8_t> T ) { tempT = std::move( T ); }
 
   /// RevMemOp: retrieve the invalidate flag
   bool getInv() const { return Inv; }
@@ -142,7 +136,6 @@ private:
   uint32_t             CustomOpc{};  ///< RevMemOp: custom memory opcode
   uint32_t             SplitRqst{};  ///< RevMemOp: number of split cache line requests
   std::vector<uint8_t> membuf{};     ///< RevMemOp: buffer
-  std::vector<uint8_t> tempT{};      ///< RevMemOp: temporary target buffer for R-M-W ops
   RevFlag              flags{};      ///< RevMemOp: request flags
   void*                target{};     ///< RevMemOp: target register pointer
   MemReq               procReq{};    ///< RevMemOp: original request from RevCore

--- a/include/SST.h
+++ b/include/SST.h
@@ -45,4 +45,8 @@
 
 #pragma GCC diagnostic pop
 
+namespace SST::RevCPU {
+using namespace SST::Interfaces;
+}
+
 #endif

--- a/include/insns/Zaamo.h
+++ b/include/insns/Zaamo.h
@@ -17,15 +17,16 @@
 namespace SST::RevCPU {
 
 class Zaamo : public RevExt {
-  template<typename XLEN, RevFlag F_AMO>
+  template<typename TYPE, RevFlag F_AMO>
   static bool amooper( const RevFeature* F, RevRegFile* R, RevMem* M, const RevInst& Inst ) {
-    static_assert( std::is_unsigned_v<XLEN>, "XLEN must be unsigned integral type" );
+    static_assert( std::is_unsigned_v<TYPE>, "TYPE must be unsigned integral type" );
 
     RevFlag flags{ F_AMO };
 
     if( Inst.aq ) {
       RevFlagSet( flags, RevFlag::F_AQ );
     }
+
     if( Inst.rl ) {
       RevFlagSet( flags, RevFlag::F_RL );
     }
@@ -37,7 +38,7 @@ class Zaamo : public RevExt {
       R->LSQueue->insert( req.LSQHashPair() );
       M->AMOVal( F->GetHartToExecID(), R->RV32[Inst.rs1], &R->RV32[Inst.rs2], &R->RV32[Inst.rd], req, flags );
     } else {
-      flags = RevFlag{ uint32_t( flags ) | uint32_t( RevFlag::F_SEXT64 ) };
+      RevFlagSet( flags, RevFlag::F_SEXT64 );
       MemReq req(
         R->RV64[Inst.rs1], Inst.rd, RevRegClass::RegGPR, F->GetHartToExecID(), MemOp::MemOpAMO, true, R->GetMarkLoadComplete()
       );
@@ -45,8 +46,8 @@ class Zaamo : public RevExt {
       M->AMOVal(
         F->GetHartToExecID(),
         R->RV64[Inst.rs1],
-        reinterpret_cast<std::make_signed_t<XLEN>*>( &R->RV64[Inst.rs2] ),
-        reinterpret_cast<std::make_signed_t<XLEN>*>( &R->RV64[Inst.rd] ),
+        reinterpret_cast<std::make_signed_t<TYPE>*>( &R->RV64[Inst.rs2] ),
+        reinterpret_cast<std::make_signed_t<TYPE>*>( &R->RV64[Inst.rd] ),
         req,
         flags
       );

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -102,7 +102,7 @@ void RevMem::LR( uint32_t hart, uint64_t addr, size_t len, void* target, const M
     ctrl->sendREADLOCKRequest( hart, addr, uint64_t( BaseMem ), uint32_t( len ), target, req, flags );
   } else {
     memcpy( target, BaseMem, len );
-    RevHandleFlagResp( target, len, flags );
+    RevBasicMemCtrl::RevHandleFlagResp( target, len, flags );
     // clear the hazard
     req.MarkLoadComplete();
   }
@@ -614,7 +614,7 @@ bool RevMem::ReadMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Target, 
     memcpy( DataMem + remainder, &physMem[adjPhysAddr], Len - remainder );
 
     // Handle flag response
-    RevHandleFlagResp( Target, Len, flags );
+    RevBasicMemCtrl::RevHandleFlagResp( Target, Len, flags );
 
     // clear the hazard - if this was an AMO operation then we will clear outside of this function in AMOMem()
     if( MemOp::MemOpAMO != req.ReqType )

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -40,15 +40,6 @@ RevMem::RevMem( uint64_t memSize, RevOpts* opts, SST::Output* output )
   AddMemSegAt( stacktop, 1024 );  // Add the 1024 bytes for the program header information
 }
 
-bool RevMem::outstandingRqsts() {
-  if( ctrl ) {
-    return ctrl->outstandingRqsts();
-  }
-
-  // RevMemCtrl is not enabled; no outstanding requests
-  return false;
-}
-
 void RevMem::HandleMemFault( uint32_t width ) {
   // build up the fault payload
   uint64_t rval    = RevRand( 0, ( uint32_t{ 1 } << width ) - 1 );
@@ -93,14 +84,14 @@ void RevMem::LR( uint32_t hart, uint64_t addr, size_t len, void* target, const M
   // A reservation maps a hart to an (addr, len) range and is invalidated if any other hart writes to this range
   LRSC.insert_or_assign( hart, std::pair( addr, len ) );
 
-  // now handle the memory operation
-  uint64_t       pageNum  = addr >> addrShift;
-  uint64_t       physAddr = CalcPhysAddr( pageNum, addr );
-  unsigned char* BaseMem  = &physMem[physAddr];
-
   if( ctrl ) {
-    ctrl->sendREADLOCKRequest( hart, addr, uint64_t( BaseMem ), uint32_t( len ), target, req, flags );
+    ctrl->sendREADLOCKRequest( hart, addr, 0, uint32_t( len ), target, req, flags );
   } else {
+    // now handle the memory operation
+    uint64_t       pageNum  = addr >> addrShift;
+    uint64_t       physAddr = CalcPhysAddr( pageNum, addr );
+    unsigned char* BaseMem  = &physMem[physAddr];
+
     memcpy( target, BaseMem, len );
     RevBasicMemCtrl::RevHandleFlagResp( target, len, flags );
     // clear the hazard
@@ -483,13 +474,6 @@ uint64_t RevMem::AllocMemAt( const uint64_t& BaseAddr, const uint64_t& SegSize )
   return ret;
 }
 
-bool RevMem::FenceMem( uint32_t Hart ) {
-  if( ctrl ) {
-    return ctrl->sendFENCE( Hart );
-  }
-  return true;  // base RevMem support does nothing here
-}
-
 bool RevMem::AMOMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Data, void* Target, const MemReq& req, RevFlag flags ) {
 #ifdef _REV_DEBUG_
   std::cout << "AMO of " << Len << " Bytes Starting at 0x" << std::hex << Addr << std::dec << std::endl;
@@ -497,11 +481,7 @@ bool RevMem::AMOMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Data, voi
 
   if( ctrl ) {
     // sending to the RevMemCtrl
-    uint64_t       pageNum  = Addr >> addrShift;
-    uint64_t       physAddr = CalcPhysAddr( pageNum, Addr );
-    unsigned char* BaseMem  = &physMem[physAddr];
-
-    ctrl->sendAMORequest( Hart, Addr, uint64_t( BaseMem ), Len, static_cast<unsigned char*>( Data ), Target, req, flags );
+    ctrl->sendAMORequest( Hart, Addr, 0, Len, static_cast<unsigned char*>( Data ), Target, req, flags );
   } else {
     // process the request locally
     union {
@@ -621,37 +601,6 @@ bool RevMem::ReadMem( uint32_t Hart, uint64_t Addr, uint32_t Len, void* Target, 
       req.MarkLoadComplete();
   }
   memStats.bytesRead += Len;
-  return true;
-}
-
-bool RevMem::FlushLine( uint32_t Hart, uint64_t Addr ) {
-  uint64_t pageNum  = Addr >> addrShift;
-  uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
-  if( ctrl ) {
-    ctrl->sendFLUSHRequest( Hart, Addr, physAddr, getLineSize(), false, RevFlag::F_NONE );
-  }
-  // else, this is effectively a nop
-  return true;
-}
-
-bool RevMem::InvLine( uint32_t Hart, uint64_t Addr ) {
-  uint64_t pageNum  = Addr >> addrShift;
-  uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
-  if( ctrl ) {
-    ctrl->sendFLUSHRequest( Hart, Addr, physAddr, getLineSize(), true, RevFlag::F_NONE );
-  }
-  // else, this is effectively a nop
-  return true;
-}
-
-bool RevMem::CleanLine( uint32_t Hart, uint64_t Addr ) {
-  uint64_t pageNum  = Addr >> addrShift;
-  uint64_t physAddr = CalcPhysAddr( pageNum, Addr );
-  if( ctrl ) {
-    ctrl->sendFENCE( Hart );
-    ctrl->sendFLUSHRequest( Hart, Addr, physAddr, getLineSize(), false, RevFlag::F_NONE );
-  }
-  // else, this is effectively a nop
   return true;
 }
 

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -65,7 +65,7 @@ RevMemOp::RevMemOp(
   uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, std::vector<uint8_t> buffer, MemOp Op, RevFlag flags
 )
   : Hart( Hart ), Addr( Addr ), PAddr( PAddr ), Size( Size ), Inv( false ), Op( Op ), CustomOpc( 0 ), SplitRqst( 1 ),
-    membuf( buffer ), flags( flags ), target( nullptr ), procReq() {}
+    membuf( std::move( buffer ) ), flags( flags ), target( nullptr ), procReq() {}
 
 RevMemOp::RevMemOp(
   uint32_t Hart, uint64_t Addr, uint64_t PAddr, uint32_t Size, void* target, uint32_t CustomOpc, MemOp Op, RevFlag flags
@@ -1142,7 +1142,7 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
     // determine if we have a split request
     if( op->getSplitRqst() > 1 ) {
       // split request exists, determine how to handle it
-      memcpy( static_cast<uint8_t*>( op->getTarget() ) + uint8_t( ev->pAddr - op->getAddr() ), &ev->data[0], ev->size );
+      memcpy( static_cast<uint8_t*>( op->getTarget() ) + ( ev->pAddr - op->getAddr() ), &ev->data[0], ev->size );
 
       if( getNumSplitRqsts( op ) == 1 ) {
         // this was the last request to service, delete the op
@@ -1190,47 +1190,42 @@ void RevBasicMemCtrl::performAMO( RevMemOp* Tmp ) {
     output->fatal( CALL_INFO, -1, "Error : AMOTable entry is null\n" );
   }
 
-  RevFlag  flags = Tmp->getFlags();
-  uint32_t size  = Tmp->getSize();
+  RevFlag  flags  = Tmp->getFlags();
+  uint32_t size   = Tmp->getSize();
+  uint8_t* target = reinterpret_cast<uint8_t*>( Tmp->getTarget() );
 
   union {
-    uint8_t       u8;
-    uint16_t      u16;
-    uint32_t      u32;
-    uint64_t      u64;
-    float         f;
-    double        d;
-    unsigned char uc[8];
-  } Target, Src, Rtn;
+    uint8_t  u8;
+    uint16_t u16;
+    uint32_t u32;
+    uint64_t u64;
+    float    f;
+    double   d;
+  } Src, Rtn;
 
-  // Copy the contents of the original target
-  memcpy( &Target, Tmp->getTarget(), size );
-
-  // Copy the source value
+  // Copy the rs2 source register value
   memcpy( &Src, &Tmp->getBuf()[0], size );
 
+  // Copy the original value into Rtn
+  memcpy( &Rtn, target, size );
+
   // Perform the atomic operation
-  if( RevFlagAtomicFloat( flags ) == RevFlag::F_NONE ) {
-    switch( size ) {
-    case 4: ApplyAMO( flags, &Target, Src.u32 ); break;
-    case 8: ApplyAMO( flags, &Target, Src.u64 ); break;
-    }
+  switch( size ) {
+  case 4: ApplyAMO( flags, target, Src.u32 ); break;
+  case 8: ApplyAMO( flags, target, Src.u64 ); break;
   }
 
-  // copy the target data over to the buffer and build the memory request
+  // copy the modified target data over to the buffer and build the memory request
   // this will write the value to memory
   std::vector<uint8_t> buffer;
   for( uint32_t i = 0; i < size; ++i )
-    buffer.push_back( Target.uc[i] );
+    buffer.push_back( target[i] );
+
+  // Copy the return value to the destination register
+  memcpy( target, &Rtn, size );
 
   RevMemOp* Op =
     new RevMemOp( Tmp->getHart(), Tmp->getAddr(), Tmp->getPhysAddr(), size, std::move( buffer ), MemOp::MemOpWRITE, flags );
-
-  // Copy the return result to tempT
-  std::vector<uint8_t> tempT;
-  for( uint32_t i = 0; i < size; ++i )
-    tempT.push_back( Rtn.uc[i] );
-  Op->setTempT( std::move( tempT ) );
 
   // Retrieve the memory request object, but DO NOT mark the load
   // as complete.  The actual write response from the read-modify-write
@@ -1309,8 +1304,6 @@ void RevBasicMemCtrl::handleWriteResp( StandardMem::WriteResp* ev ) {
     // this was a write request for an AMO, clear the hazard
     const MemReq& r = op->getMemReq();
     if( isAMO ) {
-      // write the target
-      std::vector<uint8_t> tempT = op->getTempT();
       r.MarkLoadComplete();
     }
     delete op;

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -83,12 +83,6 @@ RevMemOp::RevMemOp(
   }
 }
 
-void RevMemOp::setTempT( std::vector<uint8_t> T ) {
-  for( auto i : T ) {
-    tempT.push_back( i );
-  }
-}
-
 // ---------------------------------------------------------------
 // RevMemCtrl
 // ---------------------------------------------------------------
@@ -1071,48 +1065,39 @@ bool RevBasicMemCtrl::processNextRqst(
   return true;
 }
 
-/// RevFlag: Perform an integer conversion
-template<typename SRC, typename DEST>
-static inline void convert( void* target ) {
-  SRC src;
-  memcpy( &src, target, sizeof( src ) );
-  DEST dest{ src };
-  memcpy( target, &dest, sizeof( dest ) );
-}
-
 /// RevFlag: Handle flag response
-void RevHandleFlagResp( void* target, size_t size, RevFlag flags ) {
+void RevBasicMemCtrl::RevHandleFlagResp( void* target, size_t size, RevFlag flags ) {
   if( RevFlagHas( flags, RevFlag::F_BOXNAN ) && size < sizeof( double ) ) {
     BoxNaN( static_cast<double*>( target ), static_cast<float*>( target ) );
   } else {
     switch( size ) {
     case 1:
       if( RevFlagHas( flags, RevFlag::F_SEXT32 ) ) {
-        convert<int8_t, int32_t>( target );
+        RevConvertInt<int8_t, int32_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_ZEXT32 ) ) {
-        convert<uint8_t, uint32_t>( target );
+        RevConvertInt<uint8_t, uint32_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_SEXT64 ) ) {
-        convert<int8_t, int64_t>( target );
+        RevConvertInt<int8_t, int64_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_ZEXT64 ) ) {
-        convert<uint8_t, uint64_t>( target );
+        RevConvertInt<uint8_t, uint64_t>( target );
       }
       break;
     case 2:
       if( RevFlagHas( flags, RevFlag::F_SEXT32 ) ) {
-        convert<int16_t, int32_t>( target );
+        RevConvertInt<int16_t, int32_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_ZEXT32 ) ) {
-        convert<uint16_t, uint32_t>( target );
+        RevConvertInt<uint16_t, uint32_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_SEXT64 ) ) {
-        convert<int16_t, int64_t>( target );
+        RevConvertInt<int16_t, int64_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_ZEXT64 ) ) {
-        convert<uint16_t, uint64_t>( target );
+        RevConvertInt<uint16_t, uint64_t>( target );
       }
       break;
     case 4:
       if( RevFlagHas( flags, RevFlag::F_SEXT64 ) ) {
-        convert<int32_t, int64_t>( target );
+        RevConvertInt<int32_t, int64_t>( target );
       } else if( RevFlagHas( flags, RevFlag::F_ZEXT64 ) ) {
-        convert<uint32_t, uint64_t>( target );
+        RevConvertInt<uint32_t, uint64_t>( target );
       }
     }
   }
@@ -1143,28 +1128,22 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
     std::cout << "Address of the target register = 0x" << std::hex << (uint64_t*) ( op->getTarget() ) << std::dec << std::endl;
 #endif
 
-    auto range = AMOTable.equal_range( op->getAddr() );
     bool isAMO = false;
-    for( auto i = range.first; i != range.second; ++i ) {
-      auto Entry = i->second;
+    for( auto [i, end] = AMOTable.equal_range( op->getAddr() ); i != end; ++i ) {
+      const auto& [hart, buffer, target, flags, memop, in] = i->second;
+
       // determine if we have an atomic request associated
       // with this read operation
-      if( std::get<AMOTABLE_MEMOP>( Entry ) == op ) {
+      if( memop == op ) {
         isAMO = true;
+        break;
       }
     }
 
     // determine if we have a split request
     if( op->getSplitRqst() > 1 ) {
       // split request exists, determine how to handle it
-
-      uint8_t* target    = static_cast<uint8_t*>( op->getTarget() );
-      uint32_t startByte = (uint32_t) ( ev->pAddr - op->getAddr() );
-      target += uint8_t( startByte );
-      for( uint32_t i = 0; i < (uint32_t) ( ev->size ); i++ ) {
-        *target = ev->data[i];
-        target++;
-      }
+      memcpy( static_cast<uint8_t*>( op->getTarget() ) + uint8_t( ev->pAddr - op->getAddr() ), &ev->data[0], ev->size );
 
       if( getNumSplitRqsts( op ) == 1 ) {
         // this was the last request to service, delete the op
@@ -1185,11 +1164,8 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
     }
 
     // no split request exists; handle as normal
-    uint8_t* target = (uint8_t*) ( op->getTarget() );
-    for( uint32_t i = 0; i < op->getSize(); i++ ) {
-      *target = ev->data[i];
-      target++;
-    }
+    memcpy( op->getTarget(), &ev->data[0], op->getSize() );
+
     // determine if we need to sign/zero extend
     handleFlagResp( op );
     if( isAMO ) {
@@ -1210,81 +1186,81 @@ void RevBasicMemCtrl::handleReadResp( StandardMem::ReadResp* ev ) {
   num_read--;
 }
 
-void RevBasicMemCtrl::performAMO( std::tuple<uint32_t, unsigned char*, void*, RevFlag, RevMemOp*, bool> Entry ) {
-  RevMemOp* Tmp = std::get<AMOTABLE_MEMOP>( Entry );
+void RevBasicMemCtrl::performAMO( RevMemOp* Tmp ) {
   if( Tmp == nullptr ) {
     output->fatal( CALL_INFO, -1, "Error : AMOTable entry is null\n" );
   }
-  void* Target                = Tmp->getTarget();
 
-  RevFlag              flags  = Tmp->getFlags();
-  std::vector<uint8_t> buffer = Tmp->getBuf();
-  std::vector<uint8_t> tempT;
+  RevFlag  flags = Tmp->getFlags();
+  uint32_t size  = Tmp->getSize();
 
-  tempT.clear();
-  uint8_t* TmpBuf8 = static_cast<uint8_t*>( Target );
-  for( size_t i = 0; i < Tmp->getSize(); i++ ) {
-    tempT.push_back( TmpBuf8[i] );
-  }
+  union {
+    uint8_t       u8;
+    uint16_t      u16;
+    uint32_t      u32;
+    uint64_t      u64;
+    float         f;
+    double        d;
+    unsigned char uc[8];
+  } Target, Src, Rtn;
 
-  if( Tmp->getSize() == 4 ) {
-    // 32-bit (W) AMOs
-    uint32_t TmpBuf = 0;
-    for( size_t i = 0; i < buffer.size(); i++ ) {
-      TmpBuf |= uint32_t{ buffer[i] } << i * 8;
+  // Copy the contents of the original target
+  memcpy( &Target, Tmp->getTarget(), size );
+
+  // Copy the source value
+  memcpy( &Src, &Tmp->getBuf()[0], size );
+
+  // Perform the atomic operation
+  if( RevFlagAtomicFloat( flags ) == RevFlag::F_NONE ) {
+    switch( size ) {
+    case 4: ApplyAMO( flags, &Target, Src.u32 ); break;
+    case 8: ApplyAMO( flags, &Target, Src.u64 ); break;
     }
-    ApplyAMO( flags, Target, TmpBuf );
-  } else {
-    // 64-bit (D) AMOs
-    uint64_t TmpBuf = 0;
-    for( size_t i = 0; i < buffer.size(); i++ ) {
-      TmpBuf |= uint64_t{ buffer[i] } << i * 8;
-    }
-    ApplyAMO( flags, Target, TmpBuf );
   }
 
   // copy the target data over to the buffer and build the memory request
-  buffer.clear();
-  for( size_t i = 0; i < Tmp->getSize(); i++ ) {
-    buffer.push_back( TmpBuf8[i] );
-  }
+  // this will write the value to memory
+  std::vector<uint8_t> buffer;
+  for( uint32_t i = 0; i < size; ++i )
+    buffer.push_back( Target.uc[i] );
 
   RevMemOp* Op =
-    new RevMemOp( Tmp->getHart(), Tmp->getAddr(), Tmp->getPhysAddr(), Tmp->getSize(), buffer, MemOp::MemOpWRITE, Tmp->getFlags() );
-  Op->setTempT( tempT );
-  for( uint32_t i = 0; i < Op->getSize(); i++ ) {
-    TmpBuf8[i] = tempT[i];
-  }
+    new RevMemOp( Tmp->getHart(), Tmp->getAddr(), Tmp->getPhysAddr(), size, std::move( buffer ), MemOp::MemOpWRITE, flags );
+
+  // Copy the return result to tempT
+  std::vector<uint8_t> tempT;
+  for( uint32_t i = 0; i < size; ++i )
+    tempT.push_back( Rtn.uc[i] );
+  Op->setTempT( std::move( tempT ) );
 
   // Retrieve the memory request object, but DO NOT mark the load
   // as complete.  The actual write response from the read-modify-write
   // process will mark the load as complete.  At this point, copy the
   // MemReq object to the new request
-  const MemReq& r = Tmp->getMemReq();
-  Op->setMemReq( r );
+  Op->setMemReq( Tmp->getMemReq() );
 
   // insert a new entry into the AMO Table
-  auto NewEntry = std::make_tuple(
-    Op->getHart(),
-    nullptr,  // this can be null here since we don't need to modify the response
-    Op->getTarget(),
-    Op->getFlags(),
-    Op,
-    true
+  AMOTable.emplace(
+    Op->getAddr(),
+    std::make_tuple(
+      Op->getHart(),
+      nullptr,  // this can be null here since we don't need to modify the response
+      Op->getTarget(),
+      Op->getFlags(),
+      Op,
+      true
+    )
   );
-  AMOTable.insert( { Op->getAddr(), NewEntry } );
   rqstQ.push_back( Op );
 }
 
 void RevBasicMemCtrl::handleAMO( RevMemOp* op ) {
-  auto range = AMOTable.equal_range( op->getAddr() );
-  for( auto i = range.first; i != range.second; ++i ) {
-    auto Entry = i->second;
+  for( auto [i, end] = AMOTable.equal_range( op->getAddr() ); i != end; ++i ) {
+    const auto& [hart, buffer, target, flags, memop, in] = i->second;
     // perform the arithmetic operation and generate a WRITE request
-    if( std::get<AMOTABLE_MEMOP>( Entry ) == op ) {
-      performAMO( Entry );
+    if( memop == op ) {
       AMOTable.erase( i );  // erase the current entry so we can add a new one
-      return;
+      return performAMO( op );
     }
   }
 }
@@ -1302,12 +1278,10 @@ void RevBasicMemCtrl::handleWriteResp( StandardMem::WriteResp* ev ) {
     // walk the AMOTable and clear any matching AMO ops
     // note that we must match on both the target address and the RevMemOp pointer
     bool isAMO = false;
-    auto range = AMOTable.equal_range( op->getAddr() );
-    for( auto i = range.first; i != range.second; ) {
-      auto Entry = i->second;
-      // if the request matches the target,
-      // then delete it
-      if( std::get<AMOTABLE_MEMOP>( Entry ) == op ) {
+    for( auto [i, end] = AMOTable.equal_range( op->getAddr() ); i != end; ) {
+      const auto& [hart, buffer, target, flags, memop, in] = i->second;
+      // if the request matches the target, then delete it
+      if( memop == op ) {
         AMOTable.erase( i++ );
         isAMO = true;
       } else {

--- a/src/RevMemCtrl.cc
+++ b/src/RevMemCtrl.cc
@@ -897,7 +897,7 @@ bool RevBasicMemCtrl::buildStandardMemRqst( RevMemOp* op, bool& Success ) {
     std::cout << "WARNING: lineSize == 0!" << std::endl;
   else if( op->getAddr() % lineSize )
     std::cout << "WARNING: address is not cache aligned!" << std::endl;
-  if( !op->isCacheable() )
+  if( !isCacheable( op->getFlags() ) )
     std::cout << "WARNING: operation is not cache-able!" << std::endl;
 #endif
 
@@ -919,20 +919,19 @@ bool RevBasicMemCtrl::buildStandardMemRqst( RevMemOp* op, bool& Success ) {
   // ALWAYS 1 and we dispatch a single memory requests per
   // RevMemOp
   // ---------------------------------------------------------
-  RevFlag TmpFlags;
-  if( ( hasCache ) && ( op->isCacheable() ) ) {
-    // cache is enabled and we want to cache the request
-    return buildCacheMemRqst( op, Success );
-  } else if( ( hasCache ) && ( !op->isCacheable() ) ) {
-    // cache is enabled but the request says not to cache the data
-    Success  = true;
-    TmpFlags = op->getStdFlags();
-    return buildRawMemRqst( op, TmpFlags );
+  if( hasCache ) {
+    if( isCacheable( op->getFlags() ) ) {
+      // cache is enabled and we want to cache the request
+      return buildCacheMemRqst( op, Success );
+    } else {
+      // cache is enabled but the request says not to cache the data
+      Success = true;
+      return buildRawMemRqst( op, op->getStdFlags() );
+    }
   } else {
     // no cache enabled
-    Success  = true;
-    TmpFlags = op->getNonCacheFlags();
-    return buildRawMemRqst( op, TmpFlags );
+    Success = true;
+    return buildRawMemRqst( op, op->getNonCacheFlags() );
   }
 }
 


### PR DESCRIPTION
Post-CDR; This improves the handling of `RevFlag` and memory operations:
- `RevFlag.h` is moved to a separate header, to break circular dependencies between headers
- `flags_t` is used as the underlying type of `RevFlag` so that `RevFlag` is interchangeable with SST `flags_t` (previously a `static_assert` was used, but this makes the assertion true by definition)
- `BaseAddr` is `0` in memory requests which use MemH, and remove page calculations for RevMem when MemH is used
- Move cache flush/invalidate functions to headers for inlining, and simplify them
- Add `make_dependent<T>(M)` so that `RevMem` can be an incomplete class in `RevInstHelpers.h`, breaking circular dependencies
- Make `RevHandleFlagResp`  and `RevConvertInt` `static` members of `RevBasicMemCtrl`
- Make `isCacheable()` a free function in`RevFlag.h` instead of a member function
- Make `AMOTable` an `unordered_multimap` instead of a `multimap`
- Use structured bindings `auto& [a, b, c, ... ] = tuple;` instead of `std::get<MACRO>( tuple )` 
- Make `performAMO( )` take a single `RevMemOp* op` parameter instead of a tuple, since the `op` field was the only field used
- Make most of the Forza and non-Forza atomics code the same, except in a few places with a small number of lines different