### PR TITLE
Use arrays with deduced size instead of hard-coded sizes

### DIFF
--- a/test/syscalls/chdir/chdir.c
+++ b/test/syscalls/chdir/chdir.c
@@ -8,7 +8,7 @@ int main() {
    *       chdir("/tmp") you will get garbage data.
    *       This is a known issue with Text data in assembly
   */
-  const char dir[5] = "/tmp";
+  const char dir[]  = "/tmp";
   int        result = rev_chdir( &dir[0] );
 
   if( result != 0 ) {

--- a/test/syscalls/file_io/file_io.c
+++ b/test/syscalls/file_io/file_io.c
@@ -15,17 +15,17 @@
 int main() {
   char buffer[BUF_SIZE];
 
-  const char path[12] = "test.txt";
+  const char path[]  = "test.txt";
 
   // Open the file "test.txt" under the current directory
   // rev_write(STDOUT_FILENO, OpenMsg, sizeof(OpenMsg));
-  int fd              = rev_openat( AT_FDCWD, path, 0, O_RDONLY );
+  int fd             = rev_openat( AT_FDCWD, path, 0, O_RDONLY );
 
   // Read from the file
-  uint64_t bytesRead  = rev_read( fd, buffer, 29 );
+  uint64_t bytesRead = rev_read( fd, buffer, 29 );
 
   // Null-terminate the buffer so we can use it as a string
-  buffer[bytesRead]   = '\0';
+  buffer[bytesRead]  = '\0';
 
   // Write to STDOUT
   rev_write( STDOUT_FILENO, buffer, bytesRead );

--- a/test/syscalls/printf/printf.c
+++ b/test/syscalls/printf/printf.c
@@ -4,14 +4,14 @@
 
 int main() {
 
-  const char msg[10]       = "Greetings\n";
-  ssize_t    bytes_written = rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  const char msg[]         = "Greetings\n";
+  ssize_t    bytes_written = rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
 
   if( bytes_written < 0 ) {
     rev_exit( 1 );
   }
-  const char msg2[67]       = "Greetings - this is a much longer text string. Just larger than 64\n";
-  ssize_t    bytes_written2 = rev_write( STDOUT_FILENO, msg2, sizeof( msg2 ) );
+  const char msg2[]         = "Greetings - this is a much longer text string. Just larger than 64\n";
+  ssize_t    bytes_written2 = rev_write( STDOUT_FILENO, msg2, sizeof( msg2 ) - 1 );
 
   if( bytes_written2 < 0 ) {
     rev_exit( 1 );
@@ -23,8 +23,8 @@ int main() {
   printf( "The meaning of life is %d\n", i );
 
   //The test below fails - we are reaching into invalid address space, this appears unrealted to most recent changes
-  /*  const char msg3[98] = "Greetings - this is a much longer message and some nice text, in fact, it is bigger than 64 bytes\n";
-  ssize_t bytes_written3 = rev_write(STDOUT_FILENO, msg3, sizeof(msg3));
+  /*  const char msg3[] = "Greetings - this is a much longer message and some nice text, in fact, it is bigger than 64 bytes\n";
+  ssize_t bytes_written3 = rev_write(STDOUT_FILENO, msg3, sizeof(msg3) - 1);
 
   if( bytes_written3 < 0 ){
     rev_exit(1);

--- a/test/syscalls/write/write.c
+++ b/test/syscalls/write/write.c
@@ -3,22 +3,22 @@
 
 int main() {
 
-  const char msg[10]       = "Greetings\n";
-  ssize_t    bytes_written = rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  const char msg[]         = "Greetings\n";
+  ssize_t    bytes_written = rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
 
   if( bytes_written < 0 ) {
     rev_exit( 1 );
   }
-  const char msg2[67]       = "Greetings - this is a much longer text string. Just larger than 64\n";
-  ssize_t    bytes_written2 = rev_write( STDOUT_FILENO, msg2, sizeof( msg2 ) );
+  const char msg2[]         = "Greetings - this is a much longer text string. Just larger than 64\n";
+  ssize_t    bytes_written2 = rev_write( STDOUT_FILENO, msg2, sizeof( msg2 ) - 1 );
 
   if( bytes_written2 < 0 ) {
     rev_exit( 1 );
   }
 
   //The test below fails - we are reaching into invalid address space, this appears unrealted to most recent changes
-  /*  const char msg3[98] = "Greetings - this is a much longer message and some nice text, in fact, it is bigger than 64 bytes\n";
-  ssize_t bytes_written3 = rev_write(STDOUT_FILENO, msg3, sizeof(msg3));
+  /*  const char msg3[] = "Greetings - this is a much longer message and some nice text, in fact, it is bigger than 64 bytes\n";
+  ssize_t bytes_written3 = rev_write(STDOUT_FILENO, msg3, sizeof(msg3) -1 );
 
   if( bytes_written3 < 0 ){
     rev_exit(1);

--- a/test/threading/pthreads/pthread_arg_passing/pthread_arg_passing.c
+++ b/test/threading/pthreads/pthread_arg_passing/pthread_arg_passing.c
@@ -14,18 +14,18 @@ struct ThreadInfo {
 
 // create the function to be executed as a thread
 void* thread1( struct ThreadInfo* info ) {
-  const char msg[29] = "Hello from thread1 function\n";
+  const char msg[] = "Hello from thread1 function\n";
   // Append tid to msg
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
   // Convert the number to a string
   assert( info->a == 1 );
   return 0;
 }
 
 void* thread2( struct ThreadInfo* info ) {
-  const char msg[29] = "Howdy from thread2 function\n";
+  const char msg[] = "Howdy from thread2 function\n";
   // Append tid to msg
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
 
   assert( info->a == 2 );
   // Convert the number to a string
@@ -35,11 +35,11 @@ void* thread2( struct ThreadInfo* info ) {
 int main( int argc, char** argv ) {
   // Create three instances of structs to pass to threads
   struct ThreadInfo thread1_info, thread2_info;
-  thread1_info.a           = 1;
-  thread2_info.a           = 2;
+  thread1_info.a         = 1;
+  thread2_info.a         = 2;
 
-  const char first_msg[23] = "Welcome to the circus\n";
-  rev_write( STDOUT_FILENO, first_msg, sizeof( first_msg ) );
+  const char first_msg[] = "Welcome to the circus\n";
+  rev_write( STDOUT_FILENO, first_msg, sizeof( first_msg ) - 1 );
   // create the thread objs
   rev_pthread_t tid1, tid2;
   // uint64_t thr = 1;
@@ -51,8 +51,8 @@ int main( int argc, char** argv ) {
   rev_pthread_join( tid1 );
   rev_pthread_join( tid2 );
 
-  const char msg[26] = "Bonjour from main thread\n";
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  const char msg[] = "Bonjour from main thread\n";
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
   // rev_exit(99);
   return 0;
 }

--- a/test/threading/pthreads/pthread_basic/pthread_basic.c
+++ b/test/threading/pthreads/pthread_basic/pthread_basic.c
@@ -9,25 +9,28 @@
 
 // create the function to be executed as a thread
 void* thread1() {
-  const char msg[29] = "Hello from thread1 function\n";
+  const char msg[] = "Hello from thread1 function\n";
+  asm( " fence" );
+
   // Append tid to msg
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
   // Convert the number to a string
   return 0;
 }
 
 void* thread2() {
-  const char msg[29] = "Howdy from thread2 function\n";
+  const char msg[] = "Howdy from thread2 function\n";
   // Append tid to msg
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  asm( " fence" );
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
 
   // Convert the number to a string
   return 0;
 }
 
 int main( int argc, char** argv ) {
-  const char first_msg[23] = "Welcome to the circus\n";
-  rev_write( STDOUT_FILENO, first_msg, sizeof( first_msg ) );
+  const char first_msg[] = "Welcome to the circus\n";
+  rev_write( STDOUT_FILENO, first_msg, sizeof( first_msg ) - 1 );
   // create the thread objs
   rev_pthread_t tid1, tid2;
   // uint64_t thr = 1;
@@ -36,13 +39,13 @@ int main( int argc, char** argv ) {
   rev_pthread_create( &tid1, NULL, (void*) thread1, NULL );
   rev_pthread_create( &tid2, NULL, (void*) thread2, NULL );
 
-  const char joined_msg[76] = "thread w/ tid1 has finished and been joined. "
-                              "Now proceeding with execution\n";
+  const char joined_msg[] = "thread w/ tid1 has finished and been joined. "
+                            "Now proceeding with execution\n";
   rev_pthread_join( tid1 );
-  rev_write( STDOUT_FILENO, joined_msg, sizeof( joined_msg ) );
+  rev_write( STDOUT_FILENO, joined_msg, sizeof( joined_msg ) - 1 );
   rev_pthread_join( tid2 );
 
-  const char msg[26] = "Bonjour from main thread\n";
-  rev_write( STDOUT_FILENO, msg, sizeof( msg ) );
+  const char msg[] = "Bonjour from main thread\n";
+  rev_write( STDOUT_FILENO, msg, sizeof( msg ) - 1 );
   return 0;
 }


### PR DESCRIPTION
This changes some tests to use `char array[] = "string";` declarations instead of hard-coding the array sizes, to reduce the chance of errors. `sizeof( array ) - 1` is used wherever the string without the trailing `\0` byte is needed.