### PR TITLE
detecting unsupported ECALLs and test checking improvements

### DIFF
--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -7,6 +7,12 @@
 #include <sys/fcntl.h>
 #include <sys/xattr.h>
 
+#ifndef _REV_ECALL_OVERRIDE
+#define UNIMPLEMENTED() output->verbose( CALL_INFO, 0, 0, "Error: unimplemented ecall\n" )
+#else
+#define UNIMPLEMENTED()
+#endif
+
 namespace SST::RevCPU {
 
 /// Parse a string for an ECALL starting at address straddr, updating the state
@@ -62,6 +68,7 @@ EcallStatus RevCore::ECALL_io_setup() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_setup called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -70,6 +77,7 @@ EcallStatus RevCore::ECALL_io_destroy() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_destroy called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -78,6 +86,7 @@ EcallStatus RevCore::ECALL_io_submit() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_submit called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -86,6 +95,7 @@ EcallStatus RevCore::ECALL_io_cancel() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_cancel called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -94,6 +104,7 @@ EcallStatus RevCore::ECALL_io_getevents() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_getevents called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -153,6 +164,7 @@ EcallStatus RevCore::ECALL_setxattr() {
     return EcallLoadAndParseString(name, action);
   }
 #else
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 #endif
 }
@@ -162,6 +174,7 @@ EcallStatus RevCore::ECALL_lsetxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: lsetxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -170,6 +183,7 @@ EcallStatus RevCore::ECALL_fsetxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fsetxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -178,6 +192,7 @@ EcallStatus RevCore::ECALL_getxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -186,6 +201,7 @@ EcallStatus RevCore::ECALL_lgetxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: lgetxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -194,6 +210,7 @@ EcallStatus RevCore::ECALL_fgetxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fgetxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -202,6 +219,7 @@ EcallStatus RevCore::ECALL_listxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: listxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -210,6 +228,7 @@ EcallStatus RevCore::ECALL_llistxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: llistxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -218,6 +237,7 @@ EcallStatus RevCore::ECALL_flistxattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: flistxattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -226,6 +246,7 @@ EcallStatus RevCore::ECALL_removexattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: removexattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -234,6 +255,7 @@ EcallStatus RevCore::ECALL_lremovexattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: lremovexattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -242,6 +264,7 @@ EcallStatus RevCore::ECALL_fremovexattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fremovexattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -264,6 +287,7 @@ EcallStatus RevCore::ECALL_lookup_dcookie() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: lookup_dcookie called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -272,6 +296,7 @@ EcallStatus RevCore::ECALL_eventfd2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: eventfd2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -280,6 +305,7 @@ EcallStatus RevCore::ECALL_epoll_create1() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: epoll_create1 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -288,6 +314,7 @@ EcallStatus RevCore::ECALL_epoll_ctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: epoll_ctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -296,11 +323,13 @@ EcallStatus RevCore::ECALL_epoll_pwait() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: epoll_pwait called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
 // 23, rev_dup(unsigned int fildes)
 EcallStatus RevCore::ECALL_dup() {
+  UNIMPLEMENTED();
   output->verbose( CALL_INFO, 2, 0, "ECALL: dup called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID );
   return EcallStatus::SUCCESS;
 }
@@ -310,6 +339,7 @@ EcallStatus RevCore::ECALL_dup3() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: dup3 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -318,6 +348,7 @@ EcallStatus RevCore::ECALL_fcntl64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fcntl64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -326,6 +357,7 @@ EcallStatus RevCore::ECALL_inotify_init1() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: inotify_init1 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -334,6 +366,7 @@ EcallStatus RevCore::ECALL_inotify_add_watch() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: inotify_add_watch called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -342,6 +375,7 @@ EcallStatus RevCore::ECALL_inotify_rm_watch() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: inotify_rm_watch called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -350,6 +384,7 @@ EcallStatus RevCore::ECALL_ioctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ioctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -358,6 +393,7 @@ EcallStatus RevCore::ECALL_ioprio_set() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ioprio_set called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -366,6 +402,7 @@ EcallStatus RevCore::ECALL_ioprio_get() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ioprio_get called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -374,6 +411,7 @@ EcallStatus RevCore::ECALL_flock() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: flock called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -382,6 +420,7 @@ EcallStatus RevCore::ECALL_mknodat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mknodat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -412,6 +451,7 @@ EcallStatus RevCore::ECALL_unlinkat() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -420,6 +460,7 @@ EcallStatus RevCore::ECALL_symlinkat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: symlinkat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -428,6 +469,7 @@ EcallStatus RevCore::ECALL_linkat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: linkat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -436,6 +478,7 @@ EcallStatus RevCore::ECALL_renameat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: renameat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -444,6 +487,7 @@ EcallStatus RevCore::ECALL_umount() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: umount called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -452,6 +496,7 @@ EcallStatus RevCore::ECALL_mount() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mount called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -460,6 +505,7 @@ EcallStatus RevCore::ECALL_pivot_root() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pivot_root called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -468,6 +514,7 @@ EcallStatus RevCore::ECALL_ni_syscall() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ni_syscall called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -476,6 +523,7 @@ EcallStatus RevCore::ECALL_statfs64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: statfs64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -484,6 +532,7 @@ EcallStatus RevCore::ECALL_fstatfs64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fstatfs64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -492,6 +541,7 @@ EcallStatus RevCore::ECALL_truncate64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: truncate64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -500,6 +550,7 @@ EcallStatus RevCore::ECALL_ftruncate64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ftruncate64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -508,6 +559,7 @@ EcallStatus RevCore::ECALL_fallocate() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fallocate called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -516,6 +568,7 @@ EcallStatus RevCore::ECALL_faccessat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: faccessat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -541,6 +594,7 @@ EcallStatus RevCore::ECALL_fchdir() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -549,6 +603,7 @@ EcallStatus RevCore::ECALL_chroot() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: chroot called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -557,6 +612,7 @@ EcallStatus RevCore::ECALL_fchmod() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fchmod called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -565,6 +621,7 @@ EcallStatus RevCore::ECALL_fchmodat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fchmodat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -573,6 +630,7 @@ EcallStatus RevCore::ECALL_fchownat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fchownat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -581,6 +639,7 @@ EcallStatus RevCore::ECALL_fchown() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fchown called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -710,6 +769,7 @@ EcallStatus RevCore::ECALL_vhangup() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: vhangup called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -718,6 +778,7 @@ EcallStatus RevCore::ECALL_pipe2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pipe2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -726,6 +787,7 @@ EcallStatus RevCore::ECALL_quotactl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: quotactl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -734,6 +796,7 @@ EcallStatus RevCore::ECALL_getdents64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getdents64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -863,6 +926,7 @@ EcallStatus RevCore::ECALL_readv() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: readv called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -871,6 +935,7 @@ EcallStatus RevCore::ECALL_writev() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: writev called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -879,6 +944,7 @@ EcallStatus RevCore::ECALL_pread64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pread64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -887,6 +953,7 @@ EcallStatus RevCore::ECALL_pwrite64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pwrite64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -895,6 +962,7 @@ EcallStatus RevCore::ECALL_preadv() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: preadv called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -903,6 +971,7 @@ EcallStatus RevCore::ECALL_pwritev() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pwritev called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -911,6 +980,7 @@ EcallStatus RevCore::ECALL_sendfile64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sendfile64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -919,6 +989,7 @@ EcallStatus RevCore::ECALL_pselect6_time32() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pselect6_time32 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -927,6 +998,7 @@ EcallStatus RevCore::ECALL_ppoll_time32() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ppoll_time32 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -935,6 +1007,7 @@ EcallStatus RevCore::ECALL_signalfd4() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: signalfd4 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -943,6 +1016,7 @@ EcallStatus RevCore::ECALL_vmsplice() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: vmsplice called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -951,12 +1025,14 @@ EcallStatus RevCore::ECALL_splice() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: splice called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
 // 77, rev_tee(int fdin, int fdout, size_t len, unsigned int flags)
 EcallStatus RevCore::ECALL_tee() {
   output->verbose( CALL_INFO, 2, 0, "ECALL: tee called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -965,6 +1041,7 @@ EcallStatus RevCore::ECALL_readlinkat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: readlinkat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -973,6 +1050,7 @@ EcallStatus RevCore::ECALL_newfstatat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: newfstatat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -981,6 +1059,7 @@ EcallStatus RevCore::ECALL_newfstat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: newfstat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -989,6 +1068,7 @@ EcallStatus RevCore::ECALL_sync() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sync called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -997,6 +1077,7 @@ EcallStatus RevCore::ECALL_fsync() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fsync called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1005,6 +1086,7 @@ EcallStatus RevCore::ECALL_fdatasync() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fdatasync called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1013,6 +1095,7 @@ EcallStatus RevCore::ECALL_sync_file_range2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sync_file_range2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1021,6 +1104,7 @@ EcallStatus RevCore::ECALL_sync_file_range() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sync_file_range called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1029,6 +1113,7 @@ EcallStatus RevCore::ECALL_timerfd_create() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timerfd_create called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1037,6 +1122,7 @@ EcallStatus RevCore::ECALL_timerfd_settime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timerfd_settime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1045,6 +1131,7 @@ EcallStatus RevCore::ECALL_timerfd_gettime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timerfd_gettime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1053,6 +1140,7 @@ EcallStatus RevCore::ECALL_utimensat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: utimensat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1061,6 +1149,7 @@ EcallStatus RevCore::ECALL_acct() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: acct called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1069,6 +1158,7 @@ EcallStatus RevCore::ECALL_capget() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: capget called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1077,6 +1167,7 @@ EcallStatus RevCore::ECALL_capset() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: capset called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1085,6 +1176,7 @@ EcallStatus RevCore::ECALL_personality() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: personality called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1114,6 +1206,7 @@ EcallStatus RevCore::ECALL_exit_group() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: exit_group called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1122,6 +1215,7 @@ EcallStatus RevCore::ECALL_waitid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: waitid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1130,6 +1224,7 @@ EcallStatus RevCore::ECALL_set_tid_address() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: set_tid_address called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1138,6 +1233,7 @@ EcallStatus RevCore::ECALL_unshare() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: unshare called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1146,6 +1242,7 @@ EcallStatus RevCore::ECALL_futex() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: futex called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1154,6 +1251,7 @@ EcallStatus RevCore::ECALL_set_robust_list() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: set_robust_list called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1162,6 +1260,7 @@ EcallStatus RevCore::ECALL_get_robust_list() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: get_robust_list called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1170,6 +1269,7 @@ EcallStatus RevCore::ECALL_nanosleep() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: nanosleep called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1178,6 +1278,7 @@ EcallStatus RevCore::ECALL_getitimer() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getitimer called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1186,6 +1287,7 @@ EcallStatus RevCore::ECALL_setitimer() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setitimer called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1194,6 +1296,7 @@ EcallStatus RevCore::ECALL_kexec_load() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: kexec_load called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1202,6 +1305,7 @@ EcallStatus RevCore::ECALL_init_module() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: init_module called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1210,6 +1314,7 @@ EcallStatus RevCore::ECALL_delete_module() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: delete_module called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1218,6 +1323,7 @@ EcallStatus RevCore::ECALL_timer_create() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timer_create called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1226,6 +1332,7 @@ EcallStatus RevCore::ECALL_timer_gettime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timer_gettime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1234,6 +1341,7 @@ EcallStatus RevCore::ECALL_timer_getoverrun() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timer_getoverrun called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1242,6 +1350,7 @@ EcallStatus RevCore::ECALL_timer_settime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timer_settime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1250,6 +1359,7 @@ EcallStatus RevCore::ECALL_timer_delete() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: timer_delete called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1258,6 +1368,7 @@ EcallStatus RevCore::ECALL_clock_settime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: clock_settime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1286,6 +1397,7 @@ EcallStatus RevCore::ECALL_clock_getres() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: clock_getres called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1294,6 +1406,7 @@ EcallStatus RevCore::ECALL_clock_nanosleep() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: clock_nanosleep called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1302,6 +1415,7 @@ EcallStatus RevCore::ECALL_syslog() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: syslog called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1310,6 +1424,7 @@ EcallStatus RevCore::ECALL_ptrace() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: ptrace called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1318,6 +1433,7 @@ EcallStatus RevCore::ECALL_sched_setparam() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_setparam called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1326,6 +1442,7 @@ EcallStatus RevCore::ECALL_sched_setscheduler() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_setscheduler called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1334,6 +1451,7 @@ EcallStatus RevCore::ECALL_sched_getscheduler() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_getscheduler called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1342,6 +1460,7 @@ EcallStatus RevCore::ECALL_sched_getparam() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_getparam called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1350,6 +1469,7 @@ EcallStatus RevCore::ECALL_sched_setaffinity() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_setaffinity called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1358,6 +1478,7 @@ EcallStatus RevCore::ECALL_sched_getaffinity() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_getaffinity called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1366,6 +1487,7 @@ EcallStatus RevCore::ECALL_sched_yield() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_yield called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1379,6 +1501,7 @@ EcallStatus RevCore::ECALL_sched_get_priority_max() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1392,6 +1515,7 @@ EcallStatus RevCore::ECALL_sched_get_priority_min() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1400,6 +1524,7 @@ EcallStatus RevCore::ECALL_sched_rr_get_interval() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_rr_get_interval called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1408,6 +1533,7 @@ EcallStatus RevCore::ECALL_restart_syscall() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: restart_syscall called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1416,6 +1542,7 @@ EcallStatus RevCore::ECALL_kill() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: kill called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1424,6 +1551,7 @@ EcallStatus RevCore::ECALL_tkill() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: tkill called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1432,6 +1560,7 @@ EcallStatus RevCore::ECALL_tgkill() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: tgkill called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1440,6 +1569,7 @@ EcallStatus RevCore::ECALL_sigaltstack() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sigaltstack called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1448,6 +1578,7 @@ EcallStatus RevCore::ECALL_rt_sigsuspend() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_sigsuspend called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1456,6 +1587,7 @@ EcallStatus RevCore::ECALL_rt_sigaction() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_sigaction called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1464,6 +1596,7 @@ EcallStatus RevCore::ECALL_rt_sigprocmask() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_sigprocmask called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1472,6 +1605,7 @@ EcallStatus RevCore::ECALL_rt_sigpending() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_sigpending called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1485,6 +1619,7 @@ EcallStatus RevCore::ECALL_rt_sigtimedwait_time32() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1493,6 +1628,7 @@ EcallStatus RevCore::ECALL_rt_sigqueueinfo() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_sigqueueinfo called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1501,6 +1637,7 @@ EcallStatus RevCore::ECALL_setpriority() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setpriority called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1509,6 +1646,7 @@ EcallStatus RevCore::ECALL_getpriority() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getpriority called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1517,6 +1655,7 @@ EcallStatus RevCore::ECALL_reboot() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: reboot called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1525,6 +1664,7 @@ EcallStatus RevCore::ECALL_setregid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setregid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1533,6 +1673,7 @@ EcallStatus RevCore::ECALL_setgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1541,6 +1682,7 @@ EcallStatus RevCore::ECALL_setreuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setreuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1549,6 +1691,7 @@ EcallStatus RevCore::ECALL_setuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1557,6 +1700,7 @@ EcallStatus RevCore::ECALL_setresuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setresuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1565,6 +1709,7 @@ EcallStatus RevCore::ECALL_getresuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getresuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1573,6 +1718,7 @@ EcallStatus RevCore::ECALL_setresgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setresgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1581,6 +1727,7 @@ EcallStatus RevCore::ECALL_getresgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getresgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1589,6 +1736,7 @@ EcallStatus RevCore::ECALL_setfsuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setfsuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1597,6 +1745,7 @@ EcallStatus RevCore::ECALL_setfsgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setfsgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1605,6 +1754,7 @@ EcallStatus RevCore::ECALL_times() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: times called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1613,6 +1763,7 @@ EcallStatus RevCore::ECALL_setpgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setpgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1621,6 +1772,7 @@ EcallStatus RevCore::ECALL_getpgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getpgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1629,6 +1781,7 @@ EcallStatus RevCore::ECALL_getsid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getsid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1637,6 +1790,7 @@ EcallStatus RevCore::ECALL_setsid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setsid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1645,6 +1799,7 @@ EcallStatus RevCore::ECALL_getgroups() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getgroups called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1653,6 +1808,7 @@ EcallStatus RevCore::ECALL_setgroups() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setgroups called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1661,6 +1817,7 @@ EcallStatus RevCore::ECALL_newuname() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: newuname called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1669,6 +1826,7 @@ EcallStatus RevCore::ECALL_sethostname() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sethostname called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1677,6 +1835,7 @@ EcallStatus RevCore::ECALL_setdomainname() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setdomainname called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1685,6 +1844,7 @@ EcallStatus RevCore::ECALL_getrlimit() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getrlimit called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1693,6 +1853,7 @@ EcallStatus RevCore::ECALL_setrlimit() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setrlimit called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1701,6 +1862,7 @@ EcallStatus RevCore::ECALL_getrusage() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getrusage called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1709,6 +1871,7 @@ EcallStatus RevCore::ECALL_umask() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: umask called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1717,6 +1880,7 @@ EcallStatus RevCore::ECALL_prctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: prctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1725,6 +1889,7 @@ EcallStatus RevCore::ECALL_getcpu() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getcpu called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1733,6 +1898,7 @@ EcallStatus RevCore::ECALL_gettimeofday() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: gettimeofday called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1741,6 +1907,7 @@ EcallStatus RevCore::ECALL_settimeofday() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: settimeofday called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1749,12 +1916,14 @@ EcallStatus RevCore::ECALL_adjtimex() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: adjtimex called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
 // 172, rev_getpid(void)
 EcallStatus RevCore::ECALL_getpid() {
   output->verbose( CALL_INFO, 2, 0, "ECALL: getpid called (Rev only supports a single process)\n" );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1767,6 +1936,7 @@ EcallStatus RevCore::ECALL_getppid() {
 
     "ECALL: getppid called (Rev only supports a single process)\n"
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1781,6 +1951,7 @@ EcallStatus RevCore::ECALL_getuid() {
     ActiveThreadID,
     HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1789,6 +1960,7 @@ EcallStatus RevCore::ECALL_geteuid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: geteuid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1797,6 +1969,7 @@ EcallStatus RevCore::ECALL_getgid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getgid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1805,6 +1978,7 @@ EcallStatus RevCore::ECALL_getegid() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getegid called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1824,6 +1998,7 @@ EcallStatus RevCore::ECALL_sysinfo() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sysinfo called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1832,6 +2007,7 @@ EcallStatus RevCore::ECALL_mq_open() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_open called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1840,6 +2016,7 @@ EcallStatus RevCore::ECALL_mq_unlink() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_unlink called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1848,6 +2025,7 @@ EcallStatus RevCore::ECALL_mq_timedsend() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_timedsend called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1856,6 +2034,7 @@ EcallStatus RevCore::ECALL_mq_timedreceive() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_timedreceive called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1864,6 +2043,7 @@ EcallStatus RevCore::ECALL_mq_notify() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_notify called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1872,6 +2052,7 @@ EcallStatus RevCore::ECALL_mq_getsetattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mq_getsetattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1880,6 +2061,7 @@ EcallStatus RevCore::ECALL_msgget() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: msgget called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1888,6 +2070,7 @@ EcallStatus RevCore::ECALL_msgctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: msgctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1896,6 +2079,7 @@ EcallStatus RevCore::ECALL_msgrcv() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: msgrcv called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1904,6 +2088,7 @@ EcallStatus RevCore::ECALL_msgsnd() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: msgsnd called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1912,6 +2097,7 @@ EcallStatus RevCore::ECALL_semget() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: semget called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1920,6 +2106,7 @@ EcallStatus RevCore::ECALL_semctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: semctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1928,6 +2115,7 @@ EcallStatus RevCore::ECALL_semtimedop() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: semtimedop called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1936,6 +2124,7 @@ EcallStatus RevCore::ECALL_semop() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: semop called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1944,6 +2133,7 @@ EcallStatus RevCore::ECALL_shmget() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: shmget called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1952,6 +2142,7 @@ EcallStatus RevCore::ECALL_shmctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: shmctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1960,6 +2151,7 @@ EcallStatus RevCore::ECALL_shmat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: shmat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1968,6 +2160,7 @@ EcallStatus RevCore::ECALL_shmdt() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: shmdt called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1976,6 +2169,7 @@ EcallStatus RevCore::ECALL_socket() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: socket called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1984,6 +2178,7 @@ EcallStatus RevCore::ECALL_socketpair() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: socketpair called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -1992,6 +2187,7 @@ EcallStatus RevCore::ECALL_bind() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: bind called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2000,6 +2196,7 @@ EcallStatus RevCore::ECALL_listen() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: listen called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2008,6 +2205,7 @@ EcallStatus RevCore::ECALL_accept() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: accept called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2016,6 +2214,7 @@ EcallStatus RevCore::ECALL_connect() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: connect called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2024,6 +2223,7 @@ EcallStatus RevCore::ECALL_getsockname() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getsockname called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2032,6 +2232,7 @@ EcallStatus RevCore::ECALL_getpeername() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getpeername called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2040,6 +2241,7 @@ EcallStatus RevCore::ECALL_sendto() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sendto called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2048,6 +2250,7 @@ EcallStatus RevCore::ECALL_recvfrom() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: recvfrom called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2056,6 +2259,7 @@ EcallStatus RevCore::ECALL_setsockopt() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setsockopt called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2064,6 +2268,7 @@ EcallStatus RevCore::ECALL_getsockopt() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getsockopt called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2072,6 +2277,7 @@ EcallStatus RevCore::ECALL_shutdown() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: shutdown called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2080,6 +2286,7 @@ EcallStatus RevCore::ECALL_sendmsg() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sendmsg called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2088,6 +2295,7 @@ EcallStatus RevCore::ECALL_recvmsg() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: recvmsg called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2096,6 +2304,7 @@ EcallStatus RevCore::ECALL_readahead() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: readahead called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2146,6 +2355,7 @@ EcallStatus RevCore::ECALL_mremap() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mremap called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2154,6 +2364,7 @@ EcallStatus RevCore::ECALL_add_key() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: add_key called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2162,6 +2373,7 @@ EcallStatus RevCore::ECALL_request_key() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: request_key called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2170,6 +2382,7 @@ EcallStatus RevCore::ECALL_keyctl() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: keyctl called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2329,6 +2542,7 @@ EcallStatus RevCore::ECALL_execve() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: execve called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2365,6 +2579,7 @@ EcallStatus RevCore::ECALL_fadvise64_64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fadvise64_64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2373,6 +2588,7 @@ EcallStatus RevCore::ECALL_swapon() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: swapon called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2381,6 +2597,7 @@ EcallStatus RevCore::ECALL_swapoff() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: swapoff called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2389,6 +2606,7 @@ EcallStatus RevCore::ECALL_mprotect() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mprotect called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2397,6 +2615,7 @@ EcallStatus RevCore::ECALL_msync() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: msync called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2405,6 +2624,7 @@ EcallStatus RevCore::ECALL_mlock() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mlock called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2413,6 +2633,7 @@ EcallStatus RevCore::ECALL_munlock() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: munlock called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2421,6 +2642,7 @@ EcallStatus RevCore::ECALL_mlockall() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mlockall called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2429,6 +2651,7 @@ EcallStatus RevCore::ECALL_munlockall() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: munlockall called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2437,6 +2660,7 @@ EcallStatus RevCore::ECALL_mincore() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mincore called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2445,6 +2669,7 @@ EcallStatus RevCore::ECALL_madvise() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: madvise called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2453,6 +2678,7 @@ EcallStatus RevCore::ECALL_remap_file_pages() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: remap_file_pages called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2461,6 +2687,7 @@ EcallStatus RevCore::ECALL_mbind() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mbind called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2469,6 +2696,7 @@ EcallStatus RevCore::ECALL_get_mempolicy() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: get_mempolicy called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2477,6 +2705,7 @@ EcallStatus RevCore::ECALL_set_mempolicy() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: set_mempolicy called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2485,6 +2714,7 @@ EcallStatus RevCore::ECALL_migrate_pages() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: migrate_pages called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2493,6 +2723,7 @@ EcallStatus RevCore::ECALL_move_pages() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: move_pages called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2501,6 +2732,7 @@ EcallStatus RevCore::ECALL_rt_tgsigqueueinfo() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rt_tgsigqueueinfo called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2509,6 +2741,7 @@ EcallStatus RevCore::ECALL_perf_event_open() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: perf_event_open called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2517,6 +2750,7 @@ EcallStatus RevCore::ECALL_accept4() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: accept4 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2525,6 +2759,7 @@ EcallStatus RevCore::ECALL_recvmmsg_time32() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: recvmmsg_time32 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2533,6 +2768,7 @@ EcallStatus RevCore::ECALL_wait4() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: wait4 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2541,6 +2777,7 @@ EcallStatus RevCore::ECALL_prlimit64() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: prlimit64 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2549,6 +2786,7 @@ EcallStatus RevCore::ECALL_fanotify_init() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fanotify_init called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2557,6 +2795,7 @@ EcallStatus RevCore::ECALL_fanotify_mark() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fanotify_mark called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2565,6 +2804,7 @@ EcallStatus RevCore::ECALL_name_to_handle_at() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: name_to_handle_at called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2573,6 +2813,7 @@ EcallStatus RevCore::ECALL_open_by_handle_at() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: open_by_handle_at called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2581,6 +2822,7 @@ EcallStatus RevCore::ECALL_clock_adjtime() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: clock_adjtime called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2589,6 +2831,7 @@ EcallStatus RevCore::ECALL_syncfs() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: syncfs called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2597,6 +2840,7 @@ EcallStatus RevCore::ECALL_setns() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: setns called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2605,6 +2849,7 @@ EcallStatus RevCore::ECALL_sendmmsg() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sendmmsg called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2613,6 +2858,7 @@ EcallStatus RevCore::ECALL_process_vm_readv() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: process_vm_readv called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2622,6 +2868,7 @@ EcallStatus RevCore::ECALL_process_vm_writev() {
     CALL_INFO, 2, 0, "ECALL: process_vm_writev called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
 
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2630,6 +2877,7 @@ EcallStatus RevCore::ECALL_kcmp() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: kcmp called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2638,6 +2886,7 @@ EcallStatus RevCore::ECALL_finit_module() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: finit_module called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2646,6 +2895,7 @@ EcallStatus RevCore::ECALL_sched_setattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_setattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2654,6 +2904,7 @@ EcallStatus RevCore::ECALL_sched_getattr() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: sched_getattr called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2662,6 +2913,7 @@ EcallStatus RevCore::ECALL_renameat2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: renameat2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2670,6 +2922,7 @@ EcallStatus RevCore::ECALL_seccomp() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: seccomp called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2678,6 +2931,7 @@ EcallStatus RevCore::ECALL_getrandom() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: getrandom called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2686,11 +2940,13 @@ EcallStatus RevCore::ECALL_memfd_create() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: memfd_create called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
 // 280, rev_bpf(int cmd, union bpf_attr *attr, unsigned int size)
 EcallStatus RevCore::ECALL_bpf() {
+  UNIMPLEMENTED();
   output->verbose( CALL_INFO, 2, 0, "ECALL: bpf called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID );
   return EcallStatus::SUCCESS;
 }
@@ -2700,6 +2956,7 @@ EcallStatus RevCore::ECALL_execveat() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: execveat called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2708,6 +2965,7 @@ EcallStatus RevCore::ECALL_userfaultfd() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: userfaultfd called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2716,6 +2974,7 @@ EcallStatus RevCore::ECALL_membarrier() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: membarrier called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2724,6 +2983,7 @@ EcallStatus RevCore::ECALL_mlock2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: mlock2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2732,6 +2992,7 @@ EcallStatus RevCore::ECALL_copy_file_range() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: copy_file_range called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2740,6 +3001,7 @@ EcallStatus RevCore::ECALL_preadv2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: preadv2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2748,6 +3010,7 @@ EcallStatus RevCore::ECALL_pwritev2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pwritev2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2756,6 +3019,7 @@ EcallStatus RevCore::ECALL_pkey_mprotect() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pkey_mprotect called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2764,6 +3028,7 @@ EcallStatus RevCore::ECALL_pkey_alloc() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pkey_alloc called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2772,6 +3037,7 @@ EcallStatus RevCore::ECALL_pkey_free() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pkey_free called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2780,6 +3046,7 @@ EcallStatus RevCore::ECALL_statx() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: statx called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2788,6 +3055,7 @@ EcallStatus RevCore::ECALL_io_pgetevents() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_pgetevents called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2796,6 +3064,7 @@ EcallStatus RevCore::ECALL_rseq() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: rseq called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2804,6 +3073,7 @@ EcallStatus RevCore::ECALL_kexec_file_load() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: kexec_file_load called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2941,6 +3211,7 @@ EcallStatus RevCore::ECALL_pidfd_send_signal() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pidfd_send_signal called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2949,6 +3220,7 @@ EcallStatus RevCore::ECALL_io_uring_setup() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_uring_setup called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2957,6 +3229,7 @@ EcallStatus RevCore::ECALL_io_uring_enter() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_uring_enter called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2965,6 +3238,7 @@ EcallStatus RevCore::ECALL_io_uring_register() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: io_uring_register called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2973,6 +3247,7 @@ EcallStatus RevCore::ECALL_open_tree() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: open_tree called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2981,6 +3256,7 @@ EcallStatus RevCore::ECALL_move_mount() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: move_mount called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2989,6 +3265,7 @@ EcallStatus RevCore::ECALL_fsopen() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fsopen called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -2997,6 +3274,7 @@ EcallStatus RevCore::ECALL_fsconfig() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fsconfig called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3005,6 +3283,7 @@ EcallStatus RevCore::ECALL_fsmount() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fsmount called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3013,6 +3292,7 @@ EcallStatus RevCore::ECALL_fspick() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: fspick called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3021,6 +3301,7 @@ EcallStatus RevCore::ECALL_pidfd_open() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pidfd_open called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3180,6 +3461,7 @@ EcallStatus RevCore::ECALL_close_range() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: close_range called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3188,6 +3470,7 @@ EcallStatus RevCore::ECALL_openat2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: openat2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3196,6 +3479,7 @@ EcallStatus RevCore::ECALL_pidfd_getfd() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: pidfd_getfd called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3204,6 +3488,7 @@ EcallStatus RevCore::ECALL_faccessat2() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: faccessat2 called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 
@@ -3212,6 +3497,7 @@ EcallStatus RevCore::ECALL_process_madvise() {
   output->verbose(
     CALL_INFO, 2, 0, "ECALL: process_madvise called by thread %" PRIu32 " on hart %" PRIu32 "\n", ActiveThreadID, HartToExecID
   );
+  UNIMPLEMENTED();
   return EcallStatus::SUCCESS;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # RevCPU test/CMakeLists.txt
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -60,7 +60,7 @@ else()
 endif()
 
 set (passRegex "Simulation is complete")
-
+set (failRegex "[^A-Za-z_0-9][Ee][Rr][Rr][Oo][Rr][^A-Za-z_0-9]")
 
 #------- TESTS  ---------------
 message(STATUS "CTest Setup")
@@ -174,6 +174,7 @@ macro(add_rev_test test_name test_dir timeout labels)
           ENVIRONMENT "RVCC=${RVCC};RVCXX=${RVCXX}"
           TIMEOUT ${timeout}
           PASS_REGULAR_EXPRESSION "${passRegex}"
+	  FAIL_REGULAR_EXPRESSION "${failRegex}"
           LABELS "${labels}"
 	)
         if(add_memh_test)
@@ -182,6 +183,7 @@ macro(add_rev_test test_name test_dir timeout labels)
             ENVIRONMENT "RVCC=${RVCC};RVCXX=${RVCXX}"
             TIMEOUT ${timeout}
             PASS_REGULAR_EXPRESSION "${passRegex}"
+	    FAIL_REGULAR_EXPRESSION "${failRegex}"
             LABELS "${labels}"
           )
         endif()
@@ -206,6 +208,7 @@ macro(add_rev_test test_name test_dir timeout labels)
       ENVIRONMENT "RVCC=${RVCC};RVCXX=${RVCXX}"
       TIMEOUT ${timeout}
       PASS_REGULAR_EXPRESSION "${passRegex}"
+      FAIL_REGULAR_EXPRESSION "${failRegex}"
       LABELS "${labels}"
     )
     if(((NOT ${rv32_label_index} EQUAL -1) AND DEFINED RV32_DISABLED) OR test_level GREATER TEST_LEVEL)

--- a/test/rev-model-options-config.py
+++ b/test/rev-model-options-config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -29,7 +29,7 @@ parser.add_argument("--verbose", type=int, help="Verbosity level", default=2)
 parser.add_argument("--machine", help="Machine type/configuration", default="[CORES:RV64GC]")
 parser.add_argument("--args", help="Command line arguments to pass to the target executable", default="")
 parser.add_argument("--startSymbol", help="ELF Symbol Rev should begin execution at", default="[0:main]")
-parser.add_argument("--trcStartCycle", help="Starting cycle for rev tracer [default: 0 (off)]")
+parser.add_argument("--trcStartCycle", help="Starting cycle for rev tracer [default: 0 (off)]", default=0)
 parser.add_argument("--trcLimit", help="Max trace records per core [default: 0 (no limit)]", default=0)
 parser.add_argument("--statDir", help="Location for statistics files", default=".")
 


### PR DESCRIPTION
The majority of ecall routines perform no operation but return 'SUCCESS'. This can lead to a false sense of security when writing RV code for REV that that does system calls that are essentially NOPs.  This PR provides a compile time overridable macro to print an error string for these ECALLs.  Originally I was going to make this a fatal error but it would have required adding a compile pragma to suppress the 'maybe no return' compiler warning. Also, I thought other projects might be running code with a rich mix of 'NOP' system calls that would not appreciate these kinds of failures.  In the worst case, we can revert to NOP functionality using  CMAKE_CXX_FLAGS = -D _REV_ECALL_OVERRIDE.

For regression testing, the test/CMakeList.txt was updated to provide a fail regular expression that detects these kinds of error strings. I ran the regressions on Ubuntu and MacOs as well as for both Debug and Release compilations and all current tests continue to pass.


I should also mention that the error string check is added to allow self checking tests to print error strings to the log file (standing for console output for now) and generate a regression test failure that is independent from the simulation return status code 