### PR TITLE
Fix lambda captures could have had dangling references

### DIFF
--- a/include/RevMemCtrl.h
+++ b/include/RevMemCtrl.h
@@ -713,24 +713,19 @@ void ApplyAMO( RevFlag flags, void* Target, T value ) {
 
   // Table mapping atomic operations to executable code
   // clang-format off
-  static const std::pair<RevFlag, std::function<void()>> table[] = {
-    { RevFlag::F_AMOADD,  [&]{ *TmpTarget += TmpBuf; } },
-    { RevFlag::F_AMOXOR,  [&]{ *TmpTarget ^= TmpBuf; } },
-    { RevFlag::F_AMOAND,  [&]{ *TmpTarget &= TmpBuf; } },
-    { RevFlag::F_AMOOR,   [&]{ *TmpTarget |= TmpBuf; } },
-    { RevFlag::F_AMOSWAP, [&]{ *TmpTarget  = TmpBuf; } },
-    { RevFlag::F_AMOMIN,  [&]{ *TmpTarget  = std::min(*TmpTarget,  TmpBuf);  } },
-    { RevFlag::F_AMOMAX,  [&]{ *TmpTarget  = std::max(*TmpTarget,  TmpBuf);  } },
-    { RevFlag::F_AMOMINU, [&]{ *TmpTargetU = std::min(*TmpTargetU, TmpBufU); } },
-    { RevFlag::F_AMOMAXU, [&]{ *TmpTargetU = std::max(*TmpTargetU, TmpBufU); } },
+  switch( RevFlagAtomic( flags ) ) {
+    case RevFlag::F_AMOADD:  *TmpTarget += TmpBuf; break;
+    case RevFlag::F_AMOXOR:  *TmpTarget ^= TmpBuf; break;
+    case RevFlag::F_AMOAND:  *TmpTarget &= TmpBuf; break;
+    case RevFlag::F_AMOOR:   *TmpTarget |= TmpBuf; break;
+    case RevFlag::F_AMOSWAP: *TmpTarget  = TmpBuf; break;
+    case RevFlag::F_AMOMIN:  *TmpTarget  = std::min(*TmpTarget,  TmpBuf); break;
+    case RevFlag::F_AMOMAX:  *TmpTarget  = std::max(*TmpTarget,  TmpBuf); break;
+    case RevFlag::F_AMOMINU: *TmpTargetU = std::min(*TmpTargetU, TmpBufU); break;
+    case RevFlag::F_AMOMAXU: *TmpTargetU = std::max(*TmpTargetU, TmpBufU); break;
+    default: break;
   };
   // clang-format on
-  for( const auto& [amo, op] : table ) {
-    if( RevFlagAtomic( flags ) == amo ) {
-      op();
-      break;
-    }
-  }
 }
 
 }  // namespace SST::RevCPU


### PR DESCRIPTION
This fixes the atomics code which captures-by-reference. 

The current code captures variables by reference  `[&]` and stores the resulting functions in a `static` table. And although these references may continue to point to the same stack offsets where the captured variables were at, and may work on subsequent calls to the function which reuse the `static` variable, this is not guaranteed. To be correct, the `static` `table`  would need to be non-`static` and reinitialized every time the function is called, which is wasteful since we are only interested in one of the alternatives at each call.

The new code is also simpler. Historically, it had been much more complicated, which made lambdas at the time seem like a simplification, but  now a simple `switch` statement is simpler.

