### PR TITLE
Change DumpMem() to work on translated rather than physical addresses 

### DIFF
--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -782,6 +782,8 @@ void RevMem::DumpMem( const uint64_t startAddr, const uint64_t numBytes, const u
     }
     outputStream << std::endl;
   }
+  delete[] printMem;
+  printMem = NULL;
 }
 
 void RevMem::DumpMemSeg( const std::shared_ptr<MemSegment>& MemSeg, const uint64_t bytesPerRow, std::ostream& outputStream ) {

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -183,7 +183,7 @@ void RevMem::AddToTLB( uint64_t vAddr, uint64_t physAddr ) {
     // Insert the vAddr and physAddr into the TLB and LRU list
     LRUQueue.push_front( vAddr );
     TLB.insert( {
-      vAddr, {physAddr, LRUQueue.begin()}
+      vAddr, { physAddr, LRUQueue.begin() }
     } );
   }
 }
@@ -749,26 +749,30 @@ uint64_t RevMem::ExpandHeap( uint64_t Size ) {
 }
 
 void RevMem::DumpMem( const uint64_t startAddr, const uint64_t numBytes, const uint64_t bytesPerRow, std::ostream& outputStream ) {
-  uint64_t       translatedStartAddr = startAddr;             //CalcPhysAddr( 0, startAddr );
-  const uint64_t endAddr             = startAddr + numBytes;  //translatedStartAddr + numBytes;
 
-  for( uint64_t addr = translatedStartAddr; addr < endAddr; addr += bytesPerRow ) {
-    outputStream << "0x" << std::setw( 16 ) << std::setfill( '0' ) << std::hex << addr << ": ";
+  auto [remainder, physAddr, adjPhysAddr] = AdjPageAddr( startAddr, numBytes );
+  uint8_t* printMem                       = new uint8_t[numBytes];
+  memcpy( printMem, &physMem[physAddr], remainder );
+  memcpy( printMem + remainder, &physMem[adjPhysAddr], numBytes - remainder );
+
+  uint64_t virtAddr = startAddr;
+
+  for( uint64_t addr = 0; addr < numBytes; addr += bytesPerRow ) {
+    virtAddr += addr;
+    outputStream << "0x" << std::setw( 16 ) << std::setfill( '0' ) << std::hex << virtAddr << ": ";
 
     for( uint64_t i = 0; i < bytesPerRow; ++i ) {
-      if( addr + i < endAddr ) {
-        uint8_t byte = physMem[addr + i];
+      if( addr + i < numBytes ) {
+        uint8_t byte = printMem[addr + i];
         outputStream << std::setw( 2 ) << std::setfill( '0' ) << std::hex << uint32_t{ byte } << " ";
       } else {
         outputStream << "   ";
       }
     }
-
     outputStream << " ";
-
     for( uint64_t i = 0; i < bytesPerRow; ++i ) {
-      if( addr + i < endAddr ) {
-        uint8_t byte = physMem[addr + i];
+      if( addr + i < numBytes ) {
+        uint8_t byte = printMem[addr + i];
         if( std::isprint( byte ) ) {
           outputStream << static_cast<char>( byte );
         } else {

--- a/src/RevMem.cc
+++ b/src/RevMem.cc
@@ -750,40 +750,44 @@ uint64_t RevMem::ExpandHeap( uint64_t Size ) {
 
 void RevMem::DumpMem( const uint64_t startAddr, const uint64_t numBytes, const uint64_t bytesPerRow, std::ostream& outputStream ) {
 
-  auto [remainder, physAddr, adjPhysAddr] = AdjPageAddr( startAddr, numBytes );
-  uint8_t* printMem                       = new uint8_t[numBytes];
-  memcpy( printMem, &physMem[physAddr], remainder );
-  memcpy( printMem + remainder, &physMem[adjPhysAddr], numBytes - remainder );
+  if( ctrl ) {
+    outputStream << "WARNING: DumpMem() unsupported when MemHierarchy in use" << std::endl;
+  } else {
+    auto [remainder, physAddr, adjPhysAddr] = AdjPageAddr( startAddr, numBytes );
+    uint8_t* printMem                       = new uint8_t[numBytes];
+    memcpy( printMem, &physMem[physAddr], remainder );
+    memcpy( printMem + remainder, &physMem[adjPhysAddr], numBytes - remainder );
 
-  uint64_t virtAddr = startAddr;
+    uint64_t virtAddr = startAddr;
 
-  for( uint64_t addr = 0; addr < numBytes; addr += bytesPerRow ) {
-    virtAddr += addr;
-    outputStream << "0x" << std::setw( 16 ) << std::setfill( '0' ) << std::hex << virtAddr << ": ";
+    for( uint64_t addr = 0; addr < numBytes; addr += bytesPerRow ) {
+      virtAddr += addr;
+      outputStream << "0x" << std::setw( 16 ) << std::setfill( '0' ) << std::hex << virtAddr << ": ";
 
-    for( uint64_t i = 0; i < bytesPerRow; ++i ) {
-      if( addr + i < numBytes ) {
-        uint8_t byte = printMem[addr + i];
-        outputStream << std::setw( 2 ) << std::setfill( '0' ) << std::hex << uint32_t{ byte } << " ";
-      } else {
-        outputStream << "   ";
-      }
-    }
-    outputStream << " ";
-    for( uint64_t i = 0; i < bytesPerRow; ++i ) {
-      if( addr + i < numBytes ) {
-        uint8_t byte = printMem[addr + i];
-        if( std::isprint( byte ) ) {
-          outputStream << static_cast<char>( byte );
+      for( uint64_t i = 0; i < bytesPerRow; ++i ) {
+        if( addr + i < numBytes ) {
+          uint8_t byte = printMem[addr + i];
+          outputStream << std::setw( 2 ) << std::setfill( '0' ) << std::hex << uint32_t{ byte } << " ";
         } else {
-          outputStream << ".";
+          outputStream << "   ";
         }
       }
+      outputStream << " ";
+      for( uint64_t i = 0; i < bytesPerRow; ++i ) {
+        if( addr + i < numBytes ) {
+          uint8_t byte = printMem[addr + i];
+          if( std::isprint( byte ) ) {
+            outputStream << static_cast<char>( byte );
+          } else {
+            outputStream << ".";
+          }
+        }
+      }
+      outputStream << std::endl;
     }
-    outputStream << std::endl;
+    delete[] printMem;
+    printMem = NULL;
   }
-  delete[] printMem;
-  printMem = NULL;
 }
 
 void RevMem::DumpMemSeg( const std::shared_ptr<MemSegment>& MemSeg, const uint64_t bytesPerRow, std::ostream& outputStream ) {

--- a/test/mem_dump/mem_dump.py
+++ b/test/mem_dump/mem_dump.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -75,10 +75,10 @@ comp_cpu.addParams(
         "args": args.args,
         "splash": 1,
         "memDumpRanges": ["range1", "range2"],
-        "range1.startAddr": 0x010000,
-        "range1.size": 0x100000,
-        "range2.startAddr": 0x090000,
-        "range2.size": 0x100,
+        "range1.startAddr": 0x01019c,
+        "range1.size": 0x40,
+        "range2.startAddr": 0x10116,
+        "range2.size": 0x30,
     }
 )
 

--- a/test/syscalls/mem_dump_syscalls/mem_dump.py
+++ b/test/syscalls/mem_dump_syscalls/mem_dump.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2017-2024 Tactical Computing Laboratories, LLC
+# Copyright (C) 2017-2025 Tactical Computing Laboratories, LLC
 # All Rights Reserved
 # contact@tactcomplabs.com
 #
@@ -76,10 +76,10 @@ comp_cpu.addParams(
         "args": args.args,
         "splash": 1,
         "memDumpRanges": ["range1", "range2"],
-        "range1.startAddr": 0x010000,
-        "range1.size": 0x100000,
-        "range2.startAddr": 0x090000,
-        "range2.size": 0x100,
+        "range1.startAddr": 0x11218,
+        "range1.size": 0x40,
+        "range2.startAddr": 0x10116,
+        "range2.size": 0x30,
     }
 )
 

--- a/test/syscalls/mem_dump_syscalls/mem_dump_syscalls.c
+++ b/test/syscalls/mem_dump_syscalls/mem_dump_syscalls.c
@@ -3,8 +3,8 @@
 #include <unistd.h>
 
 int main() {
-  dump_mem_range( 0x50000, 0x55000 );
-  dump_mem_range_to_file( "full_mem_dump.txt", 0, 1024 * 1024 * 10 - 1 );
+  dump_mem_range( 0x10116, 0x10152 );                                //dump _start
+  dump_mem_range_to_file( "full_mem_dump.txt", 0x100e8, 1024 * 9 );  //dump most of the .text segment
   dump_stack_to_file( "stack_dump.txt" );
   dump_stack();
 }


### PR DESCRIPTION
Updated the `DumpMem()` debug function to output based on the translated addresses - the same way `ReadMem()` works in RevMem only.  Previously `DumpMem()` operated on physical addresses. `mem_dump` Tests updated to dump valid address ranges. Output format remains the same:

Data segment dump:
```0x000000003ffffaba: 41 01 82 80 72 73 75 2f 6e 69 62 2f 79 65 78 2f  A...rsu/nib/yex/
0x000000003ffffaca: 00 00 73 65 be fa ff 3f 00 00 00 00 00 00 00 00  ..se���?........```

Test segment dump:
```0x000000000001020a: 33 0f 00 00 33 0f 00 00 01 00 e6 60 46 64 25 61  3...3.....�`Fd%a
0x000000000001021a: 82 80 01 45 82 80 49 66 c5 65 49 65 13 06 06 02  ...E..If�eIe....```
 