### PR TITLE
Disable instruction prefetch when ecalls are executing

### DIFF
--- a/include/RevRegFile.h
+++ b/include/RevRegFile.h
@@ -1,7 +1,7 @@
 //
 // _RevRegFile_h_
 //
-// Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+// Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 // All Rights Reserved
 // contact@tactcomplabs.com
 //
@@ -268,6 +268,9 @@ public:
 
   /// Get the exception cause
   RevExceptionCause GetSCAUSE() const { return SCAUSE; }
+
+  /// Check if exception is active. Currently only ECALL_USER_MODE supported
+  bool isExceptionActive() const { return SCAUSE == RevExceptionCause::ECALL_USER_MODE; }
 
   /// GetX: Get the specifed X register cast to a specific integral type
   template<typename T, typename U>

--- a/src/RevCore.cc
+++ b/src/RevCore.cc
@@ -1656,8 +1656,8 @@ bool RevCore::ClockTick( SST::Cycle_t currentCycle ) {
 
     feature->SetHartToExecID( HartToDecodeID );
 
-    // fetch the next instruction
-    if( !PrefetchInst() ) {
+    // fetch the next instruction unless exception is active
+    if( !PrefetchInst() || RegFile->isExceptionActive() ) {
       Stalled = true;
       Stats.cyclesStalled++;
     } else {
@@ -1950,7 +1950,7 @@ void RevCore::CreateThread( uint32_t NewTID, uint64_t firstPC, void* arg ) {
 //
 // Returns true if an ECALL is in progress
 bool RevCore::ExecEcall() {
-  if( RegFile->GetSCAUSE() != RevExceptionCause::ECALL_USER_MODE )
+  if( !RegFile->isExceptionActive() )
     return false;
 
   // ECALL in progress

--- a/src/RevSysCalls.cc
+++ b/src/RevSysCalls.cc
@@ -1202,12 +1202,19 @@ EcallStatus RevCore::ECALL_exit() {
     CALL_INFO,
     0,
     0,
-    "thread %" PRIu32 " on hart %" PRIu32 "exiting with"
+    "thread %" PRIu32 " on hart %" PRIu32 " exiting with"
     " status %" PRIu64 "\n",
     ActiveThreadID,
     HartToExecID,
     status
   );
+  // TODO exit shuts down the sst process which circumvents the
+  //      component lifecycle and overrides sst status code. We
+  //      should instead indicate the simulated component is finished
+  //      and let sst shutdown cleanly. The status code from REV is
+  //      printed to the log file for post-processing. We can support
+  //      testing by providing on option to 'fatal' out when status
+  //      is not 0 (or a user desired value if non-zero is expected)
   exit( int( status ) );
   // return EcallStatus::SUCCESS;
 }

--- a/test/syscalls/CMakeLists.txt
+++ b/test/syscalls/CMakeLists.txt
@@ -7,3 +7,6 @@ add_rev_test(GETCWD getcwd 30 "rv64;syscalls;memh")
 add_rev_test(MUNMAP munmap 30 "rv64;syscalls;memh")
 add_rev_test(PERF_STATS perf_stats 30 "test_level=2;rv64;syscalls;memh")
 add_rev_test(MEM_DUMP_SYSCALLS mem_dump_syscalls 30 "test_level=2;rv64;syscalls")
+# exit test does not currently produce required 'Simulation is complete' message
+# manually run using `cd exit && make clean run`
+# add_rev_test(EXIT exit 30 "rv64;syscalls;memh")

--- a/test/syscalls/exit/.gitignore
+++ b/test/syscalls/exit/.gitignore
@@ -1,0 +1,4 @@
+*.d
+log
+*.log
+*.bin

--- a/test/syscalls/exit/Makefile
+++ b/test/syscalls/exit/Makefile
@@ -1,0 +1,36 @@
+#
+# Makefile
+#
+# makefile: exit
+#
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+# All Rights Reserved
+# contact@tactcomplabs.com
+#
+# See LICENSE in the top level directory for licensing details
+#
+
+TESTNAME=exit
+
+SOURCES = $(TESTNAME).c
+INCLUDES=
+CCOPTS = -O0 -g3
+
+TARG ?= rev
+
+REV_MACHINE = "CORES:RV64IMAFDC"
+REV_VERBOSE?=0
+
+ifndef REVHOME
+$(error REVHOME is not defined)
+else
+$(info REVHOME is $(REVHOME))
+endif
+
+include $(REVHOME)/test/syscalls/mkinc/common.mk
+
+.PHONY: clean
+clean:
+	rm -f $(TESTNAME).exe $(TESTNAME).d StatisticOutput.csv
+
+#-- EOF

--- a/test/syscalls/exit/exit.c
+++ b/test/syscalls/exit/exit.c
@@ -1,0 +1,51 @@
+/*
+ * exit.c
+ *
+ * Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
+ * All Rights Reserved
+ * contact@tactcomplabs.com
+ *
+ * See LICENSE in the top level directory for licensing details
+ *
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifndef HOST_TARGET
+// REV fast printf and tracing macros
+#include "rev-macros.h"
+#include "syscalls.h"
+#define printf rev_fast_printf
+#undef assert
+#define assert TRACE_ASSERT
+#else
+#include <stdlib.h>
+#define TRACE_ON
+#define TRACE_OFF
+#endif
+
+#define xstr( s ) str( s )
+#define str( s )  #s
+
+int main() {
+
+#ifdef HOST_TARGET
+  exit( 0 );
+  assert( 0 );
+#else
+  TRACE_ON;
+  asm volatile( "li a0, 0" );   // exit code to return
+  asm volatile( "li a7, 93" );  // exit ecall number
+  asm volatile( "ecall" );
+#if 0
+  asm volatile ("add x0,x0,x0");
+#else
+  asm volatile( ".word 0x0" );  // crashes sim if prefetched
+#endif
+  TRACE_OFF;
+#endif
+  return 1;
+}


### PR DESCRIPTION
This PR is motivate by a bug where an illegal instruction is positioned after an 'exit' system call which is prefetched, decoded and fails the simulation. My claim is that ECALLS themselves should not be pipelined at all. Since, in reality, these calls are themselves comprised of code which may need to execute at a different protection level and could affect system behavior. 

The general fix implemented here is to simply not allow instruction prefetching when an ecall is executing.

One caveat noted in the comments is that I would like to change the way 'exit' is handled in REV in general. I will open a separate PR to define this and flush out the details.
