### PR TITLE
update for sst 15.0

### DIFF
--- a/include/SST.h
+++ b/include/SST.h
@@ -21,6 +21,7 @@
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
 
 #if defined( __GNUC__ ) && !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wsuggest-final-methods"


### PR DESCRIPTION
This simply adds another pragma to SST.h to support compiling with sst-core/v15.0.0_beta without warnings to avoid -Werror compiler errors on MacOs