### PR TITLE
Provide build and run flow for spike, rev, and host

### DIFF
--- a/test/syscalls/.gitignore
+++ b/test/syscalls/.gitignore
@@ -1,2 +1,4 @@
 *.tmp
 *.dSYM
+*.spike
+*.d

--- a/test/syscalls/mkinc/common.mk
+++ b/test/syscalls/mkinc/common.mk
@@ -20,6 +20,10 @@ else
 $(error unknown TARG $(TARG))
 endif
 
+.PHONY: clean
+clean:
+	rm -f $(TESTNAME).exe $(TESTNAME).d StatisticOutput.csv $(TESTNAME).spike
+
 .PHONY: help
 help:
 	@echo "# REV defaults"
@@ -27,6 +31,6 @@ help:
 	@echo "make clean run"
 	@echo "# Alternate targets"
 	@echo "make TARG=host clean run"
-	@echo "TODO make TARG=spike clean run"
+	@echo "make TARG=spike clean run"
 
 #-- EOF

--- a/test/syscalls/mkinc/rev.mk
+++ b/test/syscalls/mkinc/rev.mk
@@ -9,7 +9,7 @@
 #
 
 ifndef REVHOME
-$(error REVHOME not defined)
+ $(error REVHOME not defined)
 endif
 
 REV_ARCH ?= rv64imafdc
@@ -24,6 +24,7 @@ CC="${RVCC}"
 CCOPTS += -march=$(REV_ARCH) $(INCLUDES)
 CCOPTS += -I$(REVHOME)/common/syscalls
 CCOPTS += -I$(REVHOME)/test/include
+CCOPTS += -DREV_TARGET
 
 .PHONY: run
 

--- a/test/syscalls/mkinc/spike.mk
+++ b/test/syscalls/mkinc/spike.mk
@@ -8,6 +8,42 @@
 # See LICENSE in the top level directory for licensing details
 #
 
-$(error SPIKE NOT SUPPORTED YET)
+SPIKE ?= spike
+
+ifeq (, $(shell which $(SPIKE)))
+ $(error $(SPIKE) not found)
+endif
+
+SPIKE_ARCH ?= rv64imafdc
+
+CC="${RVCC}"
+CCOPTS += -march=$(SPIKE_ARCH) $(INCLUDES)
+CCOPTS += -I$(REVHOME)/common/syscalls
+CCOPTS += -I$(REVHOME)/test/include
+CCOPTS += -DSPIKE_TARGET
+
+.PHONY: run
+
+all: $(TESTNAME).exe
+
+STATIC = -static
+$(TESTNAME).exe: $(SOURCES)
+	$(CC) $(CCOPTS) -o $(TESTNAME).exe $^ $(STATIC)
+
+ifdef RVOBJDUMP
+all: $(TESTNAME).d
+$(TESTNAME).d: $(TESTNAME).exe
+	$(RVOBJDUMP) -dC -Mno-aliases --source $< > $@
+endif
+
+#SPIKE_OPTS=
+
+run: $(TESTNAME).spike
+
+ifdef ARGS
+ PROG_ARGS = $(ARGS)
+endif
+$(TESTNAME).spike: $(TESTNAME).exe
+	$(SPIKE) $(SPIKE_OPTS) -l --log=$@ --isa=$(SPIKE_ARCH) pk $(TESTNAME).exe $(PROG_ARGS)
 
 #-- EOF

--- a/test/syscalls/open/open.c
+++ b/test/syscalls/open/open.c
@@ -38,7 +38,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifndef HOST_TARGET
+#ifdef REV_TARGET
 // REV fast printf and tracing macros
 #include "rev-macros.h"
 #include "syscalls.h"

--- a/test/syscalls/printf/Makefile
+++ b/test/syscalls/printf/Makefile
@@ -22,14 +22,9 @@ REV_VERBOSE?=0
 
 ifndef REVHOME
 $(error REVHOME is not defined)
-else
-$(info REVHOME is $(REVHOME))
 endif
 
 include $(REVHOME)/test/syscalls/mkinc/common.mk
 
-.PHONY: clean
-clean:
-	rm -f $(TESTNAME).exe $(TESTNAME).d StatisticOutput.csv
 
 #-- EOF

--- a/test/syscalls/printf/printf.c
+++ b/test/syscalls/printf/printf.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifndef HOST_TARGET
+#ifdef REV_TARGET
 #include "rev-macros.h"
 #include "rev-printf.h"
 #undef assert


### PR DESCRIPTION
This is a follow-on PR to #376 and completes the support for running tests on spike ( in addition to rev and host). This is useful in the development of emulated system calls by providing the ability to compare results on different targets. Only two tests are currently using this in the rev repository but the flow is also being used in developing external test suites through the use of the REVHOME environment variable.

Examples:
```
cd test/syscalls/printf
make clean run                          # build and run for  rev
make clean run TARG=host    # build and run for host
make clean run TARG=spike   # build and run for spike
```
Tests may use compile-time flags to differentiate the different targets. 

Specifically:
 REV_TARGET
 HOST_TARGET
 SPIKE_TARGET

The make file is only used by `ctest` for compiling the test for REV so the tests are compatible with the current testing methodology.



